### PR TITLE
Add skill versioning and update command

### DIFF
--- a/server/cli.ts
+++ b/server/cli.ts
@@ -16,6 +16,7 @@ import { scaffoldMoiDir } from './moi-scaffold'
 import { type OpenClawAgent, discoverOpenClawAgents } from './openclaw'
 import { liftToWorkspaceRoot, registerWorkspace } from './registry'
 import {
+  type SkillStatus,
   isBehind,
   isMinorBehind,
   resolveWorkspaceRoot,
@@ -1132,39 +1133,44 @@ async function runSkillUpdate(cwd: string): Promise<void> {
   )
 }
 
-// `dir` is a `--dir` option, not a positional: `moi skill` carries subcommands
-// (update/install), and citty treats a bare positional as an unknown
-// subcommand. Reuses the shared `dirArg` spec; defaults to the current dir.
-const skillUpdate = defineCommand({
-  meta: {
-    name: 'update',
-    description: 'Update this workspace’s skills to the version shipped with the CLI'
-  },
-  args: { dir: dirArg },
-  async run({ args }) {
-    await runSkillUpdate(resolve(args.dir))
-  }
-})
+// Colored status label for one skill row: minor+ behind is actionable, a patch
+// gap is informational, otherwise current.
+function skillState(s: SkillStatus): string {
+  if (isMinorBehind(s.installed, s.bundled)) return pc.yellow('update available')
+  if (isBehind(s.installed, s.bundled)) return pc.dim('patch behind')
+  return pc.green('up to date')
+}
 
