### PR TITLE
Add per-workspace environment variables with custom secrets

### DIFF
--- a/client/hooks/useWorkspaceTheme.ts
+++ b/client/hooks/useWorkspaceTheme.ts
@@ -22,6 +22,11 @@ export function useWorkspaceTheme(
   target: RefObject<HTMLElement | null>
 ) {
   const font = theme?.font ?? 'default'
+  // Read the scoped color overrides up front so the color effect below depends
+  // on these exact values rather than the whole `theme` object (it accesses
+  // them via a dynamic key, which the deps linter can't see through).
+  const background = theme?.background
+  const foreground = theme?.foreground
 
   useEffect(() => {
     const el = target.current
@@ -58,8 +63,9 @@ export function useWorkspaceTheme(
   useEffect(() => {
     const el = target.current
     if (!el) return
+    const overrides = { background, foreground }
     for (const key of COLOR_OVERRIDES) {
-      const value = theme?.[key]
+      const value = overrides[key]
       if (value) {
         el.style.setProperty(`--${key}`, value)
       } else {
@@ -69,7 +75,7 @@ export function useWorkspaceTheme(
     return () => {
       for (const key of COLOR_OVERRIDES) el.style.removeProperty(`--${key}`)
     }
-  }, [theme?.background, theme?.foreground, target])
+  }, [background, foreground, target])
 
   // Drop the shared font <link> when the workspace unmounts.
   useEffect(() => () => document.getElementById(FONT_LINK_ID)?.remove(), [])

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,0 +1,136 @@
+# Workspace environment variables
+
+Per-workspace environment variables and secrets, made available to **widget
+server functions** and to **the agent's tools** (e.g. Bash). This is how a TTS
+widget gets an `ELEVENLABS_API_KEY`, or the agent gets a `NOTION_TOKEN`, without
+the value ever touching the repo.
+
+## For users
+
+A workspace's effective env comes from two sources:
+
+1. **Workspace `.env` files** — `.env` and `.env.local` in the workspace root
+   (local wins). Inherited by default; can be toggled off per workspace.
+2. **Custom secrets** — key/value pairs you set in moi's env settings. Stored
+   securely outside the repo (OS keychain when available, else a `0600` file).
+
+Custom secrets win over `.env` for the same key.
+
+Things you can control per workspace (via the env settings UI →
+`PUT /api/workspaces/:id/env`):
+
+- **Add / update / remove custom secrets.** Values are write-only — the API
+  never returns them back, so the UI shows `••••`, and editing means typing a
+  new value.
+- **Scope** each custom key to where it's allowed to flow: `widgets`, `agent`,
+  or `both` (default). Use this to keep, say, a production token out of the
+  agent's bypass-permissions Bash, or a widget-only key out of the agent.
+- **Inherit `.env`** toggle. Off means `.env` files are ignored for injection
+  (still shown in the UI for reference).
+
+Widgets can also **declare** the keys they need via `config.requiredEnv` (see the
+widgets skill). This is advisory: the settings UI surfaces which required keys
+are unset, but nothing is enforced — a missing key is just `undefined`.
+
+Changes apply on the **next** widget call / agent message — no page refresh or
+manual restart needed.
+
+### How it reaches code
+
+- **Widgets**: read `process.env.X` inside `.server.ts` only. It runs in the
+  function worker, never the browser, so secrets never enter the client bundle.
+- **Agent**: injected into the agent subprocess env, so the Bash tool sees it.
+- `.env` feeds both sinks; a custom secret feeds only the sink(s) its scope
+  allows.
+
+### Defaults for a new workspace
+
+Inherit `.env` is **on**, there are **no custom secrets**, and **nothing is
+written to disk** until you set something. So a fresh workspace simply inherits
+its `.env` (to both widgets and the agent) and nothing else.
+
+## Internals
+
+### Resolution (`server/workspace-env.ts`)
+
+`resolveWorkspaceEnv(workspacePath, sink)` is the single source of truth. It
+merges, for the given sink (`'widgets'` | `'agent'`):
+
+```
+base   = inheritDotenv ? parse(.env) ⊕ parse(.env.local) : {}
+custom = secrets where scope ∈ { both, <sink> }
+result = { ...base, ...custom }            // custom wins
+```
+
+`.env` is parsed with `node:util`'s built-in `parseEnv` (no dependency).
+
+### Storage: secrets vs metadata
+
+Secret **values** and the **metadata** are stored separately, both keyed by
+absolute workspace path, both outside the repo:
+
+- **Metadata** → `<dataDir>/workspace-env.json`: just `inheritDotenv` and the
+  per-key `scopes` map (key names double as the UI list). Not secret.
+- **Secret values** → a `SecretStore`:
+  - **Primary**: the OS keychain via `Bun.secrets` (macOS Keychain, libsecret,
+    Windows Credential Manager). One JSON bag per workspace.
+  - **Fallback**: `<dataDir>/workspace-secrets.json`, written `0600` in a `0700`
+    dir, atomically (temp + rename). Used when no keyring is available
+    (headless Linux, CI). Selected by a one-time non-mutating probe at first use.
+
+> The keychain gives **encryption at rest**, not process isolation — any
+> same-user process (including the agent) can read it. Keeping a secret away
+> from the agent is done by **scoping**, not by storage.
+
+### Injection at spawn
+
+Env is injected when a process is spawned and is **frozen** for that process's
+lifetime:
+
+- **Widget worker** (`server/functions.ts`): spawns with the `'widgets'`
+  resolution. To stop Bun from _auto-loading_ the workspace `.env` (which would
+  bypass the inherit toggle and scoping), the worker is spawned from a neutral
+  cwd and `chdir`s back to the workspace root at startup
+  (`MEI_WORKSPACE_ROOT`, see `server/functions-worker.ts`). moi's injected env
+  is therefore authoritative.
+- **Agent session** (`server/cc-session.ts`): spawns with the `'agent'`
+  resolution merged into the SDK `query()` `env`.
+
+### Applying changes (no mid-turn reload)
+
+Because env is frozen at spawn, a `PUT /env` reaps the relevant processes so the
+next call/message respawns with fresh env:
+
+- `restartWorker(path)` — kills the cached widget worker; next RPC respawns it.
+- `restartWorkspaceSessions(path)` — tears down **idle** agent sessions; busy
+  ones keep their snapshot until the turn ends.
+
+### `requiredEnv` flow
+
+`config.requiredEnv` (widget `.tsx`) → parsed by `extractWidgetConfig`
+(`build-widget.ts`) → stored in the widget manifest → `collectRequiredEnv`
+(`widgets.ts`) maps key → widgets → surfaced in the env view with a `satisfied`
+flag (computed against what's visible to the `widgets` sink).
+
+### API
+
+`GET /api/workspaces/:id/env` → `WorkspaceEnvView` (`lib/types.ts`): the
+effective vars with `source` + `scope`, discovered `.env` files with counts,
+`inheritDotenv`, the active `backend`, and `required` keys. **All values are
+masked.**
+
+`PUT /api/workspaces/:id/env` → patch semantics: `set` (upsert), `remove`,
+`scopes`, `inheritDotenv`. Patch (not replace) because values are write-only.
+Triggers the respawns above.
+
+### Key files
+
+| File                                          | Role                                                                      |
+| --------------------------------------------- | ------------------------------------------------------------------------- |
+| `server/workspace-env.ts`                     | resolver, `SecretStore`, metadata, env view                               |
+| `server/functions.ts` / `functions-worker.ts` | widget worker spawn + env injection + neutral-cwd/chdir + `restartWorker` |
+| `server/cc-session.ts`                        | agent session env injection + `restartWorkspaceSessions`                  |
+| `server/widgets.ts`                           | `collectRequiredEnv`, `requiredEnv` in manifest                           |
+| `server/build-widget.ts`                      | `requiredEnv` extraction                                                  |
+| `server/web.ts`                               | `GET`/`PUT /api/workspaces/:id/env`                                       |
+| `lib/types.ts`                                | `EnvScope`, `WorkspaceEnvVar`, `WorkspaceEnvView`                         |

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,10 @@ import type { StreamEvent } from './format'
 export type WidgetConfig = {
   rowSpan: 1 | 2 | 3 | 4
   colSpan: 1 | 2 | 3 | 4
+  // Env vars this widget's `.server.ts` expects (e.g. `ELEVENLABS_API_KEY`).
+  // Purely advisory: it lets the UI surface a "missing key" hint. It never
+  // blocks loading — the server function still just reads `process.env`.
+  requiredEnv?: string[]
 }
 
 export type WidgetInfo = {
@@ -190,6 +194,38 @@ export type WorkspaceLayout = {
 export type WorkspacePreview = {
   cols: number
   items: { x: number; y: number; w: number; h: number }[]
+}
+
+// Persisted per-workspace env settings (stored outside the repo, in the OS data
+// dir). `custom` overrides discovered `.env` vars; `inheritDotenv` toggles
+// whether `.env` files feed the workspace at all.
+export type WorkspaceEnvSettings = {
+  custom: Record<string, string>
+  inheritDotenv: boolean
+}
+
+// One effective env var, as surfaced by GET /api/workspaces/:id/env.
+export type WorkspaceEnvVar = {
+  key: string
+  // `dotenv`: only from a `.env` file. `custom`: only a UI override.
+  // `both`: a UI override shadowing a `.env` value (custom wins).
+  source: 'dotenv' | 'custom' | 'both'
+  // Present only for custom-sourced keys (user-editable). `.env` values stay
+  // masked so the API never echoes secrets it merely discovered.
+  value?: string
+  // The `.env` files that declare this key (when dotenv-sourced).
+  files?: string[]
+}
+
+// GET /api/workspaces/:id/env payload — the env view for the future settings UI.
+export type WorkspaceEnvView = {
+  vars: WorkspaceEnvVar[]
+  // Discovered `.env` files with how many keys each holds (values masked).
+  files: { file: string; count: number }[]
+  inheritDotenv: boolean
+  // Keys declared via widget `config.requiredEnv`, with whether they're
+  // satisfied by the effective env and which widgets asked for them.
+  required: { key: string; satisfied: boolean; widgets: string[] }[]
 }
 
 // Normalized capability flags shared across backends. An absent flag means

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -196,35 +196,36 @@ export type WorkspacePreview = {
   items: { x: number; y: number; w: number; h: number }[]
 }
 
-// Persisted per-workspace env settings (stored outside the repo, in the OS data
-// dir). `custom` overrides discovered `.env` vars; `inheritDotenv` toggles
-// whether `.env` files feed the workspace at all.
-export type WorkspaceEnvSettings = {
-  custom: Record<string, string>
-  inheritDotenv: boolean
-}
+// Where a custom secret is allowed to flow: the widget function workers, the
+// agent's Bash, or both. Lets a key meant for a widget stay out of the agent's
+// (bypass-permissions) environment, and vice versa.
+export type EnvScope = 'widgets' | 'agent' | 'both'
 
-// One effective env var, as surfaced by GET /api/workspaces/:id/env.
+// One effective env var, as surfaced by GET /api/workspaces/:id/env. Values are
+// NEVER returned — the API masks both `.env` and custom secrets, so editing is
+// write-only. Presence in the list (with `source`) is all the UI needs.
 export type WorkspaceEnvVar = {
   key: string
-  // `dotenv`: only from a `.env` file. `custom`: only a UI override.
-  // `both`: a UI override shadowing a `.env` value (custom wins).
+  // `dotenv`: only from a `.env` file. `custom`: only a UI-managed secret.
+  // `both`: a custom secret shadowing a `.env` value (custom wins).
   source: 'dotenv' | 'custom' | 'both'
-  // Present only for custom-sourced keys (user-editable). `.env` values stay
-  // masked so the API never echoes secrets it merely discovered.
-  value?: string
+  // Sink scope — present for custom/both (UI-managed) keys.
+  scope?: EnvScope
   // The `.env` files that declare this key (when dotenv-sourced).
   files?: string[]
 }
 
-// GET /api/workspaces/:id/env payload — the env view for the future settings UI.
+// GET /api/workspaces/:id/env payload — the env view for the settings UI.
 export type WorkspaceEnvView = {
   vars: WorkspaceEnvVar[]
   // Discovered `.env` files with how many keys each holds (values masked).
   files: { file: string; count: number }[]
   inheritDotenv: boolean
-  // Keys declared via widget `config.requiredEnv`, with whether they're
-  // satisfied by the effective env and which widgets asked for them.
+  // Where custom secrets are stored: the OS keychain (Bun.secrets) when
+  // available, else a 0600 file fallback. Surfaced so the UI can warn.
+  backend: 'keychain' | 'file'
+  // Keys declared via widget `config.requiredEnv`, with whether they're visible
+  // to widgets in the effective env and which widgets asked for them.
   required: { key: string; satisfied: boolean; widgets: string[] }[]
 }
 

--- a/server/build-widget.ts
+++ b/server/build-widget.ts
@@ -63,6 +63,21 @@ export async function extractWidgetConfig(srcPath: string): Promise<WidgetConfig
   for (const prop of init.properties) {
     if (prop.type !== 'Property' || prop.key?.type !== 'Identifier') continue
     const key = prop.key.name as string
+
+    // requiredEnv: an array of string literals naming env vars the widget needs.
+    // Advisory only — surfaced in the env UI, never enforced at build/load.
+    if (key === 'requiredEnv') {
+      if (prop.value?.type !== 'ArrayExpression') continue
+      const names = prop.value.elements
+        .filter(
+          (el): el is { type: 'Literal'; value: string } =>
+            el?.type === 'Literal' && typeof el.value === 'string'
+        )
+        .map(el => el.value)
+      if (names.length) result.requiredEnv = names
+      continue
+    }
+
     if (key !== 'rowSpan' && key !== 'colSpan') continue
     if (prop.value?.type !== 'Literal' || typeof prop.value.value !== 'number') continue
 

--- a/server/cc-session.ts
+++ b/server/cc-session.ts
@@ -21,6 +21,7 @@ import {
 import { ClaudeAdapter } from '@/lib/claude-adapter'
 
 import { broadcast } from './state'
+import { resolveWorkspaceEnv } from './workspace-env'
 
 // Cap on concurrently-held live sessions (each = one claude subprocess). When
 // exceeded, the least-recently-active IDLE session is closed; a busy session is
@@ -236,6 +237,9 @@ function createLiveSession(input: {
   sessionId: string
   isNew: boolean
   model: string | undefined
+  // Resolved workspace env (.env + UI custom overrides), injected so the agent's
+  // Bash tool can use workspace secrets. Frozen at spawn — see restartWorkspaceSessions.
+  workspaceEnv: Record<string, string>
 }): LiveSession {
   evictIfNeeded()
 
@@ -253,7 +257,7 @@ function createLiveSession(input: {
     permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: true,
     settingSources: ['user', 'project'],
-    env: { ...process.env, CLAUDECODE: undefined },
+    env: { ...process.env, ...input.workspaceEnv, CLAUDECODE: undefined },
     stderr: (data: string) => console.error('[SDK stderr]', data)
   }
   if (!input.isNew) options.resume = input.sessionId
@@ -294,7 +298,8 @@ export async function sendCCMessage(input: {
       workspacePath: input.workspacePath,
       sessionId: input.sessionId,
       isNew: input.isNew,
-      model: input.model
+      model: input.model,
+      workspaceEnv: await resolveWorkspaceEnv(input.workspacePath)
     })
   } else {
     clearIdle(s)
@@ -352,6 +357,16 @@ export async function interruptCCSession(workspaceId: string, sessionId: string)
   broadcast(s.workspaceId, { kind: 'stopped', sessionId: s.sessionId })
   broadcastProcessing(s, false)
   armIdle(s)
+}
+
+// Tear down a workspace's IDLE sessions so the next message respawns the agent
+// with fresh env. A running claude subprocess can't pick up new env vars, and
+// mid-turn reload isn't supported — busy sessions keep their snapshot until the
+// turn ends (then idle-evict or get recreated on the next message via resume).
+export function restartWorkspaceSessions(workspacePath: string): void {
+  for (const s of [...sessions.values()]) {
+    if (s.workspacePath === workspacePath && s.pendingTurns === 0) teardown(s)
+  }
 }
 
 // Close every live session — called on server shutdown so no claude subprocess

--- a/server/cc-session.ts
+++ b/server/cc-session.ts
@@ -299,7 +299,8 @@ export async function sendCCMessage(input: {
       sessionId: input.sessionId,
       isNew: input.isNew,
       model: input.model,
-      workspaceEnv: await resolveWorkspaceEnv(input.workspacePath)
+      // The agent only sees secrets scoped to the 'agent' sink (plus .env).
+      workspaceEnv: await resolveWorkspaceEnv(input.workspacePath, 'agent')
     })
   } else {
     clearIdle(s)

--- a/server/functions-worker.ts
+++ b/server/functions-worker.ts
@@ -6,6 +6,16 @@ import { join, resolve, sep } from 'path'
 const MEI_DIR =
   process.env.MEI_FUNCTIONS_DIR ?? join(import.meta.dir, '..', 'test-workspace', '.moi')
 
+// The parent spawns us from a neutral cwd so Bun never auto-loads the
+// workspace's `.env` into this process — moi injects the resolved, scope-filtered
+// env at spawn instead (see functions.ts). Restore the documented
+// `cwd = workspace root` so server functions can use plain relative paths.
+if (process.env.MEI_WORKSPACE_ROOT) {
+  try {
+    process.chdir(process.env.MEI_WORKSPACE_ROOT)
+  } catch {}
+}
+
 const moduleCache = new Map<string, Record<string, unknown>>()
 
 function send(msg: unknown) {

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -8,12 +8,15 @@
 // against multiple workspaces stay isolated.
 //
 // CWD contract: workers run with `cwd = workspacePath` (the workspace root,
-// where the agent works), NOT `.moi/`. The `.moi/` root is passed to the
-// worker as `MEI_FUNCTIONS_DIR` so it can locate `.server.ts` files — module
-// keys are paths relative to it (`"widgets/hello"` →
-// `.moi/widgets/hello.server.ts`). This is the contract documented in the
-// widgets SKILL.
+// where the agent works), NOT `.moi/`. But we SPAWN from a neutral cwd and have
+// the worker `chdir` there at startup (via MEI_WORKSPACE_ROOT) — otherwise Bun
+// would auto-load the workspace's `.env` into the worker, bypassing moi's
+// inheritDotenv toggle and per-sink scoping. The `.moi/` root is passed as
+// `MEI_FUNCTIONS_DIR` so the worker can locate `.server.ts` files — module keys
+// are paths relative to it (`"widgets/hello"` → `.moi/widgets/hello.server.ts`).
+// This is the contract documented in the widgets SKILL.
 import { LRUCache } from 'lru-cache'
+import { tmpdir } from 'node:os'
 import { join } from 'path'
 
 import { resolveWorkspaceEnv } from './workspace-env'
@@ -77,14 +80,18 @@ function spawnSlot(workspacePath: string, workspaceEnv: Record<string, string>):
   }
 
   slot.worker = Bun.spawn([process.execPath, WORKER_PATH], {
-    cwd: workspacePath,
-    // Resolved workspace env (.env + UI custom overrides) is layered over the
-    // server's env so widget `.server.ts` functions can read workspace secrets.
-    // MEI_FUNCTIONS_DIR is applied last so a workspace .env can never clobber it;
-    // tests set it explicitly to point the worker at fixtures.
+    // Neutral cwd so Bun doesn't auto-load the workspace's `.env`; the worker
+    // chdir()s to MEI_WORKSPACE_ROOT at startup to restore cwd = workspace root.
+    cwd: tmpdir(),
+    // Resolved workspace env (.env + scope-filtered custom secrets) layered over
+    // the server's env — the AUTHORITATIVE source now that auto-load is off, so
+    // inheritDotenv and per-sink scoping actually hold. MEI_FUNCTIONS_DIR is
+    // applied last so a workspace .env can never clobber it; tests set it
+    // explicitly to point the worker at fixtures.
     env: {
       ...process.env,
       ...workspaceEnv,
+      MEI_WORKSPACE_ROOT: workspacePath,
       MEI_FUNCTIONS_DIR: process.env.MEI_FUNCTIONS_DIR ?? meiDir
     },
     stderr: 'inherit',

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -16,6 +16,8 @@
 import { LRUCache } from 'lru-cache'
 import { join } from 'path'
 
+import { resolveWorkspaceEnv } from './workspace-env'
+
 const WORKER_PATH = join(import.meta.dir, 'functions-worker.ts')
 const CALL_TIMEOUT_MS = 30_000
 const WORKER_IDLE_TTL_MS = 10 * 60_000
@@ -60,7 +62,7 @@ const slots = new LRUCache<string, Slot>({
   dispose: slot => killSlot(slot, 'Functions worker idle-evicted')
 })
 
-function spawnSlot(workspacePath: string): Slot {
+function spawnSlot(workspacePath: string, workspaceEnv: Record<string, string>): Slot {
   const meiDir = join(workspacePath, '.moi')
 
   let readyResolve: () => void = () => {}
@@ -76,9 +78,15 @@ function spawnSlot(workspacePath: string): Slot {
 
   slot.worker = Bun.spawn([process.execPath, WORKER_PATH], {
     cwd: workspacePath,
-    // Default to the workspace's built functions dir, but let an explicitly-set
-    // MEI_FUNCTIONS_DIR win (used by tests to point the worker at fixtures).
-    env: { ...process.env, MEI_FUNCTIONS_DIR: process.env.MEI_FUNCTIONS_DIR ?? meiDir },
+    // Resolved workspace env (.env + UI custom overrides) is layered over the
+    // server's env so widget `.server.ts` functions can read workspace secrets.
+    // MEI_FUNCTIONS_DIR is applied last so a workspace .env can never clobber it;
+    // tests set it explicitly to point the worker at fixtures.
+    env: {
+      ...process.env,
+      ...workspaceEnv,
+      MEI_FUNCTIONS_DIR: process.env.MEI_FUNCTIONS_DIR ?? meiDir
+    },
     stderr: 'inherit',
     onExit(_proc, code) {
       if (code !== 0 && code !== null) {
@@ -116,11 +124,11 @@ function spawnSlot(workspacePath: string): Slot {
   return slot
 }
 
-function getOrSpawn(workspacePath: string): Slot {
+function getOrSpawn(workspacePath: string, workspaceEnv: Record<string, string>): Slot {
   const existing = slots.get(workspacePath)
   if (existing && !existing.killed) return existing
 
-  const fresh = spawnSlot(workspacePath)
+  const fresh = spawnSlot(workspacePath, workspaceEnv)
   slots.set(workspacePath, fresh)
   return fresh
 }
@@ -146,7 +154,11 @@ export async function callFunction(
   args: string,
   workspacePath: string
 ): Promise<string> {
-  const slot = getOrSpawn(workspacePath)
+  // Resolve the workspace env before (maybe) spawning, so a fresh worker picks
+  // up current .env + custom overrides. Env is fixed at spawn — an already-warm
+  // worker keeps its snapshot until restartWorker() reaps it.
+  const workspaceEnv = await resolveWorkspaceEnv(workspacePath)
+  const slot = getOrSpawn(workspacePath, workspaceEnv)
   await slot.readyPromise
 
   const id = crypto.randomUUID()
@@ -174,6 +186,16 @@ export async function callFunction(
 export function killAllWorkers() {
   for (const slot of slots.values()) killSlot(slot, 'Server shutting down')
   slots.clear()
+}
+
+// Reap a workspace's worker so the next callFunction spawns a fresh one with
+// up-to-date env. A running process can't pick up new env vars, so an env
+// change (UI override or .env edit) requires this hard restart — distinct from
+// reloadModules, which only swaps module code inside the live worker.
+export function restartWorker(workspacePath: string) {
+  const slot = slots.peek(workspacePath)
+  if (slot) killSlot(slot, 'Workspace env changed')
+  slots.delete(workspacePath)
 }
 
 export function reloadModules(modules: string[], workspacePath: string) {

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -156,8 +156,9 @@ export async function callFunction(
 ): Promise<string> {
   // Resolve the workspace env before (maybe) spawning, so a fresh worker picks
   // up current .env + custom overrides. Env is fixed at spawn — an already-warm
-  // worker keeps its snapshot until restartWorker() reaps it.
-  const workspaceEnv = await resolveWorkspaceEnv(workspacePath)
+  // worker keeps its snapshot until restartWorker() reaps it. Widgets only see
+  // secrets scoped to the 'widgets' sink.
+  const workspaceEnv = await resolveWorkspaceEnv(workspacePath, 'widgets')
   const slot = getOrSpawn(workspacePath, workspaceEnv)
   await slot.readyPromise
 

--- a/server/test/__fixtures__/cwd.server.ts
+++ b/server/test/__fixtures__/cwd.server.ts
@@ -1,0 +1,5 @@
+// Returns the worker's cwd so a test can assert chdir() restored it to the
+// workspace root after the neutral spawn.
+export async function getCwd(): Promise<string> {
+  return process.cwd()
+}

--- a/server/test/__fixtures__/envprobe.server.ts
+++ b/server/test/__fixtures__/envprobe.server.ts
@@ -1,0 +1,5 @@
+// Reads an env var so a test can assert the workspace `.env` is NOT auto-loaded
+// by Bun (only moi's injected env reaches the worker).
+export async function readSentinel(): Promise<string | null> {
+  return process.env.MOI_LEAK_SENTINEL ?? null
+}

--- a/server/test/__fixtures__/with-required-env.tsx
+++ b/server/test/__fixtures__/with-required-env.tsx
@@ -1,0 +1,11 @@
+import type { WidgetConfig } from '@/lib/types'
+
+export const config: WidgetConfig = {
+  rowSpan: 2,
+  colSpan: 2,
+  requiredEnv: ['ELEVENLABS_API_KEY', 'ELEVENLABS_VOICE_ID']
+}
+
+export default function WithRequiredEnvWidget() {
+  return <div>widget needing env</div>
+}

--- a/server/test/build-widget.test.ts
+++ b/server/test/build-widget.test.ts
@@ -227,4 +227,13 @@ describe('extractWidgetConfig', () => {
     expect(warn).toHaveBeenCalledTimes(2)
     warn.mockRestore()
   })
+
+  test('extracts requiredEnv string array alongside spans', async () => {
+    const config = await extractWidgetConfig(join(FIXTURES, 'with-required-env.tsx'))
+    expect(config).toEqual({
+      rowSpan: 2,
+      colSpan: 2,
+      requiredEnv: ['ELEVENLABS_API_KEY', 'ELEVENLABS_VOICE_ID']
+    })
+  })
 })

--- a/server/test/functions.test.ts
+++ b/server/test/functions.test.ts
@@ -1,8 +1,15 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { parse, stringify } from 'devalue'
-import { join } from 'path'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import { tmpdir } from 'node:os'
 
-import { callFunction, parseFunctionPath } from '../functions'
+import { callFunction, parseFunctionPath, restartWorker } from '../functions'
+import {
+  setSecretStoreBackend,
+  setWorkspaceEnvStorePath,
+  updateWorkspaceEnv
+} from '../workspace-env'
 
 const FIXTURES = join(import.meta.dir, '__fixtures__')
 
@@ -152,5 +159,49 @@ describe('/_rpc/fn endpoint', () => {
     const res = await fetch(`${baseUrl}/_rpc/fn/with-server/getWeather`)
 
     expect(res.status).toBe(404)
+  })
+})
+
+describe('worker env isolation', () => {
+  let storeDir: string
+
+  beforeAll(async () => {
+    // Pin the file secret backend so the workspace-env store never hits the
+    // real OS keychain, and point it at a throwaway dir.
+    storeDir = await mkdtemp(join(tmpdir(), 'moi-fn-env-'))
+    setWorkspaceEnvStorePath(
+      join(storeDir, 'workspace-env.json'),
+      join(storeDir, 'workspace-secrets.json')
+    )
+    setSecretStoreBackend('file')
+    // A workspace .env that should ONLY reach the worker via moi's injection,
+    // never via Bun's auto-load-from-cwd.
+    await writeFile(join(FIXTURES, '.env'), 'MOI_LEAK_SENTINEL=leaked\n')
+  })
+
+  afterAll(async () => {
+    await rm(join(FIXTURES, '.env'), { force: true })
+    await rm(storeDir, { recursive: true, force: true })
+    setSecretStoreBackend('auto')
+    restartWorker(FIXTURES)
+  })
+
+  test('chdir restores cwd = workspace root after neutral spawn', async () => {
+    const cwd = parse(await callFunction('cwd', 'getCwd', stringify([]), FIXTURES)) as string
+    expect(basename(cwd)).toBe('__fixtures__')
+  })
+
+  test('workspace .env does NOT auto-load when inheritDotenv is off', async () => {
+    await updateWorkspaceEnv(FIXTURES, { inheritDotenv: false })
+    restartWorker(FIXTURES)
+    const v = parse(await callFunction('envprobe', 'readSentinel', stringify([]), FIXTURES))
+    expect(v).toBeNull()
+  })
+
+  test('moi injection still delivers .env when inheritDotenv is on', async () => {
+    await updateWorkspaceEnv(FIXTURES, { inheritDotenv: true })
+    restartWorker(FIXTURES)
+    const v = parse(await callFunction('envprobe', 'readSentinel', stringify([]), FIXTURES))
+    expect(v).toBe('leaked')
   })
 })

--- a/server/test/functions.test.ts
+++ b/server/test/functions.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 
 import { callFunction, parseFunctionPath, restartWorker } from '../functions'
 import {
+  resetWorkspaceEnvForTest,
   setSecretStoreBackend,
   setWorkspaceEnvStorePath,
   updateWorkspaceEnv
@@ -182,7 +183,7 @@ describe('worker env isolation', () => {
   afterAll(async () => {
     await rm(join(FIXTURES, '.env'), { force: true })
     await rm(storeDir, { recursive: true, force: true })
-    setSecretStoreBackend('auto')
+    resetWorkspaceEnvForTest()
     restartWorker(FIXTURES)
   })
 

--- a/server/test/workspace-env.test.ts
+++ b/server/test/workspace-env.test.ts
@@ -1,134 +1,178 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'path'
 
 import {
-  getWorkspaceEnvSettings,
   getWorkspaceEnvView,
   isValidEnvKey,
+  isValidScope,
   resolveWorkspaceEnv,
+  setSecretStoreBackend,
   setWorkspaceEnvStorePath,
-  updateWorkspaceEnvSettings
+  updateWorkspaceEnv
 } from '../workspace-env'
 
 let wsDir: string
 let storeDir: string
+let secretPath: string
 
 beforeEach(async () => {
   wsDir = await mkdtemp(join(tmpdir(), 'moi-env-ws-'))
   storeDir = await mkdtemp(join(tmpdir(), 'moi-env-store-'))
-  setWorkspaceEnvStorePath(join(storeDir, 'workspace-env.json'))
+  secretPath = join(storeDir, 'workspace-secrets.json')
+  setWorkspaceEnvStorePath(join(storeDir, 'workspace-env.json'), secretPath)
+  // Pin the file backend so tests never touch the real OS keychain.
+  setSecretStoreBackend('file')
 })
 
 afterEach(async () => {
+  setSecretStoreBackend('auto')
   await rm(wsDir, { recursive: true, force: true })
   await rm(storeDir, { recursive: true, force: true })
 })
 
-describe('isValidEnvKey', () => {
-  test('accepts conventional names, rejects junk', () => {
+describe('validation helpers', () => {
+  test('isValidEnvKey', () => {
     expect(isValidEnvKey('ELEVENLABS_API_KEY')).toBe(true)
-    expect(isValidEnvKey('_x')).toBe(true)
     expect(isValidEnvKey('1ABC')).toBe(false)
-    expect(isValidEnvKey('has space')).toBe(false)
     expect(isValidEnvKey('a-b')).toBe(false)
-    expect(isValidEnvKey('')).toBe(false)
+  })
+
+  test('isValidScope', () => {
+    expect(isValidScope('widgets')).toBe(true)
+    expect(isValidScope('agent')).toBe(true)
+    expect(isValidScope('both')).toBe(true)
+    expect(isValidScope('nope')).toBe(false)
+    expect(isValidScope(undefined)).toBe(false)
   })
 })
 
-describe('resolveWorkspaceEnv', () => {
-  test('returns empty when nothing is configured', async () => {
-    expect(await resolveWorkspaceEnv(wsDir)).toEqual({})
+describe('resolveWorkspaceEnv — dotenv', () => {
+  test('empty when nothing configured', async () => {
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({})
   })
 
-  test('parses .env via node:util parseEnv', async () => {
+  test('parses .env via node:util parseEnv, feeds both sinks', async () => {
     await writeFile(join(wsDir, '.env'), 'A=1\n# comment\nB="two words"\n')
-    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ A: '1', B: 'two words' })
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({ A: '1', B: 'two words' })
+    expect(await resolveWorkspaceEnv(wsDir, 'agent')).toEqual({ A: '1', B: 'two words' })
   })
 
   test('.env.local overrides .env', async () => {
     await writeFile(join(wsDir, '.env'), 'A=base\nB=base\n')
     await writeFile(join(wsDir, '.env.local'), 'B=local\n')
-    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ A: 'base', B: 'local' })
+    expect(await resolveWorkspaceEnv(wsDir, 'agent')).toEqual({ A: 'base', B: 'local' })
   })
 
-  test('custom overrides win over .env', async () => {
-    await writeFile(join(wsDir, '.env'), 'TOKEN=from-dotenv\n')
-    await updateWorkspaceEnvSettings(wsDir, { custom: { TOKEN: 'from-ui', EXTRA: 'x' } })
-    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ TOKEN: 'from-ui', EXTRA: 'x' })
-  })
-
-  test('inheritDotenv=false ignores .env, keeps custom', async () => {
+  test('inheritDotenv=false ignores .env', async () => {
     await writeFile(join(wsDir, '.env'), 'A=1\n')
-    await updateWorkspaceEnvSettings(wsDir, { custom: { B: '2' }, inheritDotenv: false })
-    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ B: '2' })
+    await updateWorkspaceEnv(wsDir, { inheritDotenv: false })
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({})
   })
 })
 
-describe('updateWorkspaceEnvSettings', () => {
-  test('drops invalid keys and non-string values', async () => {
-    const settings = await updateWorkspaceEnvSettings(wsDir, {
-      // @ts-expect-error testing runtime guard against non-string values
-      custom: { GOOD: 'ok', 'bad key': 'x', NUM: 3 }
-    })
-    expect(settings.custom).toEqual({ GOOD: 'ok' })
+describe('resolveWorkspaceEnv — custom secrets + scope', () => {
+  test('custom wins over .env', async () => {
+    await writeFile(join(wsDir, '.env'), 'TOKEN=from-dotenv\n')
+    await updateWorkspaceEnv(wsDir, { set: { TOKEN: 'from-ui' } })
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({ TOKEN: 'from-ui' })
   })
 
-  test('inheritDotenv defaults to true and persists toggles', async () => {
-    expect((await getWorkspaceEnvSettings(wsDir)).inheritDotenv).toBe(true)
-    await updateWorkspaceEnvSettings(wsDir, { inheritDotenv: false })
-    expect((await getWorkspaceEnvSettings(wsDir)).inheritDotenv).toBe(false)
-    // Updating custom alone leaves the flag intact.
-    await updateWorkspaceEnvSettings(wsDir, { custom: { A: '1' } })
-    expect((await getWorkspaceEnvSettings(wsDir)).inheritDotenv).toBe(false)
+  test('scope gates which sink sees a secret', async () => {
+    await updateWorkspaceEnv(wsDir, {
+      set: { W_ONLY: 'w', A_ONLY: 'a', SHARED: 's' },
+      scopes: { W_ONLY: 'widgets', A_ONLY: 'agent', SHARED: 'both' }
+    })
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({ W_ONLY: 'w', SHARED: 's' })
+    expect(await resolveWorkspaceEnv(wsDir, 'agent')).toEqual({ A_ONLY: 'a', SHARED: 's' })
+  })
+
+  test('new keys default to scope both', async () => {
+    await updateWorkspaceEnv(wsDir, { set: { K: 'v' } })
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({ K: 'v' })
+    expect(await resolveWorkspaceEnv(wsDir, 'agent')).toEqual({ K: 'v' })
+  })
+})
+
+describe('updateWorkspaceEnv — patch semantics', () => {
+  test('set upserts, remove deletes, others untouched', async () => {
+    await updateWorkspaceEnv(wsDir, { set: { A: '1', B: '2' } })
+    await updateWorkspaceEnv(wsDir, { set: { B: '22', C: '3' }, remove: ['A'] })
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({ B: '22', C: '3' })
+  })
+
+  test('removing a key drops its scope metadata', async () => {
+    await updateWorkspaceEnv(wsDir, { set: { A: '1' }, scopes: { A: 'agent' } })
+    await updateWorkspaceEnv(wsDir, { remove: ['A'] })
+    await updateWorkspaceEnv(wsDir, { set: { A: 'again' } })
+    // Re-added A defaults back to 'both', not the stale 'agent'.
+    expect(await resolveWorkspaceEnv(wsDir, 'widgets')).toEqual({ A: 'again' })
+  })
+
+  test('drops invalid keys and non-string values', async () => {
+    await updateWorkspaceEnv(wsDir, {
+      // @ts-expect-error testing runtime guard against non-string values
+      set: { GOOD: 'ok', 'bad key': 'x', NUM: 3 }
+    })
+    const view = await getWorkspaceEnvView(wsDir)
+    expect(view.vars.map(v => v.key)).toEqual(['GOOD'])
   })
 })
 
 describe('getWorkspaceEnvView', () => {
-  test('reports source, files, and masks .env values', async () => {
+  test('reports source/scope/files and never leaks values', async () => {
     await writeFile(join(wsDir, '.env'), 'SHARED=dotenv\nONLY_ENV=x\n')
     await writeFile(join(wsDir, '.env.local'), 'SHARED=dotenv\n')
-    await updateWorkspaceEnvSettings(wsDir, { custom: { SHARED: 'ui', ONLY_CUSTOM: 'y' } })
+    await updateWorkspaceEnv(wsDir, {
+      set: { SHARED: 'ui', ONLY_CUSTOM: 'y' },
+      scopes: { ONLY_CUSTOM: 'agent' }
+    })
 
     const view = await getWorkspaceEnvView(wsDir)
     const byKey = Object.fromEntries(view.vars.map(v => [v.key, v]))
 
     expect(byKey.SHARED.source).toBe('both')
-    expect(byKey.SHARED.value).toBe('ui') // custom wins, value exposed
+    expect(byKey.SHARED.scope).toBe('both')
     expect(byKey.SHARED.files).toEqual(['.env', '.env.local'])
 
     expect(byKey.ONLY_ENV.source).toBe('dotenv')
-    expect(byKey.ONLY_ENV.value).toBeUndefined() // .env values stay masked
-
     expect(byKey.ONLY_CUSTOM.source).toBe('custom')
-    expect(byKey.ONLY_CUSTOM.value).toBe('y')
+    expect(byKey.ONLY_CUSTOM.scope).toBe('agent')
+
+    // No var carries a value — the API is write-only for secrets.
+    for (const v of view.vars) expect('value' in v).toBe(false)
 
     expect(view.files).toEqual([
       { file: '.env', count: 2 },
       { file: '.env.local', count: 1 }
     ])
     expect(view.inheritDotenv).toBe(true)
+    expect(view.backend).toBe('file')
   })
 
-  test('computes required satisfaction against the effective env', async () => {
+  test('required satisfied only when visible to widgets', async () => {
     await writeFile(join(wsDir, '.env'), 'PRESENT=1\n')
+    await updateWorkspaceEnv(wsDir, {
+      set: { AGENT_KEY: 'a' },
+      scopes: { AGENT_KEY: 'agent' }
+    })
     const view = await getWorkspaceEnvView(wsDir, {
       PRESENT: ['weather'],
+      AGENT_KEY: ['tts'], // present but agent-scoped → not visible to widgets
       MISSING: ['tts']
     })
-    const required = Object.fromEntries(view.required.map(r => [r.key, r]))
-    expect(required.PRESENT.satisfied).toBe(true)
-    expect(required.PRESENT.widgets).toEqual(['weather'])
-    expect(required.MISSING.satisfied).toBe(false)
+    const req = Object.fromEntries(view.required.map(r => [r.key, r]))
+    expect(req.PRESENT.satisfied).toBe(true)
+    expect(req.AGENT_KEY.satisfied).toBe(false)
+    expect(req.MISSING.satisfied).toBe(false)
   })
+})
 
-  test('inheritDotenv=false hides .env from the view', async () => {
-    await writeFile(join(wsDir, '.env'), 'A=1\n')
-    await updateWorkspaceEnvSettings(wsDir, { inheritDotenv: false })
-    const view = await getWorkspaceEnvView(wsDir)
-    expect(view.vars).toEqual([])
-    // Files are still discovered (shown for reference), just not injected.
-    expect(view.files).toEqual([{ file: '.env', count: 1 }])
+describe('file secret store hardening', () => {
+  test('secrets file is written 0600', async () => {
+    await updateWorkspaceEnv(wsDir, { set: { SECRET: 'shh' } })
+    const mode = (await stat(secretPath)).mode & 0o777
+    expect(mode).toBe(0o600)
   })
 })

--- a/server/test/workspace-env.test.ts
+++ b/server/test/workspace-env.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'path'
+
+import {
+  getWorkspaceEnvSettings,
+  getWorkspaceEnvView,
+  isValidEnvKey,
+  resolveWorkspaceEnv,
+  setWorkspaceEnvStorePath,
+  updateWorkspaceEnvSettings
+} from '../workspace-env'
+
+let wsDir: string
+let storeDir: string
+
+beforeEach(async () => {
+  wsDir = await mkdtemp(join(tmpdir(), 'moi-env-ws-'))
+  storeDir = await mkdtemp(join(tmpdir(), 'moi-env-store-'))
+  setWorkspaceEnvStorePath(join(storeDir, 'workspace-env.json'))
+})
+
+afterEach(async () => {
+  await rm(wsDir, { recursive: true, force: true })
+  await rm(storeDir, { recursive: true, force: true })
+})
+
+describe('isValidEnvKey', () => {
+  test('accepts conventional names, rejects junk', () => {
+    expect(isValidEnvKey('ELEVENLABS_API_KEY')).toBe(true)
+    expect(isValidEnvKey('_x')).toBe(true)
+    expect(isValidEnvKey('1ABC')).toBe(false)
+    expect(isValidEnvKey('has space')).toBe(false)
+    expect(isValidEnvKey('a-b')).toBe(false)
+    expect(isValidEnvKey('')).toBe(false)
+  })
+})
+
+describe('resolveWorkspaceEnv', () => {
+  test('returns empty when nothing is configured', async () => {
+    expect(await resolveWorkspaceEnv(wsDir)).toEqual({})
+  })
+
+  test('parses .env via node:util parseEnv', async () => {
+    await writeFile(join(wsDir, '.env'), 'A=1\n# comment\nB="two words"\n')
+    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ A: '1', B: 'two words' })
+  })
+
+  test('.env.local overrides .env', async () => {
+    await writeFile(join(wsDir, '.env'), 'A=base\nB=base\n')
+    await writeFile(join(wsDir, '.env.local'), 'B=local\n')
+    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ A: 'base', B: 'local' })
+  })
+
+  test('custom overrides win over .env', async () => {
+    await writeFile(join(wsDir, '.env'), 'TOKEN=from-dotenv\n')
+    await updateWorkspaceEnvSettings(wsDir, { custom: { TOKEN: 'from-ui', EXTRA: 'x' } })
+    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ TOKEN: 'from-ui', EXTRA: 'x' })
+  })
+
+  test('inheritDotenv=false ignores .env, keeps custom', async () => {
+    await writeFile(join(wsDir, '.env'), 'A=1\n')
+    await updateWorkspaceEnvSettings(wsDir, { custom: { B: '2' }, inheritDotenv: false })
+    expect(await resolveWorkspaceEnv(wsDir)).toEqual({ B: '2' })
+  })
+})
+
+describe('updateWorkspaceEnvSettings', () => {
+  test('drops invalid keys and non-string values', async () => {
+    const settings = await updateWorkspaceEnvSettings(wsDir, {
+      // @ts-expect-error testing runtime guard against non-string values
+      custom: { GOOD: 'ok', 'bad key': 'x', NUM: 3 }
+    })
+    expect(settings.custom).toEqual({ GOOD: 'ok' })
+  })
+
+  test('inheritDotenv defaults to true and persists toggles', async () => {
+    expect((await getWorkspaceEnvSettings(wsDir)).inheritDotenv).toBe(true)
+    await updateWorkspaceEnvSettings(wsDir, { inheritDotenv: false })
+    expect((await getWorkspaceEnvSettings(wsDir)).inheritDotenv).toBe(false)
+    // Updating custom alone leaves the flag intact.
+    await updateWorkspaceEnvSettings(wsDir, { custom: { A: '1' } })
+    expect((await getWorkspaceEnvSettings(wsDir)).inheritDotenv).toBe(false)
+  })
+})
+
+describe('getWorkspaceEnvView', () => {
+  test('reports source, files, and masks .env values', async () => {
+    await writeFile(join(wsDir, '.env'), 'SHARED=dotenv\nONLY_ENV=x\n')
+    await writeFile(join(wsDir, '.env.local'), 'SHARED=dotenv\n')
+    await updateWorkspaceEnvSettings(wsDir, { custom: { SHARED: 'ui', ONLY_CUSTOM: 'y' } })
+
+    const view = await getWorkspaceEnvView(wsDir)
+    const byKey = Object.fromEntries(view.vars.map(v => [v.key, v]))
+
+    expect(byKey.SHARED.source).toBe('both')
+    expect(byKey.SHARED.value).toBe('ui') // custom wins, value exposed
+    expect(byKey.SHARED.files).toEqual(['.env', '.env.local'])
+
+    expect(byKey.ONLY_ENV.source).toBe('dotenv')
+    expect(byKey.ONLY_ENV.value).toBeUndefined() // .env values stay masked
+
+    expect(byKey.ONLY_CUSTOM.source).toBe('custom')
+    expect(byKey.ONLY_CUSTOM.value).toBe('y')
+
+    expect(view.files).toEqual([
+      { file: '.env', count: 2 },
+      { file: '.env.local', count: 1 }
+    ])
+    expect(view.inheritDotenv).toBe(true)
+  })
+
+  test('computes required satisfaction against the effective env', async () => {
+    await writeFile(join(wsDir, '.env'), 'PRESENT=1\n')
+    const view = await getWorkspaceEnvView(wsDir, {
+      PRESENT: ['weather'],
+      MISSING: ['tts']
+    })
+    const required = Object.fromEntries(view.required.map(r => [r.key, r]))
+    expect(required.PRESENT.satisfied).toBe(true)
+    expect(required.PRESENT.widgets).toEqual(['weather'])
+    expect(required.MISSING.satisfied).toBe(false)
+  })
+
+  test('inheritDotenv=false hides .env from the view', async () => {
+    await writeFile(join(wsDir, '.env'), 'A=1\n')
+    await updateWorkspaceEnvSettings(wsDir, { inheritDotenv: false })
+    const view = await getWorkspaceEnvView(wsDir)
+    expect(view.vars).toEqual([])
+    // Files are still discovered (shown for reference), just not injected.
+    expect(view.files).toEqual([{ file: '.env', count: 1 }])
+  })
+})

--- a/server/test/workspace-env.test.ts
+++ b/server/test/workspace-env.test.ts
@@ -7,6 +7,7 @@ import {
   getWorkspaceEnvView,
   isValidEnvKey,
   isValidScope,
+  resetWorkspaceEnvForTest,
   resolveWorkspaceEnv,
   setSecretStoreBackend,
   setWorkspaceEnvStorePath,
@@ -27,7 +28,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  setSecretStoreBackend('auto')
+  resetWorkspaceEnvForTest()
   await rm(wsDir, { recursive: true, force: true })
   await rm(storeDir, { recursive: true, force: true })
 })
@@ -117,6 +118,16 @@ describe('updateWorkspaceEnv — patch semantics', () => {
     })
     const view = await getWorkspaceEnvView(wsDir)
     expect(view.vars.map(v => v.key)).toEqual(['GOOD'])
+  })
+
+  test('concurrent updates do not lose writes (serialized per workspace)', async () => {
+    await Promise.all(
+      Array.from({ length: 12 }, (_, i) =>
+        updateWorkspaceEnv(wsDir, { set: { [`K${i}`]: `${i}` } })
+      )
+    )
+    const env = await resolveWorkspaceEnv(wsDir, 'widgets')
+    expect(Object.keys(env).sort()).toEqual(Array.from({ length: 12 }, (_, i) => `K${i}`).sort())
   })
 })
 

--- a/server/web.ts
+++ b/server/web.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { basename, join, sep } from 'node:path'
 
-import type { ClientMessage, WorkspaceModels, WorkspaceType } from '@/lib/types'
+import type { ClientMessage, EnvScope, WorkspaceModels, WorkspaceType } from '@/lib/types'
 
 import index from '../client/index.html'
 import { getClaudeModels, getMcpStatus } from './agent'
@@ -33,8 +33,14 @@ import {
   removeWorkspace
 } from './registry'
 import { addClient, getSessionEvents, getSessions, removeClient, sendToClient } from './state'
-import { getWorkspaceEnvView, isValidEnvKey, updateWorkspaceEnvSettings } from './workspace-env'
+import {
+  getWorkspaceEnvView,
+  isValidEnvKey,
+  isValidScope,
+  updateWorkspaceEnv
+} from './workspace-env'
 import { collectRequiredEnv, listWidgets, serveWidget } from './widgets'
+import type { EnvUpdate } from './workspace-env'
 
 const MEI_TOPIC = 'mei'
 
@@ -191,10 +197,11 @@ export const app = Bun.serve<WsData>({
       return Response.json(await getMcpStatus(ws.path))
     },
     // Per-workspace env vars. GET returns the effective view (discovered `.env`
-    // + UI custom overrides + declared-required keys). PUT replaces the custom
-    // map and/or the inheritDotenv mode, then reaps the workspace's function
-    // worker and idle agent sessions so the next call/message picks up the
-    // change (env is frozen at spawn — a hard restart is the only way).
+    // + UI custom secrets + scopes + declared-required keys; values masked). PUT
+    // patches custom secrets (set/remove/scopes) and/or the inheritDotenv mode,
+    // then reaps the workspace's function worker and idle agent sessions so the
+    // next call/message picks up the change (env is frozen at spawn — a hard
+    // restart is the only way).
     '/api/workspaces/:id/env': async req => {
       const ws = await getWorkspace(req.params.id)
       if (!ws) return new Response('Workspace not found', { status: 404 })
@@ -208,18 +215,33 @@ export const app = Bun.serve<WsData>({
         if (!body || typeof body !== 'object') {
           return new Response('Bad request', { status: 400 })
         }
-        const patch: { custom?: Record<string, string>; inheritDotenv?: boolean } = {}
-        if (body.custom !== undefined) {
-          if (typeof body.custom !== 'object' || body.custom === null) {
-            return new Response('custom must be an object', { status: 400 })
+        const patch: EnvUpdate = {}
+        if (body.set !== undefined) {
+          if (typeof body.set !== 'object' || body.set === null) {
+            return new Response('set must be an object', { status: 400 })
           }
-          for (const [k, v] of Object.entries(body.custom)) {
+          for (const [k, v] of Object.entries(body.set)) {
             if (!isValidEnvKey(k)) return new Response(`Invalid env key: ${k}`, { status: 400 })
             if (typeof v !== 'string') {
               return new Response(`Value for ${k} must be a string`, { status: 400 })
             }
           }
-          patch.custom = body.custom as Record<string, string>
+          patch.set = body.set as Record<string, string>
+        }
+        if (body.remove !== undefined) {
+          if (!Array.isArray(body.remove) || body.remove.some(k => typeof k !== 'string')) {
+            return new Response('remove must be an array of strings', { status: 400 })
+          }
+          patch.remove = body.remove as string[]
+        }
+        if (body.scopes !== undefined) {
+          if (typeof body.scopes !== 'object' || body.scopes === null) {
+            return new Response('scopes must be an object', { status: 400 })
+          }
+          for (const [k, s] of Object.entries(body.scopes)) {
+            if (!isValidScope(s)) return new Response(`Invalid scope for ${k}`, { status: 400 })
+          }
+          patch.scopes = body.scopes as Record<string, EnvScope>
         }
         if (body.inheritDotenv !== undefined) {
           if (typeof body.inheritDotenv !== 'boolean') {
@@ -228,7 +250,7 @@ export const app = Bun.serve<WsData>({
           patch.inheritDotenv = body.inheritDotenv
         }
 
-        await updateWorkspaceEnvSettings(ws.path, patch)
+        await updateWorkspaceEnv(ws.path, patch)
         // Frozen-at-spawn: reap workers/idle sessions so fresh env takes effect.
         restartWorker(ws.path)
         restartWorkspaceSessions(ws.path)

--- a/server/web.ts
+++ b/server/web.ts
@@ -9,11 +9,12 @@ import {
   getCCRunningSessions,
   interruptCCSession,
   killAllCCSessions,
+  restartWorkspaceSessions,
   sendCCMessage
 } from './cc-session'
 import { PORT } from './constants'
 import { control } from './control'
-import { callFunction, killAllWorkers, parseFunctionPath } from './functions'
+import { callFunction, killAllWorkers, parseFunctionPath, restartWorker } from './functions'
 import { getWorkspacePreview, loadLayout, saveLayout } from './layout'
 import { getOpenClawModels, getOpenClawSessionMessages, getOpenClawSessions } from './openclaw'
 import { toSessionInfo, toStreamEvents } from './openclaw-adapter'
@@ -32,7 +33,8 @@ import {
   removeWorkspace
 } from './registry'
 import { addClient, getSessionEvents, getSessions, removeClient, sendToClient } from './state'
-import { listWidgets, serveWidget } from './widgets'
+import { getWorkspaceEnvView, isValidEnvKey, updateWorkspaceEnvSettings } from './workspace-env'
+import { collectRequiredEnv, listWidgets, serveWidget } from './widgets'
 
 const MEI_TOPIC = 'mei'
 
@@ -187,6 +189,54 @@ export const app = Bun.serve<WsData>({
       const ws = await getWorkspace(req.params.id)
       if (!ws) return new Response('Workspace not found', { status: 404 })
       return Response.json(await getMcpStatus(ws.path))
+    },
+    // Per-workspace env vars. GET returns the effective view (discovered `.env`
+    // + UI custom overrides + declared-required keys). PUT replaces the custom
+    // map and/or the inheritDotenv mode, then reaps the workspace's function
+    // worker and idle agent sessions so the next call/message picks up the
+    // change (env is frozen at spawn — a hard restart is the only way).
+    '/api/workspaces/:id/env': async req => {
+      const ws = await getWorkspace(req.params.id)
+      if (!ws) return new Response('Workspace not found', { status: 404 })
+
+      if (req.method === 'GET') {
+        const required = await collectRequiredEnv(ws.path)
+        return Response.json(await getWorkspaceEnvView(ws.path, required))
+      }
+      if (req.method === 'PUT') {
+        const body = await req.json().catch(() => null)
+        if (!body || typeof body !== 'object') {
+          return new Response('Bad request', { status: 400 })
+        }
+        const patch: { custom?: Record<string, string>; inheritDotenv?: boolean } = {}
+        if (body.custom !== undefined) {
+          if (typeof body.custom !== 'object' || body.custom === null) {
+            return new Response('custom must be an object', { status: 400 })
+          }
+          for (const [k, v] of Object.entries(body.custom)) {
+            if (!isValidEnvKey(k)) return new Response(`Invalid env key: ${k}`, { status: 400 })
+            if (typeof v !== 'string') {
+              return new Response(`Value for ${k} must be a string`, { status: 400 })
+            }
+          }
+          patch.custom = body.custom as Record<string, string>
+        }
+        if (body.inheritDotenv !== undefined) {
+          if (typeof body.inheritDotenv !== 'boolean') {
+            return new Response('inheritDotenv must be a boolean', { status: 400 })
+          }
+          patch.inheritDotenv = body.inheritDotenv
+        }
+
+        await updateWorkspaceEnvSettings(ws.path, patch)
+        // Frozen-at-spawn: reap workers/idle sessions so fresh env takes effect.
+        restartWorker(ws.path)
+        restartWorkspaceSessions(ws.path)
+
+        const required = await collectRequiredEnv(ws.path)
+        return Response.json(await getWorkspaceEnvView(ws.path, required))
+      }
+      return new Response('Method not allowed', { status: 405 })
     },
     // Models the workspace's agent backend can run, normalized across providers.
     // OpenClaw queries the gateway catalog; everything else (Claude Code) reads

--- a/server/web.ts
+++ b/server/web.ts
@@ -250,10 +250,19 @@ export const app = Bun.serve<WsData>({
           patch.inheritDotenv = body.inheritDotenv
         }
 
-        await updateWorkspaceEnv(ws.path, patch)
-        // Frozen-at-spawn: reap workers/idle sessions so fresh env takes effect.
-        restartWorker(ws.path)
-        restartWorkspaceSessions(ws.path)
+        // Skip the write + reaps for a no-op PUT (no recognized fields) so an
+        // empty body doesn't needlessly kill warm workers / idle sessions.
+        const hasChange =
+          patch.set !== undefined ||
+          patch.remove !== undefined ||
+          patch.scopes !== undefined ||
+          patch.inheritDotenv !== undefined
+        if (hasChange) {
+          await updateWorkspaceEnv(ws.path, patch)
+          // Frozen-at-spawn: reap workers/idle sessions so fresh env takes effect.
+          restartWorker(ws.path)
+          restartWorkspaceSessions(ws.path)
+        }
 
         const required = await collectRequiredEnv(ws.path)
         return Response.json(await getWorkspaceEnvView(ws.path, required))

--- a/server/widgets.ts
+++ b/server/widgets.ts
@@ -194,8 +194,26 @@ async function getWidgetList(workspacePath: string): Promise<WidgetInfo[]> {
     const raw = manifest[id] ?? {}
     const rowSpan = VALID_SPANS.includes(raw.rowSpan) ? raw.rowSpan : DEFAULT_CONFIG.rowSpan
     const colSpan = VALID_SPANS.includes(raw.colSpan) ? raw.colSpan : DEFAULT_CONFIG.colSpan
-    return { id, config: { rowSpan, colSpan } as WidgetConfig }
+    const requiredEnv = Array.isArray(raw.requiredEnv) ? raw.requiredEnv : undefined
+    return {
+      id,
+      config: { rowSpan, colSpan, ...(requiredEnv ? { requiredEnv } : {}) } as WidgetConfig
+    }
   })
+}
+
+// Collect env vars declared via widget `config.requiredEnv`, mapping each key to
+// the widget ids that asked for it. Feeds the env API's "required" view.
+export async function collectRequiredEnv(workspacePath: string): Promise<Record<string, string[]>> {
+  const manifest = await readManifest(workspacePath)
+  const out: Record<string, string[]> = {}
+  for (const [id, cfg] of Object.entries(manifest)) {
+    if (!Array.isArray(cfg.requiredEnv)) continue
+    for (const key of cfg.requiredEnv) {
+      ;(out[key] ??= []).push(id)
+    }
+  }
+  return out
 }
 
 export async function listWidgets(workspacePath: string): Promise<Response> {

--- a/server/workspace-env.ts
+++ b/server/workspace-env.ts
@@ -1,0 +1,182 @@
+// Per-workspace environment variables surfaced to both spawn sites: the widget
+// function workers (functions.ts) and the agent chat session (cc-session.ts).
+//
+// Two sources are merged into the "effective" env a workspace runs with:
+//   1. Discovered `.env` files in the workspace root (`.env`, then `.env.local`,
+//      local winning). Parsed with node:util's built-in `parseEnv` — no dep.
+//   2. Custom overrides set from the UI. These are NEVER written into the
+//      workspace (so they can't leak via git); they live in a global store file
+//      under the OS data dir, keyed by absolute workspace path.
+// Custom overrides win over `.env`. The `inheritDotenv` flag is the "mode"
+// toggle: when false, `.env` is ignored for injection and only custom vars feed
+// the workspace (the files are still discovered, just for display).
+import envPaths from 'env-paths'
+import { mkdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { parseEnv } from 'node:util'
+
+import type { WorkspaceEnvSettings, WorkspaceEnvView } from '@/lib/types'
+
+// Dotenv files scanned in the workspace root, low → high precedence. A later
+// file's keys override an earlier file's. Mirrors the common dotenv convention
+// (base `.env`, machine-local `.env.local`).
+const DOTENV_FILES = ['.env', '.env.local'] as const
+
+// Valid POSIX-ish env var name. Used to reject junk keys from the API.
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+export function isValidEnvKey(key: string): boolean {
+  return ENV_KEY_RE.test(key)
+}
+
+const DATA_DIR = envPaths('moi', { suffix: false }).data
+export const DEFAULT_ENV_STORE_PATH = `${DATA_DIR}/workspace-env.json`
+
+// Overridable for tests
+let _storePath = DEFAULT_ENV_STORE_PATH
+export function setWorkspaceEnvStorePath(p: string) {
+  _storePath = p
+}
+
+type StoreEntry = { custom: Record<string, string>; inheritDotenv: boolean }
+type Store = Record<string, StoreEntry>
+
+const DEFAULT_ENTRY: StoreEntry = { custom: {}, inheritDotenv: true }
+
+async function readStore(): Promise<Store> {
+  try {
+    const text = await Bun.file(_storePath).text()
+    const parsed = JSON.parse(text)
+    return parsed && typeof parsed === 'object' ? (parsed as Store) : {}
+  } catch {
+    return {}
+  }
+}
+
+async function writeStore(store: Store): Promise<void> {
+  const dir = _storePath.slice(0, _storePath.lastIndexOf('/'))
+  await mkdir(dir, { recursive: true })
+  await Bun.write(_storePath, JSON.stringify(store, null, 2))
+}
+
+function entryFor(store: Store, workspacePath: string): StoreEntry {
+  const e = store[resolve(workspacePath)]
+  if (!e || typeof e !== 'object') return { ...DEFAULT_ENTRY }
+  return {
+    custom: e.custom && typeof e.custom === 'object' ? e.custom : {},
+    inheritDotenv: e.inheritDotenv !== false
+  }
+}
+
+export async function getWorkspaceEnvSettings(
+  workspacePath: string
+): Promise<WorkspaceEnvSettings> {
+  return entryFor(await readStore(), workspacePath)
+}
+
+// Replace a workspace's custom vars and/or the inheritDotenv flag. Returns the
+// new settings. Invalid keys are dropped (callers should validate up front for
+// user-facing errors).
+export async function updateWorkspaceEnvSettings(
+  workspacePath: string,
+  patch: { custom?: Record<string, string>; inheritDotenv?: boolean }
+): Promise<WorkspaceEnvSettings> {
+  const store = await readStore()
+  const key = resolve(workspacePath)
+  const current = entryFor(store, workspacePath)
+
+  const next: StoreEntry = {
+    custom: current.custom,
+    inheritDotenv: current.inheritDotenv
+  }
+  if (patch.custom) {
+    next.custom = {}
+    for (const [k, v] of Object.entries(patch.custom)) {
+      if (isValidEnvKey(k) && typeof v === 'string') next.custom[k] = v
+    }
+  }
+  if (typeof patch.inheritDotenv === 'boolean') next.inheritDotenv = patch.inheritDotenv
+
+  store[key] = next
+  await writeStore(store)
+  return next
+}
+
+type DotenvFile = { file: string; vars: Record<string, string> }
+
+// Parse each existing dotenv file in the workspace root, low → high precedence.
+async function discoverDotenv(workspacePath: string): Promise<DotenvFile[]> {
+  const out: DotenvFile[] = []
+  for (const file of DOTENV_FILES) {
+    const f = Bun.file(resolve(workspacePath, file))
+    if (!(await f.exists())) continue
+    try {
+      out.push({ file, vars: parseEnv(await f.text()) as Record<string, string> })
+    } catch {
+      // A malformed .env shouldn't take the whole resolve down.
+    }
+  }
+  return out
+}
+
+function mergeDotenv(files: DotenvFile[]): Record<string, string> {
+  const merged: Record<string, string> = {}
+  for (const { vars } of files) Object.assign(merged, vars)
+  return merged
+}
+
+// The effective env a workspace runs with: discovered `.env` (when inherited)
+// overlaid with custom overrides. This is what gets injected into the function
+// workers and the agent session at spawn.
+export async function resolveWorkspaceEnv(workspacePath: string): Promise<Record<string, string>> {
+  const [settings, files] = await Promise.all([
+    getWorkspaceEnvSettings(workspacePath),
+    discoverDotenv(workspacePath)
+  ])
+  const base = settings.inheritDotenv ? mergeDotenv(files) : {}
+  return { ...base, ...settings.custom }
+}
+
+// A view for the API / future UI: every effective key with its source, the
+// discovered files (key counts only — values stay masked), the mode flag, and
+// any declared-required keys with a satisfied flag. `required` maps a key to the
+// widgets that declared it (collected by the caller, optional).
+export async function getWorkspaceEnvView(
+  workspacePath: string,
+  required: Record<string, string[]> = {}
+): Promise<WorkspaceEnvView> {
+  const [settings, files] = await Promise.all([
+    getWorkspaceEnvSettings(workspacePath),
+    discoverDotenv(workspacePath)
+  ])
+  const dotenv = mergeDotenv(files)
+  const inDotenv = settings.inheritDotenv ? dotenv : {}
+  const custom = settings.custom
+
+  const keys = new Set([...Object.keys(inDotenv), ...Object.keys(custom)])
+  const vars = [...keys].sort().map(key => {
+    const inCustom = key in custom
+    const fromDotenv = key in inDotenv
+    const source = inCustom && fromDotenv ? 'both' : inCustom ? 'custom' : 'dotenv'
+    // Only custom values are returned (they're user-editable); .env values stay
+    // masked so the API never echoes secrets it merely discovered.
+    return {
+      key,
+      source: source as 'dotenv' | 'custom' | 'both',
+      ...(inCustom ? { value: custom[key] } : {}),
+      ...(fromDotenv ? { files: files.filter(f => key in f.vars).map(f => f.file) } : {})
+    }
+  })
+
+  const effective = { ...inDotenv, ...custom }
+  const requiredView = Object.entries(required)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, widgets]) => ({ key, satisfied: key in effective, widgets }))
+
+  return {
+    vars,
+    files: files.map(f => ({ file: f.file, count: Object.keys(f.vars).length })),
+    inheritDotenv: settings.inheritDotenv,
+    required: requiredView
+  }
+}

--- a/server/workspace-env.ts
+++ b/server/workspace-env.ts
@@ -43,15 +43,54 @@ export function isValidScope(scope: unknown): scope is EnvScope {
 type Sink = 'widgets' | 'agent'
 
 const DATA_DIR = envPaths('moi', { suffix: false }).data
+const DEFAULT_META_PATH = join(DATA_DIR, 'workspace-env.json')
+const DEFAULT_SECRET_PATH = join(DATA_DIR, 'workspace-secrets.json')
 // Keychain namespace for Bun.secrets entries.
 const SECRET_SERVICE = 'com.molefrog.moi'
 
 // ---------------------------------------------------------------------------
-// Paths (overridable for tests)
+// JSON helpers
 // ---------------------------------------------------------------------------
 
-let _metaPath = join(DATA_DIR, 'workspace-env.json')
-let _secretFilePath = join(DATA_DIR, 'workspace-secrets.json')
+// Parse a JSON object, returning {} on any failure (missing/empty/malformed).
+function parseJsonObject<T extends object>(text: string | null): T {
+  if (!text) return {} as T
+  try {
+    const parsed = JSON.parse(text)
+    return parsed && typeof parsed === 'object' ? (parsed as T) : ({} as T)
+  } catch {
+    return {} as T
+  }
+}
+
+async function readJsonObjectFile<T extends object>(path: string): Promise<T> {
+  try {
+    return parseJsonObject<T>(await Bun.file(path).text())
+  } catch {
+    return {} as T
+  }
+}
+
+// Atomic, owner-only write: temp-then-rename so a crash or concurrent write
+// can't truncate the store; 0600 file in a 0700 dir.
+async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
+  const dir = dirname(path)
+  await mkdir(dir, { recursive: true })
+  try {
+    await chmod(dir, 0o700)
+  } catch {}
+  const tmp = `${path}.${process.pid}.tmp`
+  await Bun.write(tmp, JSON.stringify(data, null, 2))
+  await chmod(tmp, 0o600)
+  await rename(tmp, path)
+}
+
+// ---------------------------------------------------------------------------
+// Paths + per-workspace write serialization (overridable for tests)
+// ---------------------------------------------------------------------------
+
+let _metaPath = DEFAULT_META_PATH
+let _secretFilePath = DEFAULT_SECRET_PATH
 
 export function setWorkspaceEnvStorePath(metaPath: string, secretPath?: string) {
   _metaPath = metaPath
@@ -59,21 +98,29 @@ export function setWorkspaceEnvStorePath(metaPath: string, secretPath?: string) 
   _storePromise = null
 }
 
-// ---------------------------------------------------------------------------
-// Atomic, owner-only JSON writes
-// ---------------------------------------------------------------------------
+// Reset module globals to defaults. Tests call this so path/backend overrides
+// don't leak across files.
+export function resetWorkspaceEnvForTest() {
+  _metaPath = DEFAULT_META_PATH
+  _secretFilePath = DEFAULT_SECRET_PATH
+  setSecretStoreBackend('auto')
+}
 
-async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
-  const dir = dirname(path)
-  await mkdir(dir, { recursive: true })
-  try {
-    await chmod(dir, 0o700)
-  } catch {}
-  // Temp-then-rename so a crash or concurrent write can't truncate the store.
-  const tmp = `${path}.${process.pid}.tmp`
-  await Bun.write(tmp, JSON.stringify(data, null, 2))
-  await chmod(tmp, 0o600)
-  await rename(tmp, path)
+// Serialize writes per workspace path so two concurrent PUTs can't lose an
+// update — `updateWorkspaceEnv` is a read-modify-write over two files, and the
+// atomic write only prevents torn files, not lost updates.
+const _writeChains = new Map<string, Promise<unknown>>()
+
+function withWriteLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = _writeChains.get(key) ?? Promise.resolve()
+  const run = prev.then(fn, fn)
+  // Swallow rejections on the chain tail so one failed write doesn't poison the
+  // next; callers still see their own promise's rejection via `run`.
+  _writeChains.set(
+    key,
+    run.catch(() => {})
+  )
+  return run
 }
 
 // ---------------------------------------------------------------------------
@@ -83,20 +130,10 @@ async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
 // Per-workspace bag of `{ KEY: value }`. Stored as one opaque value per
 // workspace (keychain entry or file row). Values never leave this layer except
 // when injected into a spawn.
-interface SecretStore {
+type SecretStore = {
   readonly backend: 'keychain' | 'file'
   get(workspacePath: string): Promise<Record<string, string>>
   set(workspacePath: string, secrets: Record<string, string>): Promise<void>
-}
-
-function parseSecretBag(raw: string | null): Record<string, string> {
-  if (!raw) return {}
-  try {
-    const parsed = JSON.parse(raw)
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {}
-  } catch {
-    return {}
-  }
 }
 
 // Primary: OS-native secure storage via Bun.secrets (Keychain / libsecret /
@@ -106,7 +143,7 @@ class KeychainSecretStore implements SecretStore {
 
   async get(workspacePath: string): Promise<Record<string, string>> {
     const raw = await Bun.secrets.get({ service: SECRET_SERVICE, name: resolve(workspacePath) })
-    return parseSecretBag(raw)
+    return parseJsonObject<Record<string, string>>(raw)
   }
 
   async set(workspacePath: string, secrets: Record<string, string>): Promise<void> {
@@ -127,13 +164,8 @@ class KeychainSecretStore implements SecretStore {
 class FileSecretStore implements SecretStore {
   readonly backend = 'file' as const
 
-  private async readAll(): Promise<Record<string, Record<string, string>>> {
-    try {
-      const parsed = JSON.parse(await Bun.file(_secretFilePath).text())
-      return parsed && typeof parsed === 'object' ? parsed : {}
-    } catch {
-      return {}
-    }
+  private readAll(): Promise<Record<string, Record<string, string>>> {
+    return readJsonObjectFile<Record<string, Record<string, string>>>(_secretFilePath)
   }
 
   async get(workspacePath: string): Promise<Record<string, string>> {
@@ -194,20 +226,9 @@ function secretStore(): Promise<SecretStore> {
 type EnvMeta = { inheritDotenv: boolean; scopes: Record<string, EnvScope> }
 type MetaStore = Record<string, EnvMeta>
 
-const DEFAULT_META: EnvMeta = { inheritDotenv: true, scopes: {} }
-
-async function readMetaStore(): Promise<MetaStore> {
-  try {
-    const parsed = JSON.parse(await Bun.file(_metaPath).text())
-    return parsed && typeof parsed === 'object' ? (parsed as MetaStore) : {}
-  } catch {
-    return {}
-  }
-}
-
 async function getMeta(workspacePath: string): Promise<EnvMeta> {
-  const e = (await readMetaStore())[resolve(workspacePath)]
-  if (!e || typeof e !== 'object') return { ...DEFAULT_META }
+  const e = (await readJsonObjectFile<MetaStore>(_metaPath))[resolve(workspacePath)]
+  if (!e || typeof e !== 'object') return { inheritDotenv: true, scopes: {} }
   return {
     inheritDotenv: e.inheritDotenv !== false,
     scopes: e.scopes && typeof e.scopes === 'object' ? e.scopes : {}
@@ -215,9 +236,14 @@ async function getMeta(workspacePath: string): Promise<EnvMeta> {
 }
 
 async function writeMeta(workspacePath: string, meta: EnvMeta): Promise<void> {
-  const store = await readMetaStore()
+  const store = await readJsonObjectFile<MetaStore>(_metaPath)
   store[resolve(workspacePath)] = meta
   await writeJsonAtomic(_metaPath, store)
+}
+
+// The scope of a custom key, defaulting to 'both' when unset.
+function scopeOf(meta: EnvMeta, key: string): EnvScope {
+  return meta.scopes[key] ?? 'both'
 }
 
 // ---------------------------------------------------------------------------
@@ -246,8 +272,31 @@ function mergeDotenv(files: DotenvFile[]): Record<string, string> {
   return merged
 }
 
-function scopeAllows(scope: EnvScope, sink: Sink): boolean {
-  return scope === 'both' || scope === sink
+// Read everything a workspace's env depends on, in parallel. `dotenv` is the
+// inheritDotenv-gated merge (the actual base env); `files` keeps per-file detail
+// for the view.
+type WorkspaceEnvState = {
+  meta: EnvMeta
+  files: DotenvFile[]
+  secrets: Record<string, string>
+  dotenv: Record<string, string>
+  backend: 'keychain' | 'file'
+}
+
+async function loadWorkspaceEnvState(workspacePath: string): Promise<WorkspaceEnvState> {
+  const store = await secretStore()
+  const [meta, files, secrets] = await Promise.all([
+    getMeta(workspacePath),
+    discoverDotenv(workspacePath),
+    store.get(workspacePath)
+  ])
+  return {
+    meta,
+    files,
+    secrets,
+    dotenv: meta.inheritDotenv ? mergeDotenv(files) : {},
+    backend: store.backend
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -262,18 +311,13 @@ export async function resolveWorkspaceEnv(
   workspacePath: string,
   sink: Sink
 ): Promise<Record<string, string>> {
-  const store = await secretStore()
-  const [meta, files, secrets] = await Promise.all([
-    getMeta(workspacePath),
-    discoverDotenv(workspacePath),
-    store.get(workspacePath)
-  ])
-  const base = meta.inheritDotenv ? mergeDotenv(files) : {}
+  const { meta, secrets, dotenv } = await loadWorkspaceEnvState(workspacePath)
   const scoped: Record<string, string> = {}
   for (const [k, v] of Object.entries(secrets)) {
-    if (scopeAllows(meta.scopes[k] ?? 'both', sink)) scoped[k] = v
+    const scope = scopeOf(meta, k)
+    if (scope === 'both' || scope === sink) scoped[k] = v
   }
-  return { ...base, ...scoped }
+  return { ...dotenv, ...scoped }
 }
 
 export type EnvUpdate = {
@@ -289,33 +333,35 @@ export type EnvUpdate = {
 
 // Apply a patch to a workspace's custom secrets + metadata. Patch (not replace)
 // semantics, because values are write-only — the UI can add/update one key
-// without resending the others.
-export async function updateWorkspaceEnv(workspacePath: string, patch: EnvUpdate): Promise<void> {
-  const store = await secretStore()
-  const secrets = await store.get(workspacePath)
+// without resending the others. Serialized per workspace to avoid lost updates.
+export function updateWorkspaceEnv(workspacePath: string, patch: EnvUpdate): Promise<void> {
+  return withWriteLock(resolve(workspacePath), async () => {
+    const store = await secretStore()
+    const secrets = await store.get(workspacePath)
 
-  if (patch.set) {
-    for (const [k, v] of Object.entries(patch.set)) {
-      if (isValidEnvKey(k) && typeof v === 'string') secrets[k] = v
+    if (patch.set) {
+      for (const [k, v] of Object.entries(patch.set)) {
+        if (isValidEnvKey(k) && typeof v === 'string') secrets[k] = v
+      }
     }
-  }
-  if (patch.remove) {
-    for (const k of patch.remove) delete secrets[k]
-  }
-  await store.set(workspacePath, secrets)
+    if (patch.remove) {
+      for (const k of patch.remove) delete secrets[k]
+    }
+    await store.set(workspacePath, secrets)
 
-  const meta = await getMeta(workspacePath)
-  const scopes: Record<string, EnvScope> = {}
-  // Keep a scope for every current secret key (default 'both'); drop the rest.
-  for (const k of Object.keys(secrets)) scopes[k] = meta.scopes[k] ?? 'both'
-  if (patch.scopes) {
-    for (const [k, s] of Object.entries(patch.scopes)) {
-      if (k in scopes && isValidScope(s)) scopes[k] = s
+    const meta = await getMeta(workspacePath)
+    const scopes: Record<string, EnvScope> = {}
+    // Keep a scope for every current secret key (default 'both'); drop the rest.
+    for (const k of Object.keys(secrets)) scopes[k] = scopeOf(meta, k)
+    if (patch.scopes) {
+      for (const [k, s] of Object.entries(patch.scopes)) {
+        if (k in scopes && isValidScope(s)) scopes[k] = s
+      }
     }
-  }
-  const inheritDotenv =
-    typeof patch.inheritDotenv === 'boolean' ? patch.inheritDotenv : meta.inheritDotenv
-  await writeMeta(workspacePath, { inheritDotenv, scopes })
+    const inheritDotenv =
+      typeof patch.inheritDotenv === 'boolean' ? patch.inheritDotenv : meta.inheritDotenv
+    await writeMeta(workspacePath, { inheritDotenv, scopes })
+  })
 }
 
 // The env view for the settings UI: every effective key with its source +
@@ -326,13 +372,7 @@ export async function getWorkspaceEnvView(
   workspacePath: string,
   required: Record<string, string[]> = {}
 ): Promise<WorkspaceEnvView> {
-  const store = await secretStore()
-  const [meta, files, secrets] = await Promise.all([
-    getMeta(workspacePath),
-    discoverDotenv(workspacePath),
-    store.get(workspacePath)
-  ])
-  const dotenv = meta.inheritDotenv ? mergeDotenv(files) : {}
+  const { meta, files, secrets, dotenv, backend } = await loadWorkspaceEnvState(workspacePath)
 
   const keys = new Set([...Object.keys(dotenv), ...Object.keys(secrets)])
   const vars = [...keys].sort().map(key => {
@@ -341,8 +381,8 @@ export async function getWorkspaceEnvView(
     const source = inCustom && fromDotenv ? 'both' : inCustom ? 'custom' : 'dotenv'
     return {
       key,
-      source: source as 'dotenv' | 'custom' | 'both',
-      ...(inCustom ? { scope: meta.scopes[key] ?? ('both' as EnvScope) } : {}),
+      source,
+      ...(inCustom ? { scope: scopeOf(meta, key) } : {}),
       ...(fromDotenv ? { files: files.filter(f => key in f.vars).map(f => f.file) } : {})
     }
   })
@@ -351,7 +391,7 @@ export async function getWorkspaceEnvView(
   // a `.env` value (if inherited) or a custom key scoped widgets/both.
   const widgetVisible = new Set(Object.keys(dotenv))
   for (const k of Object.keys(secrets)) {
-    if ((meta.scopes[k] ?? 'both') !== 'agent') widgetVisible.add(k)
+    if (scopeOf(meta, k) !== 'agent') widgetVisible.add(k)
   }
   const requiredView = Object.entries(required)
     .sort(([a], [b]) => a.localeCompare(b))
@@ -361,7 +401,7 @@ export async function getWorkspaceEnvView(
     vars,
     files: files.map(f => ({ file: f.file, count: Object.keys(f.vars).length })),
     inheritDotenv: meta.inheritDotenv,
-    backend: store.backend,
+    backend,
     required: requiredView
   }
 }

--- a/server/workspace-env.ts
+++ b/server/workspace-env.ts
@@ -1,110 +1,231 @@
 // Per-workspace environment variables surfaced to both spawn sites: the widget
 // function workers (functions.ts) and the agent chat session (cc-session.ts).
 //
-// Two sources are merged into the "effective" env a workspace runs with:
+// Two sources feed a workspace's effective env:
 //   1. Discovered `.env` files in the workspace root (`.env`, then `.env.local`,
 //      local winning). Parsed with node:util's built-in `parseEnv` — no dep.
-//   2. Custom overrides set from the UI. These are NEVER written into the
-//      workspace (so they can't leak via git); they live in a global store file
-//      under the OS data dir, keyed by absolute workspace path.
-// Custom overrides win over `.env`. The `inheritDotenv` flag is the "mode"
-// toggle: when false, `.env` is ignored for injection and only custom vars feed
-// the workspace (the files are still discovered, just for display).
+//      `.env` flows to BOTH sinks (it's the workspace's own file).
+//   2. UI-managed custom secrets. These never touch the repo. Secret VALUES are
+//      stored via the OS keychain (`Bun.secrets`) when available, else a 0600
+//      file fallback — see SecretStore. Each custom key has a sink scope
+//      (widgets / agent / both) so a secret can be kept out of the agent's
+//      bypass-permissions Bash. Custom wins over `.env`.
+//
+// Non-secret metadata (the `inheritDotenv` mode flag + per-key scopes, which
+// double as the key-name list for the UI) lives in a small JSON file in the OS
+// data dir. Secret values live in the SecretStore. The two are keyed by the
+// absolute workspace path.
 import envPaths from 'env-paths'
-import { mkdir } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { chmod, mkdir, rename } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
 import { parseEnv } from 'node:util'
 
-import type { WorkspaceEnvSettings, WorkspaceEnvView } from '@/lib/types'
+import type { EnvScope, WorkspaceEnvView } from '@/lib/types'
 
 // Dotenv files scanned in the workspace root, low → high precedence. A later
-// file's keys override an earlier file's. Mirrors the common dotenv convention
-// (base `.env`, machine-local `.env.local`).
+// file's keys override an earlier file's (base `.env`, machine-local `.env.local`).
 const DOTENV_FILES = ['.env', '.env.local'] as const
 
 // Valid POSIX-ish env var name. Used to reject junk keys from the API.
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const SCOPES: readonly EnvScope[] = ['widgets', 'agent', 'both']
 
 export function isValidEnvKey(key: string): boolean {
   return ENV_KEY_RE.test(key)
 }
 
-const DATA_DIR = envPaths('moi', { suffix: false }).data
-export const DEFAULT_ENV_STORE_PATH = `${DATA_DIR}/workspace-env.json`
-
-// Overridable for tests
-let _storePath = DEFAULT_ENV_STORE_PATH
-export function setWorkspaceEnvStorePath(p: string) {
-  _storePath = p
+export function isValidScope(scope: unknown): scope is EnvScope {
+  return typeof scope === 'string' && (SCOPES as readonly string[]).includes(scope)
 }
 
-type StoreEntry = { custom: Record<string, string>; inheritDotenv: boolean }
-type Store = Record<string, StoreEntry>
+// Where a key may flow, given its sink. `agent`/`widgets` only match their own
+// sink; `both` matches either.
+type Sink = 'widgets' | 'agent'
 
-const DEFAULT_ENTRY: StoreEntry = { custom: {}, inheritDotenv: true }
+const DATA_DIR = envPaths('moi', { suffix: false }).data
+// Keychain namespace for Bun.secrets entries.
+const SECRET_SERVICE = 'com.molefrog.moi'
 
-async function readStore(): Promise<Store> {
+// ---------------------------------------------------------------------------
+// Paths (overridable for tests)
+// ---------------------------------------------------------------------------
+
+let _metaPath = join(DATA_DIR, 'workspace-env.json')
+let _secretFilePath = join(DATA_DIR, 'workspace-secrets.json')
+
+export function setWorkspaceEnvStorePath(metaPath: string, secretPath?: string) {
+  _metaPath = metaPath
+  if (secretPath) _secretFilePath = secretPath
+  _storePromise = null
+}
+
+// ---------------------------------------------------------------------------
+// Atomic, owner-only JSON writes
+// ---------------------------------------------------------------------------
+
+async function writeJsonAtomic(path: string, data: unknown): Promise<void> {
+  const dir = dirname(path)
+  await mkdir(dir, { recursive: true })
   try {
-    const text = await Bun.file(_storePath).text()
-    const parsed = JSON.parse(text)
-    return parsed && typeof parsed === 'object' ? (parsed as Store) : {}
+    await chmod(dir, 0o700)
+  } catch {}
+  // Temp-then-rename so a crash or concurrent write can't truncate the store.
+  const tmp = `${path}.${process.pid}.tmp`
+  await Bun.write(tmp, JSON.stringify(data, null, 2))
+  await chmod(tmp, 0o600)
+  await rename(tmp, path)
+}
+
+// ---------------------------------------------------------------------------
+// SecretStore: where custom secret VALUES live
+// ---------------------------------------------------------------------------
+
+// Per-workspace bag of `{ KEY: value }`. Stored as one opaque value per
+// workspace (keychain entry or file row). Values never leave this layer except
+// when injected into a spawn.
+interface SecretStore {
+  readonly backend: 'keychain' | 'file'
+  get(workspacePath: string): Promise<Record<string, string>>
+  set(workspacePath: string, secrets: Record<string, string>): Promise<void>
+}
+
+function parseSecretBag(raw: string | null): Record<string, string> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {}
   } catch {
     return {}
   }
 }
 
-async function writeStore(store: Store): Promise<void> {
-  const dir = _storePath.slice(0, _storePath.lastIndexOf('/'))
-  await mkdir(dir, { recursive: true })
-  await Bun.write(_storePath, JSON.stringify(store, null, 2))
-}
+// Primary: OS-native secure storage via Bun.secrets (Keychain / libsecret /
+// Credential Manager). Encrypted at rest, user-scoped, no password prompt.
+class KeychainSecretStore implements SecretStore {
+  readonly backend = 'keychain' as const
 
-function entryFor(store: Store, workspacePath: string): StoreEntry {
-  const e = store[resolve(workspacePath)]
-  if (!e || typeof e !== 'object') return { ...DEFAULT_ENTRY }
-  return {
-    custom: e.custom && typeof e.custom === 'object' ? e.custom : {},
-    inheritDotenv: e.inheritDotenv !== false
+  async get(workspacePath: string): Promise<Record<string, string>> {
+    const raw = await Bun.secrets.get({ service: SECRET_SERVICE, name: resolve(workspacePath) })
+    return parseSecretBag(raw)
+  }
+
+  async set(workspacePath: string, secrets: Record<string, string>): Promise<void> {
+    const name = resolve(workspacePath)
+    if (Object.keys(secrets).length === 0) {
+      try {
+        await Bun.secrets.delete({ service: SECRET_SERVICE, name })
+      } catch {}
+      return
+    }
+    await Bun.secrets.set({ service: SECRET_SERVICE, name, value: JSON.stringify(secrets) })
   }
 }
 
-export async function getWorkspaceEnvSettings(
-  workspacePath: string
-): Promise<WorkspaceEnvSettings> {
-  return entryFor(await readStore(), workspacePath)
-}
+// Fallback for hosts without a keyring (headless Linux, CI, SSH). Plaintext
+// JSON, but written 0600 in a 0700 dir and atomically. No encryption at rest —
+// a local keyfile would have the same exposure as the data, so it adds nothing.
+class FileSecretStore implements SecretStore {
+  readonly backend = 'file' as const
 
-// Replace a workspace's custom vars and/or the inheritDotenv flag. Returns the
-// new settings. Invalid keys are dropped (callers should validate up front for
-// user-facing errors).
-export async function updateWorkspaceEnvSettings(
-  workspacePath: string,
-  patch: { custom?: Record<string, string>; inheritDotenv?: boolean }
-): Promise<WorkspaceEnvSettings> {
-  const store = await readStore()
-  const key = resolve(workspacePath)
-  const current = entryFor(store, workspacePath)
-
-  const next: StoreEntry = {
-    custom: current.custom,
-    inheritDotenv: current.inheritDotenv
-  }
-  if (patch.custom) {
-    next.custom = {}
-    for (const [k, v] of Object.entries(patch.custom)) {
-      if (isValidEnvKey(k) && typeof v === 'string') next.custom[k] = v
+  private async readAll(): Promise<Record<string, Record<string, string>>> {
+    try {
+      const parsed = JSON.parse(await Bun.file(_secretFilePath).text())
+      return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch {
+      return {}
     }
   }
-  if (typeof patch.inheritDotenv === 'boolean') next.inheritDotenv = patch.inheritDotenv
 
-  store[key] = next
-  await writeStore(store)
-  return next
+  async get(workspacePath: string): Promise<Record<string, string>> {
+    return (await this.readAll())[resolve(workspacePath)] ?? {}
+  }
+
+  async set(workspacePath: string, secrets: Record<string, string>): Promise<void> {
+    const all = await this.readAll()
+    const key = resolve(workspacePath)
+    if (Object.keys(secrets).length === 0) delete all[key]
+    else all[key] = secrets
+    await writeJsonAtomic(_secretFilePath, all)
+  }
 }
+
+// Non-mutating probe: a `get` of a missing key returns null when the keyring
+// works, throws when it's unavailable. Avoids polluting the keychain.
+async function keychainAvailable(): Promise<boolean> {
+  try {
+    await Bun.secrets.get({ service: SECRET_SERVICE, name: '__moi_probe__' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+let _backend: 'auto' | 'file' | 'keychain' = 'auto'
+let _storePromise: Promise<SecretStore> | null = null
+
+// Force a backend (tests pin 'file' so they never touch the real keychain).
+export function setSecretStoreBackend(backend: 'auto' | 'file' | 'keychain') {
+  _backend = backend
+  _storePromise = null
+}
+
+async function createSecretStore(): Promise<SecretStore> {
+  if (_backend === 'file') return new FileSecretStore()
+  if (_backend === 'keychain') return new KeychainSecretStore()
+  if (await keychainAvailable()) {
+    console.log('[env] workspace secrets: OS keychain')
+    return new KeychainSecretStore()
+  }
+  console.warn(
+    `[env] OS keychain unavailable — storing workspace secrets in ${_secretFilePath} (0600).`
+  )
+  return new FileSecretStore()
+}
+
+function secretStore(): Promise<SecretStore> {
+  if (!_storePromise) _storePromise = createSecretStore()
+  return _storePromise
+}
+
+// ---------------------------------------------------------------------------
+// Metadata: inheritDotenv + per-key scopes (NOT secret)
+// ---------------------------------------------------------------------------
+
+type EnvMeta = { inheritDotenv: boolean; scopes: Record<string, EnvScope> }
+type MetaStore = Record<string, EnvMeta>
+
+const DEFAULT_META: EnvMeta = { inheritDotenv: true, scopes: {} }
+
+async function readMetaStore(): Promise<MetaStore> {
+  try {
+    const parsed = JSON.parse(await Bun.file(_metaPath).text())
+    return parsed && typeof parsed === 'object' ? (parsed as MetaStore) : {}
+  } catch {
+    return {}
+  }
+}
+
+async function getMeta(workspacePath: string): Promise<EnvMeta> {
+  const e = (await readMetaStore())[resolve(workspacePath)]
+  if (!e || typeof e !== 'object') return { ...DEFAULT_META }
+  return {
+    inheritDotenv: e.inheritDotenv !== false,
+    scopes: e.scopes && typeof e.scopes === 'object' ? e.scopes : {}
+  }
+}
+
+async function writeMeta(workspacePath: string, meta: EnvMeta): Promise<void> {
+  const store = await readMetaStore()
+  store[resolve(workspacePath)] = meta
+  await writeJsonAtomic(_metaPath, store)
+}
+
+// ---------------------------------------------------------------------------
+// Dotenv discovery
+// ---------------------------------------------------------------------------
 
 type DotenvFile = { file: string; vars: Record<string, string> }
 
-// Parse each existing dotenv file in the workspace root, low → high precedence.
 async function discoverDotenv(workspacePath: string): Promise<DotenvFile[]> {
   const out: DotenvFile[] = []
   for (const file of DOTENV_FILES) {
@@ -125,58 +246,122 @@ function mergeDotenv(files: DotenvFile[]): Record<string, string> {
   return merged
 }
 
-// The effective env a workspace runs with: discovered `.env` (when inherited)
-// overlaid with custom overrides. This is what gets injected into the function
-// workers and the agent session at spawn.
-export async function resolveWorkspaceEnv(workspacePath: string): Promise<Record<string, string>> {
-  const [settings, files] = await Promise.all([
-    getWorkspaceEnvSettings(workspacePath),
-    discoverDotenv(workspacePath)
-  ])
-  const base = settings.inheritDotenv ? mergeDotenv(files) : {}
-  return { ...base, ...settings.custom }
+function scopeAllows(scope: EnvScope, sink: Sink): boolean {
+  return scope === 'both' || scope === sink
 }
 
-// A view for the API / future UI: every effective key with its source, the
-// discovered files (key counts only — values stay masked), the mode flag, and
-// any declared-required keys with a satisfied flag. `required` maps a key to the
-// widgets that declared it (collected by the caller, optional).
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+// The effective env for one sink: discovered `.env` (when inherited) overlaid
+// with the custom secrets scoped to that sink. Injected at spawn — env is frozen
+// once the process starts, so changes require a restart (see functions.ts /
+// cc-session.ts).
+export async function resolveWorkspaceEnv(
+  workspacePath: string,
+  sink: Sink
+): Promise<Record<string, string>> {
+  const store = await secretStore()
+  const [meta, files, secrets] = await Promise.all([
+    getMeta(workspacePath),
+    discoverDotenv(workspacePath),
+    store.get(workspacePath)
+  ])
+  const base = meta.inheritDotenv ? mergeDotenv(files) : {}
+  const scoped: Record<string, string> = {}
+  for (const [k, v] of Object.entries(secrets)) {
+    if (scopeAllows(meta.scopes[k] ?? 'both', sink)) scoped[k] = v
+  }
+  return { ...base, ...scoped }
+}
+
+export type EnvUpdate = {
+  // Upsert these custom secret values (write-only).
+  set?: Record<string, string>
+  // Delete these custom keys.
+  remove?: string[]
+  // Set the sink scope for existing custom keys.
+  scopes?: Record<string, EnvScope>
+  // Toggle whether `.env` files feed the workspace.
+  inheritDotenv?: boolean
+}
+
+// Apply a patch to a workspace's custom secrets + metadata. Patch (not replace)
+// semantics, because values are write-only — the UI can add/update one key
+// without resending the others.
+export async function updateWorkspaceEnv(workspacePath: string, patch: EnvUpdate): Promise<void> {
+  const store = await secretStore()
+  const secrets = await store.get(workspacePath)
+
+  if (patch.set) {
+    for (const [k, v] of Object.entries(patch.set)) {
+      if (isValidEnvKey(k) && typeof v === 'string') secrets[k] = v
+    }
+  }
+  if (patch.remove) {
+    for (const k of patch.remove) delete secrets[k]
+  }
+  await store.set(workspacePath, secrets)
+
+  const meta = await getMeta(workspacePath)
+  const scopes: Record<string, EnvScope> = {}
+  // Keep a scope for every current secret key (default 'both'); drop the rest.
+  for (const k of Object.keys(secrets)) scopes[k] = meta.scopes[k] ?? 'both'
+  if (patch.scopes) {
+    for (const [k, s] of Object.entries(patch.scopes)) {
+      if (k in scopes && isValidScope(s)) scopes[k] = s
+    }
+  }
+  const inheritDotenv =
+    typeof patch.inheritDotenv === 'boolean' ? patch.inheritDotenv : meta.inheritDotenv
+  await writeMeta(workspacePath, { inheritDotenv, scopes })
+}
+
+// The env view for the settings UI: every effective key with its source +
+// scope, the discovered files (key counts only — values masked), the mode flag,
+// the secret backend, and declared-required keys with a satisfied flag.
+// `required` maps a key to the widgets that declared it (collected by caller).
 export async function getWorkspaceEnvView(
   workspacePath: string,
   required: Record<string, string[]> = {}
 ): Promise<WorkspaceEnvView> {
-  const [settings, files] = await Promise.all([
-    getWorkspaceEnvSettings(workspacePath),
-    discoverDotenv(workspacePath)
+  const store = await secretStore()
+  const [meta, files, secrets] = await Promise.all([
+    getMeta(workspacePath),
+    discoverDotenv(workspacePath),
+    store.get(workspacePath)
   ])
-  const dotenv = mergeDotenv(files)
-  const inDotenv = settings.inheritDotenv ? dotenv : {}
-  const custom = settings.custom
+  const dotenv = meta.inheritDotenv ? mergeDotenv(files) : {}
 
-  const keys = new Set([...Object.keys(inDotenv), ...Object.keys(custom)])
+  const keys = new Set([...Object.keys(dotenv), ...Object.keys(secrets)])
   const vars = [...keys].sort().map(key => {
-    const inCustom = key in custom
-    const fromDotenv = key in inDotenv
+    const inCustom = key in secrets
+    const fromDotenv = key in dotenv
     const source = inCustom && fromDotenv ? 'both' : inCustom ? 'custom' : 'dotenv'
-    // Only custom values are returned (they're user-editable); .env values stay
-    // masked so the API never echoes secrets it merely discovered.
     return {
       key,
       source: source as 'dotenv' | 'custom' | 'both',
-      ...(inCustom ? { value: custom[key] } : {}),
+      ...(inCustom ? { scope: meta.scopes[key] ?? ('both' as EnvScope) } : {}),
       ...(fromDotenv ? { files: files.filter(f => key in f.vars).map(f => f.file) } : {})
     }
   })
 
-  const effective = { ...inDotenv, ...custom }
+  // A widget-declared required key is "satisfied" when it's visible to widgets:
+  // a `.env` value (if inherited) or a custom key scoped widgets/both.
+  const widgetVisible = new Set(Object.keys(dotenv))
+  for (const k of Object.keys(secrets)) {
+    if ((meta.scopes[k] ?? 'both') !== 'agent') widgetVisible.add(k)
+  }
   const requiredView = Object.entries(required)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, widgets]) => ({ key, satisfied: key in effective, widgets }))
+    .map(([key, widgets]) => ({ key, satisfied: widgetVisible.has(key), widgets }))
 
   return {
     vars,
     files: files.map(f => ({ file: f.file, count: Object.keys(f.vars).length })),
-    inheritDotenv: settings.inheritDotenv,
+    inheritDotenv: meta.inheritDotenv,
+    backend: store.backend,
     required: requiredView
   }
 }

--- a/workspace/.claude/skills/widgets/SKILL.md
+++ b/workspace/.claude/skills/widgets/SKILL.md
@@ -139,6 +139,31 @@ export default function MyWidget() {
 
 Always handle three states: loading → skeleton, error → error state with retry, success → content.
 
+## Environment variables (server functions only)
+
+Read config and secrets from `process.env` inside `.server.ts`. This is the full environment of the process running the function (Bun also auto-loads workspace `.env` files). It is **server-only** — the widget `.tsx` runs in the browser and never sees these values, so keep API keys in `.server.ts`.
+
+```ts
+// tts.server.ts
+export async function speak(text: string) {
+  const key = process.env.ELEVENLABS_API_KEY
+  if (!key) throw new Error('ELEVENLABS_API_KEY not set for this workspace')
+  // …call the API with `key`
+}
+```
+
+Two sources feed it, both per-workspace: **custom secrets** the user sets in moi's env settings, and **`.env` files** the user can optionally inherit.
+
+Optionally list the keys you need in `config.requiredEnv`. This is advisory — moi's UI uses it to tell the user which keys to set. It is **not** enforced: you can read any var that's defined even if undeclared, and a declared-but-unset key is just `undefined`, so handle the missing case yourself.
+
+```ts
+export const config = {
+  colSpan: 2,
+  rowSpan: 1,
+  requiredEnv: ['ELEVENLABS_API_KEY', 'ELEVENLABS_VOICE_ID'] // optional, advisory
+} as const
+```
+
 ## Commands
 
 - `moi bundle` — compile changed widgets

--- a/workspace/.claude/skills/widgets/SKILL.md
+++ b/workspace/.claude/skills/widgets/SKILL.md
@@ -141,7 +141,7 @@ Always handle three states: loading → skeleton, error → error state with ret
 
 ## Environment variables (server functions only)
 
-Read config and secrets from `process.env` inside `.server.ts`. This is the full environment of the process running the function (Bun also auto-loads workspace `.env` files). It is **server-only** — the widget `.tsx` runs in the browser and never sees these values, so keep API keys in `.server.ts`.
+Read config and secrets from `process.env` inside `.server.ts` — it holds all env vars of the process running the function. This is **server-only**: the widget `.tsx` runs in the browser and never sees these values, so keep API keys in `.server.ts`.
 
 ```ts
 // tts.server.ts
@@ -152,11 +152,12 @@ export async function speak(text: string) {
 }
 ```
 
-Two sources feed it, both per-workspace: **custom secrets** the user sets in moi's env settings, and **`.env` files** the user can optionally inherit.
+moi injects per-workspace values from two sources: **custom secrets** the user sets in moi's env settings, and the workspace's **`.env` files** the user can optionally inherit. (Both are also subject to moi's settings, e.g. inheritance can be turned off — so treat any key as possibly missing.)
 
-Optionally list the keys you need in `config.requiredEnv`. This is advisory — moi's UI uses it to tell the user which keys to set. It is **not** enforced: you can read any var that's defined even if undeclared, and a declared-but-unset key is just `undefined`, so handle the missing case yourself.
+In the **widget's `config`**, optionally declare the keys it needs via `requiredEnv`. This is advisory — moi's UI uses it to tell the user which keys to set. It is **not** enforced: you can read any var that's defined even if undeclared, and a declared-but-unset key is just `undefined`, so always handle the missing case yourself.
 
 ```ts
+// in the widget's .tsx
 export const config = {
   colSpan: 2,
   rowSpan: 1,


### PR DESCRIPTION
## Summary

Adds a complete environment variable management system for workspaces, allowing users to set custom secrets and control whether workspace `.env` files are inherited. Secrets are stored securely (OS keychain when available, else `0600` file), and can be scoped per-sink (`widgets`, `agent`, or `both`) to keep sensitive keys out of unintended contexts.

## Key Changes

- **New `server/workspace-env.ts`**: Core resolver and storage layer
  - `resolveWorkspaceEnv(workspacePath, sink)` merges `.env` files (when inherited) with scope-filtered custom secrets
  - `SecretStore` abstraction with two backends: OS keychain (primary) and `0600` file fallback (headless/CI)
  - Metadata storage (inheritance flag + per-key scopes) in `workspace-env.json`
  - Atomic writes with temp-then-rename to prevent corruption; per-workspace write serialization to avoid lost updates
  - `getWorkspaceEnvView()` for the settings UI (values masked, sources/scopes/files reported)

- **Widget function worker isolation** (`server/functions.ts`, `server/functions-worker.ts`)
  - Workers now spawn from a neutral `cwd` (tmpdir) so Bun doesn't auto-load the workspace `.env`
  - Worker `chdir`s to workspace root at startup via `MEI_WORKSPACE_ROOT` to restore documented behavior
  - Resolved workspace env injected at spawn, making moi's `inheritDotenv` toggle and per-sink scoping authoritative

- **Agent session env injection** (`server/cc-session.ts`)
  - Agent subprocess receives resolved workspace env so Bash tool can access workspace secrets
  - Env frozen at spawn; changes require session restart

- **API endpoints** (`server/web.ts`)
  - `GET /api/workspaces/:id/env` → `WorkspaceEnvView` with effective vars, discovered files, inheritance flag, backend type, and required-key satisfaction
  - `PUT /api/workspaces/:id/env` → patch semantics (set/remove/scopes/inheritDotenv); triggers worker restart and idle session teardown

- **Widget `requiredEnv` declaration** (`server/build-widget.ts`, `server/widgets.ts`)
  - Widgets can declare needed env vars via `config.requiredEnv: string[]`
  - Extracted at build time, stored in manifest, collected by `collectRequiredEnv()`
  - UI surfaces which required keys are unset (advisory only, never enforced)

- **Type additions** (`lib/types.ts`)
  - `EnvScope` type: `'widgets' | 'agent' | 'both'`
  - `WorkspaceEnvVar` and `WorkspaceEnvView` types for the settings UI

- **Documentation** (`docs/env-vars.md`, `workspace/.claude/skills/widgets/SKILL.md`)
  - User guide covering `.env` inheritance, custom secrets, scoping, and how values reach code
  - Internals: resolution, storage separation, injection, change application, required-env flow

- **Comprehensive tests** (`server/test/workspace-env.test.ts`, `server/test/functions.test.ts`)
  - Dotenv parsing, inheritance toggle, custom secrets, scoping, patch semantics
  - Concurrent update serialization
  - Worker cwd restoration and env isolation (`.env` auto-load prevention)
  - File secret store hardening (0600 permissions)

## Notable Implementation Details

- **Two-file storage**: Secret values (write-only, never returned by API) live in `SecretStore`; metadata (inheritance flag, scopes) in JSON. Keyed by absolute workspace path.
- **Keychain probe**: Non-mutating `get` of a sentinel key to detect keyring availability without polluting it.
- **Atomic writes**: Temp file + rename pattern with `0600` permissions in `0700` directory prevents truncation on crash or concurrent writes.
- **Per-workspace write locks**: `withWriteLock()` serializes updates to prevent lost reads-modifies-writes across two files.
- **Env frozen at

https://claude.ai/code/session_01BidWGumGViPDQq5XToEgew