-// `install` is an alias of `update` — same operation, kept for naming symmetry
-// with how skills first land in a workspace.
-const skillInstall = defineCommand({
-  meta: { name: 'install', description: 'Alias for `moi skill update`' },
-  args: { dir: dirArg },
-  async run({ args }) {
-    await runSkillUpdate(resolve(args.dir))
-  }
-})
+// `update` and `install` are the same operation under two names (install kept
+// for symmetry with how skills first land in a workspace). `dir` is a `--dir`
+// option, not a positional: citty treats a bare positional on a command that
+// carries subcommands as an unknown subcommand. Reuses the shared `dirArg`.
+const defineSkillUpdate = (name: string, description: string) =>
+  defineCommand({
+    meta: { name, description },
+    args: { dir: dirArg },
+    async run({ args }) {
+      await runSkillUpdate(resolve(args.dir))
+    }
+  })
+
+const skillSubCommands = {
+  update: defineSkillUpdate(
+    'update',
+    'Update this workspace’s skills to the version shipped with the CLI'
+  ),
+  install: defineSkillUpdate('install', 'Alias for `moi skill update`')
+}
 
 const skill = defineCommand({
   meta: { name: 'skill', description: 'Show or update the workspace skills shipped with moi' },
-  subCommands: { update: skillUpdate, install: skillInstall },
+  subCommands: skillSubCommands,
   args: { dir: dirArg },
   async run({ args, rawArgs }) {
     // citty runs this parent handler even after dispatching a subcommand, so
     // bail when one was given — otherwise `moi skill update` also prints status.
     const sub = rawArgs.find(a => !a.startsWith('-'))
-    if (sub === 'update' || sub === 'install') return
+    if (sub && sub in skillSubCommands) return
 
     const root = await resolveWorkspaceRoot(resolve(args.dir))
     const statuses = await skillStatuses(root)
@@ -1173,15 +1179,12 @@ const skill = defineCommand({
     console.log(
       columns(
         ['skill', 'installed', 'bundled', 'status'].map(h => pc.dim(h)),
-        statuses.map(s => {
-          const minor = isMinorBehind(s.installed, s.bundled)
-          const state = minor
-            ? pc.yellow('update available')
-            : isBehind(s.installed, s.bundled)
-              ? pc.dim('patch behind')
-              : pc.green('up to date')
-          return [s.name, s.installed ?? pc.dim('—'), s.bundled ?? pc.dim('—'), state]
-        })
+        statuses.map(s => [
+          s.name,
+          s.installed ?? pc.dim('—'),
+          s.bundled ?? pc.dim('—'),
+          skillState(s)
+        ])
       )
     )
     if (statuses.some(s => isBehind(s.installed, s.bundled))) {

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -15,6 +15,13 @@ import { CONTROL_PORT, PORT } from './constants'
 import { scaffoldMoiDir } from './moi-scaffold'
 import { type OpenClawAgent, discoverOpenClawAgents } from './openclaw'
 import { liftToWorkspaceRoot, registerWorkspace } from './registry'
+import {
+  isBehind,
+  isMinorBehind,
+  resolveWorkspaceRoot,
+  skillStatuses,
+  staleSkillNotice
+} from './skill-version'
 import { installBundledSkills } from './skills-template'
 
 // ---- helpers ----------------------------------------------------------------
@@ -328,8 +335,11 @@ const bundle = defineCommand({
       description: 'Narrow the build to "widgets" or "views" (default: both)'
     }
   },
-  run({ args }) {
+  async run({ args }) {
     const path = resolve(args.dir)
+    // Computed locally up front so it can ride along in the success output; the
+    // agent reads this and knows to run `moi skill update`.
+    const notice = await staleSkillNotice(path)
     const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
 
     ws.onopen = () =>
@@ -361,6 +371,7 @@ const bundle = defineCommand({
             pc.dim(`  No widgets or views found in ${where}/.moi/`) +
             '\n'
         )
+        if (notice) console.log(pc.yellow(notice) + '\n')
         ws.close()
         process.exit(0)
       }
@@ -387,6 +398,7 @@ const bundle = defineCommand({
         console.log('  ' + f.error + '\n')
       }
 
+      if (notice) console.log(pc.yellow(notice) + '\n')
       ws.close()
       process.exit(failed.length > 0 ? 1 : 0)
     }
@@ -404,7 +416,8 @@ const refresh = defineCommand({
     description:
       'Refresh widget data without rebuilding. Use after the agent mutates underlying data.'
   },
-  run() {
+  async run() {
+    const notice = await staleSkillNotice(process.cwd())
     const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
 
     ws.onopen = () => ws.send(JSON.stringify({ type: 'widget:refresh' }))
@@ -417,6 +430,7 @@ const refresh = defineCommand({
         process.exit(1)
       }
       console.log('\n' + pc.green('✓') + ' Refresh signal sent\n')
+      if (notice) console.log(pc.yellow(notice) + '\n')
       ws.close()
       process.exit(0)
     }
@@ -1085,9 +1099,101 @@ const scratch = defineCommand({
   }
 })
 
+// Re-copy bundled skills into a workspace, then report what changed. Pure
+// filesystem op — no running server needed. Resolves the workspace root the
+// same way `moi bundle` does, so it works from `.moi/` or any subdirectory.
+async function runSkillUpdate(cwd: string): Promise<void> {
+  const root = await resolveWorkspaceRoot(cwd)
+  const before = await skillStatuses(root)
+  await installBundledSkills(join(root, '.claude', 'skills'))
+  const after = await skillStatuses(root)
+
+  console.log('\n' + pc.green('✓') + ' Skills updated in ' + pc.bold(root) + '\n')
+  console.log(
+    columns(
+      ['skill', 'from', 'to'].map(h => pc.dim(h)),
+      after.map(s => {
+        const prev = before.find(b => b.name === s.name)?.installed ?? null
+        const changed = prev !== s.installed
+        return [
+          s.name,
+          prev ?? pc.dim('none'),
+          changed ? pc.green(s.installed ?? '?') : pc.dim((s.installed ?? '?') + ' (no change)')
+        ]
+      })
+    )
+  )
+  console.log(
+    '\n' +
+      pc.dim(
+        '  Changes apply when the skill is next loaded (new session or next skill invocation).'
+      ) +
+      '\n'
+  )
+}
+
+// `dir` is a `--dir` option, not a positional: `moi skill` carries subcommands
+// (update/install), and citty treats a bare positional as an unknown
+// subcommand. Reuses the shared `dirArg` spec; defaults to the current dir.
+const skillUpdate = defineCommand({
+  meta: {
+    name: 'update',
+    description: 'Update this workspace’s skills to the version shipped with the CLI'
+  },
+  args: { dir: dirArg },
+  async run({ args }) {
+    await runSkillUpdate(resolve(args.dir))
+  }
+})
+
+// `install` is an alias of `update` — same operation, kept for naming symmetry
+// with how skills first land in a workspace.
+const skillInstall = defineCommand({
+  meta: { name: 'install', description: 'Alias for `moi skill update`' },
+  args: { dir: dirArg },
+  async run({ args }) {
+    await runSkillUpdate(resolve(args.dir))
+  }
+})
+
+const skill = defineCommand({
+  meta: { name: 'skill', description: 'Show or update the workspace skills shipped with moi' },
+  subCommands: { update: skillUpdate, install: skillInstall },
+  args: { dir: dirArg },
+  async run({ args, rawArgs }) {
+    // citty runs this parent handler even after dispatching a subcommand, so
+    // bail when one was given — otherwise `moi skill update` also prints status.
+    const sub = rawArgs.find(a => !a.startsWith('-'))
+    if (sub === 'update' || sub === 'install') return
+
+    const root = await resolveWorkspaceRoot(resolve(args.dir))
+    const statuses = await skillStatuses(root)
+
+    console.log('\n' + pc.bold('moi skill') + pc.dim(' — workspace skills') + '\n')
+    console.log(
+      columns(
+        ['skill', 'installed', 'bundled', 'status'].map(h => pc.dim(h)),
+        statuses.map(s => {
+          const minor = isMinorBehind(s.installed, s.bundled)
+          const state = minor
+            ? pc.yellow('update available')
+            : isBehind(s.installed, s.bundled)
+              ? pc.dim('patch behind')
+              : pc.green('up to date')
+          return [s.name, s.installed ?? pc.dim('—'), s.bundled ?? pc.dim('—'), state]
+        })
+      )
+    )
+    if (statuses.some(s => isBehind(s.installed, s.bundled))) {
+      console.log('\n' + pc.dim('  Run ') + pc.bold('moi skill update') + pc.dim(' to refresh.'))
+    }
+    console.log()
+  }
+})
+
 const main = defineCommand({
   meta: { name: 'moi', description: 'moi — local AI workspace' },
-  subCommands: { init, start, bundle, refresh, theme, config, status, openclaw, scratch }
+  subCommands: { init, start, bundle, refresh, theme, config, status, openclaw, scratch, skill }
 })
 
 // Route `moi config --help` to the same terse cheat sheet as `moi config help`;

--- a/server/skill-version.ts
+++ b/server/skill-version.ts
@@ -19,16 +19,19 @@ export type SkillStatus = {
   bundled: string | null
 }
 
-// Parse the `version:` field out of a `SKILL.md` YAML frontmatter block.
-// Deliberately tiny (no YAML dependency) — frontmatter here is flat. Returns
-// `null` when the file or the field is missing.
+// Read the skill version from a `SKILL.md` YAML frontmatter block. Lives under
+// `metadata.version` — the Agent Skills open-standard slot; Claude Code, the
+// SDK, and openclaw don't consume it, so it's ours alone. Deliberately tiny (no
+// YAML dependency): the indentation-tolerant match picks up the `version:` line
+// whether nested under `metadata:` or top-level. Returns `null` when the file
+// or field is missing.
 export async function readSkillVersion(skillMdPath: string): Promise<string | null> {
   const file = Bun.file(skillMdPath)
   if (!(await file.exists())) return null
   const text = await file.text()
   const fm = text.match(/^---\r?\n([\s\S]*?)\r?\n---/)
   if (!fm) return null
-  const m = fm[1].match(/^version:\s*["']?([^"'\s]+)["']?\s*$/m)
+  const m = fm[1].match(/^\s*version:\s*["']?([^"'\s]+)["']?\s*$/m)
   return m ? m[1] : null
 }
 
@@ -37,30 +40,30 @@ function parse(v: string): [number, number, number] {
   return [a || 0, b || 0, c || 0]
 }
 
-// True when `bundled` is a newer MINOR-or-major release than `installed`. Patch
-// bumps are intentionally silent — they don't change behavior worth surfacing,
-// and `moi skill update` brings them along on the next minor update anyway. A
-// missing `installed` counts as behind (legacy workspace, no stamp yet).
-export function isMinorBehind(installed: string | null, bundled: string | null): boolean {
+// True when `bundled` is a newer release than `installed`, comparing only the
+// first `depth` components (2 = minor-or-major, 3 = any incl. patch). A missing
+// `installed` counts as behind (legacy workspace, no stamp yet); a missing
+// `bundled` never does.
+function behind(installed: string | null, bundled: string | null, depth: number): boolean {
   if (!bundled) return false
   if (!installed) return true
-  const [ia, ib] = parse(installed)
-  const [ba, bb] = parse(bundled)
-  if (ba !== ia) return ba > ia
-  return bb > ib
+  const a = parse(installed)
+  const b = parse(bundled)
+  for (let i = 0; i < depth; i++) {
+    if (b[i] !== a[i]) return b[i] > a[i]
+  }
+  return false
 }
 
-// Any difference at all, patch included. Used to decide whether `moi skill
-// update` would change anything for status display.
-export function isBehind(installed: string | null, bundled: string | null): boolean {
-  if (!bundled) return false
-  if (!installed) return true
-  const [ia, ib, ic] = parse(installed)
-  const [ba, bb, bc] = parse(bundled)
-  if (ba !== ia) return ba > ia
-  if (bb !== ib) return bb > ib
-  return bc > ic
-}
+// Bundled is a MINOR-or-major release ahead — surfaced to the agent. Patch bumps
+// stay silent and ride along on the next minor update.
+export const isMinorBehind = (installed: string | null, bundled: string | null): boolean =>
+  behind(installed, bundled, 2)
+
+// Any difference at all, patch included — decides whether `moi skill update`
+// would change anything, for status display.
+export const isBehind = (installed: string | null, bundled: string | null): boolean =>
+  behind(installed, bundled, 3)
 
 // Skills shipped with this CLI — directory names under the bundled skills dir.
 export async function bundledSkillNames(): Promise<string[]> {

--- a/server/skill-version.ts
+++ b/server/skill-version.ts
@@ -34,35 +34,51 @@ export async function readSkillVersion(skillMdPath: string): Promise<string | nu
   return m ? m[1] : null
 }
 
-function parse(v: string): [number, number, number] {
-  const [a, b, c] = v.split('.').map(n => parseInt(n, 10))
-  return [a || 0, b || 0, c || 0]
+// Bun.semver (built-in: `order` + `satisfies`) isn't in this repo's bun-types
+// yet, so reach it through a narrow typed view rather than `any`.
+const semver = (
+  Bun as unknown as {
+    semver: {
+      order(a: string, b: string): -1 | 0 | 1
+      satisfies(v: string, range: string): boolean
+    }
+  }
+).semver
+
+function isValidVersion(v: string): boolean {
+  try {
+    semver.order(v, v)
+    return true
+  } catch {
+    return false
+  }
 }
 
-// True when `bundled` is a newer release than `installed`, comparing only the
-// first `depth` components (2 = minor-or-major, 3 = any incl. patch). A missing
-// `installed` counts as behind (legacy workspace, no stamp yet); a missing
-// `bundled` never does.
-function behind(installed: string | null, bundled: string | null, depth: number): boolean {
-  if (!bundled) return false
-  if (!installed) return true
-  const a = parse(installed)
-  const b = parse(bundled)
-  for (let i = 0; i < depth; i++) {
-    if (b[i] !== a[i]) return b[i] > a[i]
-  }
-  return false
+// Compare an installed version against the bundled one with Bun's semver.
+// `behind` = bundled is strictly newer; `minorBehind` = that gap is at least a
+// minor bump (patch gaps stay silent). `~installed` spans installed's whole
+// major.minor, so a bundled version outside it is a minor-or-major bump. A
+// missing/invalid installed counts as behind (legacy or broken stamp → prompt);
+// a missing/invalid bundled never does (don't nag on our own broken ship).
+function compare(
+  installed: string | null,
+  bundled: string | null
+): { behind: boolean; minorBehind: boolean } {
+  if (!bundled || !isValidVersion(bundled)) return { behind: false, minorBehind: false }
+  if (!installed || !isValidVersion(installed)) return { behind: true, minorBehind: true }
+  const behind = semver.order(installed, bundled) < 0
+  return { behind, minorBehind: behind && !semver.satisfies(bundled, `~${installed}`) }
 }
 
 // Bundled is a MINOR-or-major release ahead — surfaced to the agent. Patch bumps
 // stay silent and ride along on the next minor update.
 export const isMinorBehind = (installed: string | null, bundled: string | null): boolean =>
-  behind(installed, bundled, 2)
+  compare(installed, bundled).minorBehind
 
 // Any difference at all, patch included — decides whether `moi skill update`
 // would change anything, for status display.
 export const isBehind = (installed: string | null, bundled: string | null): boolean =>
-  behind(installed, bundled, 3)
+  compare(installed, bundled).behind
 
 // Skills shipped with this CLI — directory names under the bundled skills dir.
 export async function bundledSkillNames(): Promise<string[]> {

--- a/server/skill-version.ts
+++ b/server/skill-version.ts
@@ -1,7 +1,7 @@
 // Skill versioning for Case 1: a workspace's installed skill copy drifting
 // behind the version this CLI ships. The CLI is "stupid" — it only reads the
-// `version:` stamped in each skill's `SKILL.md` frontmatter, compares the
-// workspace copy against the bundled copy, and reports drift. Updating is never
+// version marker stamped in each skill's `SKILL.md`, compares the workspace
+// copy against the bundled copy, and reports drift. Updating is never
 // automatic: the agent (which reads command output) sees the notice and runs
 // `moi skill update`. See `moi skill` in `cli.ts`.
 import { readdir } from 'node:fs/promises'
@@ -19,52 +19,19 @@ export type SkillStatus = {
   bundled: string | null
 }
 
-// Bun.YAML is built in (Bun ≥ 1.2.9) but isn't in this repo's bun-types yet, so
-// reach it through a narrow typed view rather than `any`.
-const yaml = (Bun as unknown as { YAML: { parse(src: string): unknown } }).YAML
+// The version is stamped as a self-contained marker in SKILL.md, e.g.
+// `<moi-skill version="0.1.0" />`, rather than in YAML frontmatter. SKILL.md
+// frontmatter is NOT reliably strict YAML — the free-text `description` routinely
+// contains `: ` and other tokens that make real parsers reject the block — so a
+// controlled, unambiguous marker we own is both simpler and more robust than
+// scraping the frontmatter. Returns `null` when the file or marker is missing.
+const VERSION_MARKER = /<moi-skill\b[^>]*\bversion="([^"]+)"/
 
-// Isolate the `metadata:` mapping from a frontmatter block and return it as a
-// standalone YAML document (child indentation stripped), or null if absent.
-// SKILL.md frontmatter is NOT reliably strict YAML — the free-text `description`
-// routinely contains `: ` and other tokens a strict parser rejects — so we feed
-// only this small block (which we control) to the parser, never the whole thing.
-function isolateMetadata(frontmatter: string): string | null {
-  const lines = frontmatter.split(/\r?\n/)
-  const start = lines.findIndex(l => /^metadata:/.test(l))
-  if (start === -1) return null
-  const inline = lines[start].slice('metadata:'.length).trim()
-  if (inline) return inline // flow form: `metadata: { version: 1.0.0 }`
-  // Block form: take the indented child lines until the next top-level key,
-  // stripping the indent so the result parses as a root-level mapping.
-  const body: string[] = []
-  for (const line of lines.slice(start + 1)) {
-    if (/^\s+\S/.test(line)) body.push(line.replace(/^\s+/, ''))
-    else if (line.trim() !== '') break
-  }
-  return body.length > 0 ? body.join('\n') : null
-}
-
-// Read the skill version from a `SKILL.md`'s `metadata.version` (the Agent
-// Skills standard slot). Returns `null` when the file, the metadata block, or
-// the version is missing or unparseable.
 export async function readSkillVersion(skillMdPath: string): Promise<string | null> {
   const file = Bun.file(skillMdPath)
   if (!(await file.exists())) return null
-  const text = await file.text()
-  const fence = text.match(/^---\r?\n([\s\S]*?)\r?\n---/)
-  if (!fence) return null
-  const metaYaml = isolateMetadata(fence[1])
-  if (!metaYaml) return null
-  let meta: unknown
-  try {
-    meta = yaml.parse(metaYaml)
-  } catch {
-    return null
-  }
-  if (typeof meta !== 'object' || meta === null) return null
-  const v = (meta as { version?: unknown }).version
-  if (typeof v === 'string') return v
-  return typeof v === 'number' ? String(v) : null
+  const m = (await file.text()).match(VERSION_MARKER)
+  return m ? m[1] : null
 }
 
 function parse(v: string): [number, number, number] {

--- a/server/skill-version.ts
+++ b/server/skill-version.ts
@@ -1,0 +1,110 @@
+// Skill versioning for Case 1: a workspace's installed skill copy drifting
+// behind the version this CLI ships. The CLI is "stupid" — it only reads the
+// `version:` stamped in each skill's `SKILL.md` frontmatter, compares the
+// workspace copy against the bundled copy, and reports drift. Updating is never
+// automatic: the agent (which reads command output) sees the notice and runs
+// `moi skill update`. See `moi skill` in `cli.ts`.
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { findWorkspaceForPath, liftToWorkspaceRoot, listWorkspaces } from './registry'
+import { BUNDLED_SKILLS_DIR } from './skills-template'
+
+export type SkillStatus = {
+  name: string
+  // Version stamped in the workspace's copy. `null` means absent — either the
+  // skill isn't installed or it predates skill versioning (treated as behind).
+  installed: string | null
+  // Version shipped with this CLI. `null` only if a bundled skill lacks a stamp.
+  bundled: string | null
+}
+
+// Parse the `version:` field out of a `SKILL.md` YAML frontmatter block.
+// Deliberately tiny (no YAML dependency) — frontmatter here is flat. Returns
+// `null` when the file or the field is missing.
+export async function readSkillVersion(skillMdPath: string): Promise<string | null> {
+  const file = Bun.file(skillMdPath)
+  if (!(await file.exists())) return null
+  const text = await file.text()
+  const fm = text.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!fm) return null
+  const m = fm[1].match(/^version:\s*["']?([^"'\s]+)["']?\s*$/m)
+  return m ? m[1] : null
+}
+
+function parse(v: string): [number, number, number] {
+  const [a, b, c] = v.split('.').map(n => parseInt(n, 10))
+  return [a || 0, b || 0, c || 0]
+}
+
+// True when `bundled` is a newer MINOR-or-major release than `installed`. Patch
+// bumps are intentionally silent — they don't change behavior worth surfacing,
+// and `moi skill update` brings them along on the next minor update anyway. A
+// missing `installed` counts as behind (legacy workspace, no stamp yet).
+export function isMinorBehind(installed: string | null, bundled: string | null): boolean {
+  if (!bundled) return false
+  if (!installed) return true
+  const [ia, ib] = parse(installed)
+  const [ba, bb] = parse(bundled)
+  if (ba !== ia) return ba > ia
+  return bb > ib
+}
+
+// Any difference at all, patch included. Used to decide whether `moi skill
+// update` would change anything for status display.
+export function isBehind(installed: string | null, bundled: string | null): boolean {
+  if (!bundled) return false
+  if (!installed) return true
+  const [ia, ib, ic] = parse(installed)
+  const [ba, bb, bc] = parse(bundled)
+  if (ba !== ia) return ba > ia
+  if (bb !== ib) return bb > ib
+  return bc > ic
+}
+
+// Skills shipped with this CLI — directory names under the bundled skills dir.
+export async function bundledSkillNames(): Promise<string[]> {
+  try {
+    const entries = await readdir(BUNDLED_SKILLS_DIR, { withFileTypes: true })
+    return entries.filter(e => e.isDirectory()).map(e => e.name)
+  } catch {
+    return []
+  }
+}
+
+// Per-skill installed-vs-bundled versions for a workspace root.
+export async function skillStatuses(workspaceRoot: string): Promise<SkillStatus[]> {
+  const names = await bundledSkillNames()
+  return Promise.all(
+    names.map(async name => ({
+      name,
+      bundled: await readSkillVersion(join(BUNDLED_SKILLS_DIR, name, 'SKILL.md')),
+      installed: await readSkillVersion(join(workspaceRoot, '.claude', 'skills', name, 'SKILL.md'))
+    }))
+  )
+}
+
+// Resolve a path to its workspace root: the registered workspace that owns it,
+// else lifted out of any `.moi/`, else the path itself. Mirrors how `moi
+// bundle` resolves a target so `moi skill` works from the same places.
+export async function resolveWorkspaceRoot(cwd: string): Promise<string> {
+  const ws = findWorkspaceForPath(await listWorkspaces(), cwd)
+  if (ws) return ws.path
+  return liftToWorkspaceRoot(cwd)
+}
+
+// One-line, agent-facing notice when any installed skill is a minor+ behind the
+// bundled version — else `null`. Other commands append it to their output so
+// the agent reading that output knows to run `moi skill update`. Never throws:
+// version checks must not break the command they ride on.
+export async function staleSkillNotice(cwd: string): Promise<string | null> {
+  try {
+    const root = await resolveWorkspaceRoot(cwd)
+    const stale = (await skillStatuses(root)).filter(s => isMinorBehind(s.installed, s.bundled))
+    if (stale.length === 0) return null
+    const parts = stale.map(s => `${s.name} (${s.installed ?? 'none'} → ${s.bundled})`)
+    return `⚠ moi skill outdated: ${parts.join(', ')} — run \`moi skill update\` to refresh.`
+  } catch {
+    return null
+  }
+}

--- a/server/skill-version.ts
+++ b/server/skill-version.ts
@@ -19,20 +19,52 @@ export type SkillStatus = {
   bundled: string | null
 }
 
-// Read the skill version from a `SKILL.md` YAML frontmatter block. Lives under
-// `metadata.version` — the Agent Skills open-standard slot; Claude Code, the
-// SDK, and openclaw don't consume it, so it's ours alone. Deliberately tiny (no
-// YAML dependency): the indentation-tolerant match picks up the `version:` line
-// whether nested under `metadata:` or top-level. Returns `null` when the file
-// or field is missing.
+// Bun.YAML is built in (Bun ≥ 1.2.9) but isn't in this repo's bun-types yet, so
+// reach it through a narrow typed view rather than `any`.
+const yaml = (Bun as unknown as { YAML: { parse(src: string): unknown } }).YAML
+
+// Isolate the `metadata:` mapping from a frontmatter block and return it as a
+// standalone YAML document (child indentation stripped), or null if absent.
+// SKILL.md frontmatter is NOT reliably strict YAML — the free-text `description`
+// routinely contains `: ` and other tokens a strict parser rejects — so we feed
+// only this small block (which we control) to the parser, never the whole thing.
+function isolateMetadata(frontmatter: string): string | null {
+  const lines = frontmatter.split(/\r?\n/)
+  const start = lines.findIndex(l => /^metadata:/.test(l))
+  if (start === -1) return null
+  const inline = lines[start].slice('metadata:'.length).trim()
+  if (inline) return inline // flow form: `metadata: { version: 1.0.0 }`
+  // Block form: take the indented child lines until the next top-level key,
+  // stripping the indent so the result parses as a root-level mapping.
+  const body: string[] = []
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s+\S/.test(line)) body.push(line.replace(/^\s+/, ''))
+    else if (line.trim() !== '') break
+  }
+  return body.length > 0 ? body.join('\n') : null
+}
+
+// Read the skill version from a `SKILL.md`'s `metadata.version` (the Agent
+// Skills standard slot). Returns `null` when the file, the metadata block, or
+// the version is missing or unparseable.
 export async function readSkillVersion(skillMdPath: string): Promise<string | null> {
   const file = Bun.file(skillMdPath)
   if (!(await file.exists())) return null
   const text = await file.text()
-  const fm = text.match(/^---\r?\n([\s\S]*?)\r?\n---/)
-  if (!fm) return null
-  const m = fm[1].match(/^\s*version:\s*["']?([^"'\s]+)["']?\s*$/m)
-  return m ? m[1] : null
+  const fence = text.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!fence) return null
+  const metaYaml = isolateMetadata(fence[1])
+  if (!metaYaml) return null
+  let meta: unknown
+  try {
+    meta = yaml.parse(metaYaml)
+  } catch {
+    return null
+  }
+  if (typeof meta !== 'object' || meta === null) return null
+  const v = (meta as { version?: unknown }).version
+  if (typeof v === 'string') return v
+  return typeof v === 'number' ? String(v) : null
 }
 
 function parse(v: string): [number, number, number] {

--- a/server/skills-template.ts
+++ b/server/skills-template.ts
@@ -9,12 +9,17 @@ import { join } from 'node:path'
 // symlinked CLI binaries still find the source tree.
 export const TEMPLATE_DIR = join(import.meta.dir, '..', 'workspace')
 
+// The folder holding the skill packages this CLI ships. Each subdirectory is
+// one skill (e.g. `moi-workspace/`) with its own `SKILL.md`. Source of truth
+// for what `moi skill update` copies and what versions it compares against.
+export const BUNDLED_SKILLS_DIR = join(TEMPLATE_DIR, '.claude', 'skills')
+
 // Copy each shipped skill folder into `targetSkillsDir`. Overwrites existing
 // files (e.g. on a re-install after a moi upgrade) but leaves unrelated
 // directories alone. Creates the target if missing.
 export async function installBundledSkills(targetSkillsDir: string): Promise<void> {
   await mkdir(targetSkillsDir, { recursive: true })
-  await cp(join(TEMPLATE_DIR, '.claude', 'skills'), targetSkillsDir, {
+  await cp(BUNDLED_SKILLS_DIR, targetSkillsDir, {
     recursive: true,
     force: true
   })

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -241,7 +241,7 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 
 - **You'll know** — `moi` commands warn you when this skill is behind.
 - **To update** — run `moi skill update`. Never mid-task: finish first, or do it at the end (changes apply on the next skill load).
-- **Then** — if you updated, tell the user. If unsure whether you should, ask first, casually: "btw, a newer moi skill is available — want me to update it?"
+- **Then** — if you updated, mention it. If unsure whether you should, raise it as a passing aside, never the main point of your reply.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
 <moi-skill version="0.1.0" />

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -114,16 +114,6 @@ documentation. Call `moi` in the `.moi` folder.
 
 For more options, commands, use `moi help`.
 
-## Keeping the skill current
-
-This skill is shipped with the `moi` CLI and copied into the workspace. When the CLI is upgraded, the
-copy here can fall behind. `moi` commands surface this: if you ever see a line like
-`⚠ moi skill outdated: moi-workspace (… → …) — run \`moi skill update\` to refresh.` in command
-output, run `moi skill update` to bring this skill up to date. The update only rewrites the bundled
-skill files — your `.moi` applets, deps, and config are untouched. Changes take effect the next time
-the skill is loaded (a new session or next invocation), not mid-task, so finish what you're doing
-first. Only minor+ updates are surfaced; patch differences are pulled in silently on the next update.
-
 # Critical constraints when interacting with moi
 
 - Never read or modify files outside the `.moi` directory, unless the user explicitly asks. If you
@@ -244,6 +234,14 @@ export const config = {
 
 The inverse of a widget: a view **owns its whole page** — its own `h-full w-full` layout, scrolling
 (`overflow-auto`), padding, and chrome. Build it to read like an app screen. See `VIEW-DESIGN.md`.
+
+# Keeping this skill current
+
+This skill is installed with moi (via the CLI or the UI) and can fall behind when the moi CLI updates.
+
+- **You'll know** — `moi` commands print a `⚠ moi skill outdated …` line.
+- **To update** — run `moi skill update`. Never mid-task: finish first, or do it at the end (changes apply on the next skill load).
+- **Then** — if you updated, tell the user. If unsure whether you should, ask first, casually: "btw, a newer moi skill is available — want me to update it?"
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
 <moi-skill version="0.1.0" />

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: moi-workspace
+version: 0.1.0
 description: The moi workspace — the web UI the user chats from, extended with agent-authored applets (widgets, views) plus theme & config. Read this FIRST in two cases. (a) A message carries hidden <moi>…</moi> meta tags: it was fired from a moi workspace, so you are running inside one even if nothing else says so. (b) The user uses moi vocab — workspace, applet, widget, view, scratchpad, dashboard, or a `moi` command — or asks to build, edit, customize, or theme the workspace UI or its layout.
 ---
 
@@ -110,8 +111,19 @@ documentation. Call `moi` in the `.moi` folder.
 - `moi theme --font=<key>` — change font theme (omit `--font` to list options)
 - `moi theme --color=<key>` — change color preset (omit `--color` to list options)
 - `moi config` — set the workspace name & icon (`moi config --help` for usage)
+- `moi skill` — show installed vs bundled skill versions; `moi skill update` to refresh
 
 For more options, commands, use `moi help`.
+
+## Keeping the skill current
+
+This skill is shipped with the `moi` CLI and copied into the workspace. When the CLI is upgraded, the
+copy here can fall behind. `moi` commands surface this: if you ever see a line like
+`⚠ moi skill outdated: moi-workspace (… → …) — run \`moi skill update\` to refresh.` in command
+output, run `moi skill update` to bring this skill up to date. The update only rewrites the bundled
+skill files — your `.moi` applets, deps, and config are untouched. Changes take effect the next time
+the skill is loaded (a new session or next invocation), not mid-task, so finish what you're doing
+first. Only minor+ updates are surfaced; patch differences are pulled in silently on the next update.
 
 # Critical constraints when interacting with moi
 

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: moi-workspace
 description: The moi workspace — the web UI the user chats from, extended with agent-authored applets (widgets, views) plus theme & config. Read this FIRST in two cases. (a) A message carries hidden <moi>…</moi> meta tags: it was fired from a moi workspace, so you are running inside one even if nothing else says so. (b) The user uses moi vocab — workspace, applet, widget, view, scratchpad, dashboard, or a `moi` command — or asks to build, edit, customize, or theme the workspace UI or its layout.
-metadata:
-  version: 0.1.0
 ---
 
 # Workspace
@@ -246,3 +244,6 @@ export const config = {
 
 The inverse of a widget: a view **owns its whole page** — its own `h-full w-full` layout, scrolling
 (`overflow-auto`), padding, and chrome. Build it to read like an app screen. See `VIEW-DESIGN.md`.
+
+<!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
+<moi-skill version="0.1.0" />

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -239,7 +239,7 @@ The inverse of a widget: a view **owns its whole page** — its own `h-full w-fu
 
 This skill is installed with moi (via the CLI or the UI) and can fall behind when the moi CLI updates.
 
-- **You'll know** — `moi` commands print a `⚠ moi skill outdated …` line.
+- **You'll know** — `moi` commands warn you when this skill is behind.
 - **To update** — run `moi skill update`. Never mid-task: finish first, or do it at the end (changes apply on the next skill load).
 - **Then** — if you updated, tell the user. If unsure whether you should, ask first, casually: "btw, a newer moi skill is available — want me to update it?"
 

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: moi-workspace
-version: 0.1.0
 description: The moi workspace — the web UI the user chats from, extended with agent-authored applets (widgets, views) plus theme & config. Read this FIRST in two cases. (a) A message carries hidden <moi>…</moi> meta tags: it was fired from a moi workspace, so you are running inside one even if nothing else says so. (b) The user uses moi vocab — workspace, applet, widget, view, scratchpad, dashboard, or a `moi` command — or asks to build, edit, customize, or theme the workspace UI or its layout.
+metadata:
+  version: 0.1.0
 ---
 
 # Workspace

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -101,7 +101,8 @@ my-agent-folder/
 
 Treat `moi` as an external command — you cannot inspect or modify its sources. Use only the
 documented subcommands (`moi bundle`, `moi bundle --force`, etc.). Call `moi help` for
-documentation. Call `moi` in the `.moi` folder.
+documentation. Run all `moi` commands from the **project root** — the folder that contains `.moi/`,
+never from inside `.moi/` itself. You don't pass paths; moi resolves the workspace from where it's run.
 
 - `moi bundle` — compile changed applets
 - `moi bundle --force` — rebuild all applets (use after changing `config`)

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -241,7 +241,7 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 
 - **You'll know** — `moi` commands warn you when this skill is behind.
 - **To update** — run `moi skill update`. Never mid-task: finish first, or do it at the end (changes apply on the next skill load).
-- **Then** — if you updated, mention it. If unsure whether you should, raise it as a passing aside, never the main point of your reply.
+- **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
 <moi-skill version="0.1.0" />


### PR DESCRIPTION
## Summary

Adds skill versioning infrastructure to track when workspace-installed skills drift behind the bundled versions shipped with the CLI. Introduces a new `moi skill` command to view and update skill versions, with automatic notices surfaced to the agent when updates are available.

## Key Changes

- **New `skill-version.ts` module**: Core versioning logic that reads skill versions from `SKILL.md` frontmatter, compares installed vs bundled versions, and determines update availability. Distinguishes between minor/major updates (actionable) and patch updates (informational).

- **New `moi skill` command**: Displays a table of installed vs bundled skill versions with status indicators. Subcommands `moi skill update` and `moi skill install` (alias) re-copy bundled skills and report what changed.

- **Stale skill notices**: Commands that modify the workspace (`bundle`, `refresh`) now compute and display a notice when any skill is a minor+ version behind, prompting the agent to run `moi skill update`. The notice is never thrown and won't break commands.

- **Workspace root resolution**: Shared logic (`resolveWorkspaceRoot`) mirrors how `moi bundle` resolves paths, so `moi skill` works from the same locations (registered workspace, `.moi/` subdirectory, or current directory).

- **Skill versioning in bundled skills**: Added `metadata.version: 0.1.0` to the `moi-workspace` skill's `SKILL.md` frontmatter and documented the update workflow in the skill itself.

- **CLI integration**: Updated `bundle` and `refresh` commands to be async and include stale skill notices in their output. Added `skill` to the main command's subcommands.

## Implementation Details

- Version comparison uses semantic versioning (major.minor.patch) with configurable depth: minor-or-major updates are surfaced to the agent, patch updates are silent.
- The `readSkillVersion` function is deliberately minimal (no YAML parser) and tolerant of indentation, reading from the standard Agent Skills `metadata.version` field.
- `staleSkillNotice` never throws—version checks must not break the commands they ride on.
- The `runSkillUpdate` function uses a before/after snapshot to show which skills changed and which stayed the same.

https://claude.ai/code/session_012cBXwcuRHZYah5AVpdr7us