### PR TITLE
scratch: omit base64 image blobs from `read` output

### DIFF
--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -44,7 +44,7 @@ import { cn } from '@/client/lib/cn'
 import { useWorkspaceId } from '@/client/lib/WorkspaceContext'
 import { setScratchExecutor } from '@/client/lib/scratch-executor'
 import { type MeiEvent, useMeiEvent } from '@/client/hooks/useMeiEvents'
-import type { ScratchOp, ScratchOpResult } from '@/lib/types'
+import type { ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
 
 // Identifies this tab's writes so it can ignore the `scratchpad:updated` echo of
 // its own save (see the MEI reload below). Per page load.
@@ -64,6 +64,15 @@ const LICENSE_KEY = process.env.PUBLIC_TLDRAW_LICENSE_KEY || undefined
 // mutation we flush an immediate save so a following `moi scratch read` (served
 // off disk) is consistent. Returns the shape name (add), a PNG data URL (view),
 // or a bare ack.
+// Map a relayed op's optional color/size onto tldraw shape props. Omitted
+// fields are left off so the shape keeps its tldraw default.
+function styleProps(style: ScratchStyle) {
+  return {
+    ...(style.color ? { color: style.color } : {}),
+    ...(style.size ? { size: style.size } : {})
+  }
+}
+
 function makeExecutor(editor: Editor, flushSave: () => void) {
   return async (op: ScratchOp): Promise<ScratchOpResult> => {
     switch (op.kind) {
@@ -77,6 +86,7 @@ function makeExecutor(editor: Editor, flushSave: () => void) {
             geo: 'rectangle',
             w: op.w,
             h: op.h,
+            ...styleProps(op),
             ...(op.text ? { richText: toRichText(op.text) } : {})
           }
         })
@@ -89,7 +99,7 @@ function makeExecutor(editor: Editor, flushSave: () => void) {
           type: 'text',
           x: op.x,
           y: op.y,
-          props: { richText: toRichText(op.text) }
+          props: { richText: toRichText(op.text), ...styleProps(op) }
         })
         flushSave()
         return { name: op.name }
@@ -100,7 +110,7 @@ function makeExecutor(editor: Editor, flushSave: () => void) {
           type: 'note',
           x: op.x,
           y: op.y,
-          props: { richText: toRichText(op.text) }
+          props: { richText: toRichText(op.text), ...styleProps(op) }
         })
         flushSave()
         return { name: op.name }
@@ -108,13 +118,16 @@ function makeExecutor(editor: Editor, flushSave: () => void) {
       case 'add-arrow': {
         const id = createShapeId(op.name)
         // Arrow at the canvas origin: point endpoints carry absolute coords;
-        // bound endpoints get placeholders that the binding then drives.
+        // bound endpoints get placeholders that the binding then drives. `elbow`
+        // routes with right angles (diagram-style); default is a curved arc.
         editor.createShape({
           id,
           type: 'arrow',
           x: 0,
           y: 0,
           props: {
+            ...styleProps(op),
+            ...(op.elbow ? { kind: 'elbow' } : {}),
             start: 'name' in op.from ? { x: 0, y: 0 } : { x: op.from.x, y: op.from.y },
             end: 'name' in op.to ? { x: 100, y: 0 } : { x: op.to.x, y: op.to.y }
           }
@@ -157,6 +170,12 @@ function makeExecutor(editor: Editor, flushSave: () => void) {
       }
       case 'delete': {
         editor.deleteShape(createShapeId(op.name))
+        flushSave()
+        return { ok: true }
+      }
+      case 'clear': {
+        const ids = [...editor.getCurrentPageShapeIds()]
+        if (ids.length > 0) editor.deleteShapes(ids)
         flushSave()
         return { ok: true }
       }

--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -19,11 +19,9 @@ import {
   DefaultVerticalAlignStyle,
   GeoShapeGeoStyle,
   Tldraw,
-  createShapeId,
   getSnapshot,
   loadSnapshot,
-  react,
-  toRichText
+  react
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { motion } from 'motion/react'
@@ -44,7 +42,7 @@ import { cn } from '@/client/lib/cn'
 import { useWorkspaceId } from '@/client/lib/WorkspaceContext'
 import { setScratchExecutor } from '@/client/lib/scratch-executor'
 import { type MeiEvent, useMeiEvent } from '@/client/hooks/useMeiEvents'
-import type { ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
+import type { ScratchOp, ScratchOpResult } from '@/lib/types'
 
 // Identifies this tab's writes so it can ignore the `scratchpad:updated` echo of
 // its own save (see the MEI reload below). Per page load.
@@ -59,137 +57,23 @@ const AUTOSAVE_MS = 500
 // tldraw's default unlicensed watermark. See docs/moi-scratchpad.md.
 const LICENSE_KEY = process.env.PUBLIC_TLDRAW_LICENSE_KEY || undefined
 
-// Map a relayed op onto the tldraw Editor API. Shape names → deterministic ids
-// via createShapeId, so the same op run in two tabs converges. After any
-// mutation we flush an immediate save so a following `moi scratch read` (served
-// off disk) is consistent. Returns the shape name (add), a PNG data URL (view),
-// or a bare ack.
-// Map a relayed op's optional color/size onto tldraw shape props. Omitted
-// fields are left off so the shape keeps its tldraw default.
-function styleProps(style: ScratchStyle) {
-  return {
-    ...(style.color ? { color: style.color } : {}),
-    ...(style.size ? { size: style.size } : {})
-  }
-}
-
-function makeExecutor(editor: Editor, flushSave: () => void) {
+// Execute a relayed op in this tab. Only `view` is relayed now — rasterizing the
+// canvas to a PNG needs the browser (`editor.toImageDataUrl`); every mutation runs
+// server-side against the disk snapshot (see server/scratchpad-executor.ts), so a
+// non-view op arriving here is unexpected.
+function makeExecutor(editor: Editor) {
   return async (op: ScratchOp): Promise<ScratchOpResult> => {
-    switch (op.kind) {
-      case 'add-rect': {
-        editor.createShape({
-          id: createShapeId(op.name),
-          type: 'geo',
-          x: op.x,
-          y: op.y,
-          props: {
-            geo: 'rectangle',
-            w: op.w,
-            h: op.h,
-            ...styleProps(op),
-            ...(op.text ? { richText: toRichText(op.text) } : {})
-          }
-        })
-        flushSave()
-        return { name: op.name }
-      }
-      case 'add-text': {
-        editor.createShape({
-          id: createShapeId(op.name),
-          type: 'text',
-          x: op.x,
-          y: op.y,
-          props: { richText: toRichText(op.text), ...styleProps(op) }
-        })
-        flushSave()
-        return { name: op.name }
-      }
-      case 'add-note': {
-        editor.createShape({
-          id: createShapeId(op.name),
-          type: 'note',
-          x: op.x,
-          y: op.y,
-          props: { richText: toRichText(op.text), ...styleProps(op) }
-        })
-        flushSave()
-        return { name: op.name }
-      }
-      case 'add-arrow': {
-        const id = createShapeId(op.name)
-        // Arrow at the canvas origin: point endpoints carry absolute coords;
-        // bound endpoints get placeholders that the binding then drives. `elbow`
-        // routes with right angles (diagram-style); default is a curved arc.
-        editor.createShape({
-          id,
-          type: 'arrow',
-          x: 0,
-          y: 0,
-          props: {
-            ...styleProps(op),
-            ...(op.elbow ? { kind: 'elbow' } : {}),
-            start: 'name' in op.from ? { x: 0, y: 0 } : { x: op.from.x, y: op.from.y },
-            end: 'name' in op.to ? { x: 100, y: 0 } : { x: op.to.x, y: op.to.y }
-          }
-        })
-        const bind = (end: { name: string }, terminal: 'start' | 'end') =>
-          editor.createBinding({
-            type: 'arrow',
-            fromId: id,
-            toId: createShapeId(end.name),
-            props: {
-              terminal,
-              normalizedAnchor: { x: 0.5, y: 0.5 },
-              isPrecise: false,
-              isExact: false,
-              snap: 'none'
-            }
-          })
-        if ('name' in op.from) bind(op.from, 'start')
-        if ('name' in op.to) bind(op.to, 'end')
-        flushSave()
-        return { name: op.name }
-      }
-      case 'move': {
-        const shape = editor.getShape(createShapeId(op.name))
-        if (!shape) throw new Error(`No shape named "${op.name}"`)
-        editor.updateShape({ id: shape.id, type: shape.type, x: op.x, y: op.y })
-        flushSave()
-        return { ok: true }
-      }
-      case 'set': {
-        const shape = editor.getShape(createShapeId(op.name))
-        if (!shape) throw new Error(`No shape named "${op.name}"`)
-        editor.updateShape({
-          id: shape.id,
-          type: shape.type,
-          props: { richText: toRichText(op.text) }
-        })
-        flushSave()
-        return { ok: true }
-      }
-      case 'delete': {
-        editor.deleteShape(createShapeId(op.name))
-        flushSave()
-        return { ok: true }
-      }
-      case 'clear': {
-        const ids = [...editor.getCurrentPageShapeIds()]
-        if (ids.length > 0) editor.deleteShapes(ids)
-        flushSave()
-        return { ok: true }
-      }
-      case 'view': {
-        const ids = [...editor.getCurrentPageShapeIds()]
-        if (ids.length === 0) throw new Error('Canvas is empty — nothing to view.')
-        const { url } = await editor.toImageDataUrl(ids, {
-          format: 'png',
-          background: true,
-          padding: 32
-        })
-        return { image: url }
-      }
+    if (op.kind !== 'view') {
+      throw new Error(`Scratchpad op "${op.kind}" runs on the server, not the browser.`)
     }
+    const ids = [...editor.getCurrentPageShapeIds()]
+    if (ids.length === 0) throw new Error('Canvas is empty — nothing to view.')
+    const { url } = await editor.toImageDataUrl(ids, {
+      format: 'png',
+      background: true,
+      padding: 32
+    })
+    return { image: url }
   }
 }
 
@@ -747,14 +631,6 @@ export function Scratchpad() {
     }).catch(() => {})
   }, [workspaceId])
 
-  const flushSave = useCallback(() => {
-    if (saveTimer.current) {
-      clearTimeout(saveTimer.current)
-      saveTimer.current = null
-    }
-    save()
-  }, [save])
-
   // Hydrate once per workspace. `document: null` → start with an empty canvas.
   useEffect(() => {
     let cancelled = false
@@ -819,7 +695,7 @@ export function Scratchpad() {
         },
         { source: 'user', scope: 'document' }
       )
-      setScratchExecutor(workspaceId, makeExecutor(editor, flushSave))
+      setScratchExecutor(workspaceId, makeExecutor(editor))
       // Focus management: tldraw only fires keyboard shortcuts while the editor's
       // instance `isFocused` is set, but with `autoFocus={false}` it never flips
       // that on its own. We drive it from where the pointer lands — a pointerdown
@@ -854,7 +730,7 @@ export function Scratchpad() {
         editorRef.current = null
       }
     },
-    [workspaceId, save, flushSave]
+    [workspaceId, save]
   )
 
   if (!loaded) return <div className="min-h-0 flex-1 bg-muted/40" />

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -63,7 +63,7 @@ moi scratch clear                           # wipe the whole canvas
   `small` or `large`, mirroring the toolbar's two sizes. Omit either to keep tldraw's default.
   The agent's options deliberately match what the user can pick by hand — neither surface can
   make something the other can't.
-- `clear` deletes every shape on the canvas in one shot (needs a live tab, like the draw ops).
+- `clear` deletes every shape on the canvas in one shot.
 - Coordinates are tldraw canvas space (origin top-left, y down).
 
 The set is deliberately small — text, rect, note, arrow (with color/stroke), plus
@@ -72,31 +72,39 @@ tldraw API.
 
 ## How it works
 
-The canvas is a real tldraw editor running in the **browser** — that's where all drawing and
-rendering happens, exactly like tldraw's own [Make Real](https://makereal.tldraw.com). The
-moi server is a **relay and a disk store**, not a tldraw runtime; it never tries to
-reconstruct tldraw shapes itself.
+The canvas the **user** sees is a real tldraw editor in the browser. The **agent**, though,
+doesn't need that tab open to draw: every `moi scratch` op except `view` runs against the disk
+snapshot, either by parsing it (`read`) or by replaying it through a **headless tldraw store**
+on the server (the mutations). Only `view` — rendering pixels — genuinely requires the browser.
 
-- **Persistence.** The browser autosaves the canvas to `.moi/scratchpad.json` (a tldraw
-  document snapshot, owned by moi — not hand-edited). Saves are **debounced — about 500ms
-  after you stop drawing**, not on every stroke — and each one writes the whole snapshot.
-  Reloading rehydrates from it; a "canvas updated" signal pushes other open tabs to reload,
-  so everyone converges.
-- **Reading** (`moi scratch read`) is served straight from that snapshot on disk — the server
-  parses the saved shapes into a compact listing. No browser required.
-- **Drawing and viewing** (`add`/`move`/`set`/`delete`/`view`) are **relayed to the live
-  editor** in a connected tab: the browser runs the op against tldraw (`createShape`,
-  `updateShape`, `toImage`, …) and sends back the result (a new shape id, or a PNG). This is
-  why draws produce valid shapes and `view` is pixel-faithful — tldraw itself does the work.
+- **Persistence.** `.moi/scratchpad.json` holds a tldraw document snapshot (owned by moi — not
+  hand-edited). The browser autosaves it ~500ms after you stop drawing; the server writes it
+  after each agent mutation. Either writer publishes a "canvas updated" signal, and every open
+  tab reloads from disk, so all viewers converge.
+- **Reading** (`moi scratch read`) parses that snapshot straight off disk into a compact shape
+  listing. No browser, no tldraw runtime.
+- **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server: it loads the snapshot
+  into a headless `tldraw` store (`createTLStore` + the default shape/binding utils), applies
+  the op as store records — using each shape's `getDefaultProps()` so records are schema-valid —
+  writes the snapshot back, and nudges open tabs to reload. **No live tab required.** The store
+  validates every record on `put`, so a malformed shape throws instead of corrupting the file.
+  (We drive the store, not an `Editor`, because the Editor needs a DOM + text measurement that
+  the server runtime doesn't have. See `server/scratchpad-executor.ts`.)
+- **Viewing** (`moi scratch view`) is the one op still relayed to a connected tab: only the
+  browser can rasterize the canvas (`editor.toImageDataUrl`). With no tab showing **this**
+  workspace's scratchpad it returns "No live canvas" — every other op still works off disk.
 - **Each command targets its own workspace's canvas.** The CLI runs in a workspace directory,
-  which resolves to that workspace; the relayed op carries that identity, and only a tab
-  showing **that workspace's** scratchpad runs it. So `moi scratch view` from one workspace
-  never returns another's canvas. "No live canvas" therefore means no tab is showing _this_
-  workspace's scratchpad — `read` (off disk) still works regardless.
-- **Concurrency is last-write-wins.** The browser is the only writer to disk, and the agent's
-  draws run _inside_ that same editor, so they persist through the same autosave. If the user
-  and agent touch the canvas at the same moment, the later save wins — edits are cheap and
-  visible, so a clobbered change is easy to redo. No merging, no locking.
+  which resolves to that workspace; reads, writes, and the relayed `view` all key off that
+  identity, so one workspace never touches another's canvas.
+- **Concurrency is last-write-wins.** Now there are two writers — the browser and the server —
+  each writing the whole snapshot. Server writes are serialized per workspace (load → mutate →
+  save under a lock) and reload open tabs; a simultaneous user stroke and agent draw can still
+  clobber one another, but edits are cheap and visible, so a lost change is easy to redo. No
+  merging, no locking across the browser/server boundary.
+
+> Earlier this worked differently: _all_ mutations were relayed to a live tab too, so the agent
+> couldn't draw to a closed canvas. The write path moved server-side so drawing no longer
+> depends on the user keeping the Scratchpad open.
 
 ## Building it
 

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -57,11 +57,12 @@ moi scratch clear                           # wipe the whole canvas
 - `arrow --from <id> --to <id>` binds endpoints to shapes, so the arrow **follows** when the
   shapes move — that's the connector you reach for in a diagram. Add `--elbow` for
   right-angle (squared) routing instead of the default curved arc.
-- `--color` takes a palette name (`black`, `grey`, `blue`, `light-blue`, `red`, `light-red`,
-  `green`, `light-green`, `yellow`, `orange`, `violet`, `light-violet`, `white`) **or any
-  hex** (e.g. `#4465e9`) — a hex is snapped to the nearest palette color, since tldraw shapes
-  only hold palette colors. `--stroke` is the size/weight: `s`, `m`, `l`, `xl`. Omit either to
-  keep tldraw's default.
+- `--color` takes one of the **six palette names the UI toolbar offers** — `black`, `red`,
+  `yellow`, `green`, `blue`, `grey` — **or any hex** (e.g. `#4465e9`), which is snapped to the
+  nearest of those six (tldraw shapes only hold palette colors). `--stroke` is the weight,
+  `small` or `large`, mirroring the toolbar's two sizes. Omit either to keep tldraw's default.
+  The agent's options deliberately match what the user can pick by hand — neither surface can
+  make something the other can't.
 - `clear` deletes every shape on the canvas in one shot (needs a live tab, like the draw ops).
 - Coordinates are tldraw canvas space (origin top-left, y down).
 

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -42,23 +42,32 @@ that maps onto tldraw's own shape API — friendly to drive and stable against t
 internal schema:
 
 ```
-moi scratch add text   --at <x,y> --text "..."          [--id NAME]
-moi scratch add rect   --at <x,y> --size <w,h> [--text]  [--id NAME]
-moi scratch add note   --at <x,y> --text "..."           [--id NAME]
-moi scratch add arrow  --from <id|x,y> --to <id|x,y>     [--id NAME]
+moi scratch add text   --at <x,y> --text "..."          [--id NAME] [--color C] [--stroke S]
+moi scratch add rect   --at <x,y> --size <w,h> [--text]  [--id NAME] [--color C] [--stroke S]
+moi scratch add note   --at <x,y> --text "..."           [--id NAME] [--color C] [--stroke S]
+moi scratch add arrow  --from <id|x,y> --to <id|x,y>     [--id NAME] [--color C] [--stroke S] [--elbow]
 moi scratch move   <id> --to <x,y>
 moi scratch set    <id> --text "..."        # relabel / edit
 moi scratch delete <id>
+moi scratch clear                           # wipe the whole canvas
 ```
 
 - `--id` gives a shape a stable handle so later commands can address it; otherwise the
   command returns the generated id.
-- `arrow --from <id> --to <id>` binds endpoints to shapes, so the arrow follows when the
-  shapes move — same as drawing a connector between two boxes by hand.
+- `arrow --from <id> --to <id>` binds endpoints to shapes, so the arrow **follows** when the
+  shapes move — that's the connector you reach for in a diagram. Add `--elbow` for
+  right-angle (squared) routing instead of the default curved arc.
+- `--color` takes a palette name (`black`, `grey`, `blue`, `light-blue`, `red`, `light-red`,
+  `green`, `light-green`, `yellow`, `orange`, `violet`, `light-violet`, `white`) **or any
+  hex** (e.g. `#4465e9`) — a hex is snapped to the nearest palette color, since tldraw shapes
+  only hold palette colors. `--stroke` is the size/weight: `s`, `m`, `l`, `xl`. Omit either to
+  keep tldraw's default.
+- `clear` deletes every shape on the canvas in one shot (needs a live tab, like the draw ops).
 - Coordinates are tldraw canvas space (origin top-left, y down).
 
-The set is deliberately small — text, rect, note, arrow, plus move/set/delete. Enough to lay
-out a diagram or annotate the user's drawing; not a full tldraw API.
+The set is deliberately small — text, rect, note, arrow (with color/stroke), plus
+move/set/delete/clear. Enough to lay out a diagram or annotate the user's drawing; not a full
+tldraw API.
 
 ## How it works
 

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -29,11 +29,14 @@ The agent works the canvas through a `moi scratch` CLI — it both **sees** and 
   `type`, position, size, and text. Use this to reason about exact shapes — what's where,
   what to move, what to relabel. Works whether or not a browser tab is open. Image shapes
   carry a `src`, but **base64 data URLs are omitted** (reported as `base64:omitted`) — the
-  blob is huge and unreadable as text, so call `view` when you actually need to see it.
-- `moi scratch view` — render the canvas to a **PNG**. Use this to actually _see_ what the
-  user drew (freehand, layout, anything structure can't capture).
+  blob is huge and unreadable as text, so use `read-image` or `view` for the pixels.
+- `moi scratch read-image <id>` — save a single image shape's bytes to a file (prints the
+  path). Served off disk, like `read` — this is how the agent pulls the pixels of one image
+  that `read` omitted. A remote (`http`) asset prints its URL instead.
+- `moi scratch view` — render the **whole canvas** to a **PNG**. Use this to actually _see_
+  what the user drew (freehand, layout, anything structure can't capture).
 
-`read` is for logic; `view` is for vision.
+`read` is for logic; `view` / `read-image` are for vision.
 
 ### Drawing
 
@@ -46,6 +49,7 @@ moi scratch add text   --at <x,y> --text "..."          [--id NAME] [--color C] 
 moi scratch add rect   --at <x,y> --size <w,h> [--text]  [--id NAME] [--color C] [--stroke S]
 moi scratch add note   --at <x,y> --text "..."           [--id NAME] [--color C] [--stroke S]
 moi scratch add arrow  --from <id|x,y> --to <id|x,y>     [--id NAME] [--color C] [--stroke S] [--elbow]
+moi scratch add image  <path>                            [--at <x,y>] [--id NAME] [--quality lo|hi]
 moi scratch move   <id> --to <x,y>
 moi scratch set    <id> --text "..."        # relabel / edit
 moi scratch delete <id>
@@ -63,6 +67,9 @@ moi scratch clear                           # wipe the whole canvas
   `small` or `large`, mirroring the toolbar's two sizes. Omit either to keep tldraw's default.
   The agent's options deliberately match what the user can pick by hand — neither surface can
   make something the other can't.
+- `add image <path>` embeds a local image file. The server **resizes it to fit the canvas** —
+  `--quality lo` (default, long side ≤1024px) or `hi` (≤2048px) — re-encoding to WebP so a 10MB
+  paste never lands on the canvas whole. EXIF orientation is baked in; images are never enlarged.
 - `clear` deletes every shape on the canvas in one shot.
 - Coordinates are tldraw canvas space (origin top-left, y down).
 
@@ -81,15 +88,16 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
   hand-edited). The browser autosaves it ~500ms after you stop drawing; the server writes it
   after each agent mutation. Either writer publishes a "canvas updated" signal, and every open
   tab reloads from disk, so all viewers converge.
-- **Reading** (`moi scratch read`) parses that snapshot straight off disk into a compact shape
-  listing. No browser, no tldraw runtime.
+- **Reading** (`moi scratch read`, `read-image`) parses that snapshot straight off disk — the
+  shape listing, or one image's bytes. No browser, no tldraw runtime.
 - **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server: it loads the snapshot
   into a headless `tldraw` store (`createTLStore` + the default shape/binding utils), applies
   the op as store records — using each shape's `getDefaultProps()` so records are schema-valid —
   writes the snapshot back, and nudges open tabs to reload. **No live tab required.** The store
   validates every record on `put`, so a malformed shape throws instead of corrupting the file.
-  (We drive the store, not an `Editor`, because the Editor needs a DOM + text measurement that
-  the server runtime doesn't have. See `server/scratchpad-executor.ts`.)
+  `add image` additionally resizes the file through `sharp` (the same dep the icon pipeline uses)
+  before embedding it. (We drive the store, not an `Editor`, because the Editor needs a DOM + text
+  measurement the server runtime doesn't have. See `server/scratchpad-executor.ts`.)
 - **Viewing** (`moi scratch view`) is the one op still relayed to a connected tab: only the
   browser can rasterize the canvas (`editor.toImageDataUrl`). With no tab showing **this**
   workspace's scratchpad it returns "No live canvas" — every other op still works off disk.

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -27,7 +27,9 @@ The agent works the canvas through a `moi scratch` CLI — it both **sees** and 
 
 - `moi scratch read` — dump the canvas as **structured JSON**: each shape with its `id`,
   `type`, position, size, and text. Use this to reason about exact shapes — what's where,
-  what to move, what to relabel. Works whether or not a browser tab is open.
+  what to move, what to relabel. Works whether or not a browser tab is open. Image shapes
+  carry a `src`, but **base64 data URLs are omitted** (reported as `base64:omitted`) — the
+  blob is huge and unreadable as text, so call `view` when you actually need to see it.
 - `moi scratch view` — render the canvas to a **PNG**. Use this to actually _see_ what the
   user drew (freehand, layout, anything structure can't capture).
 

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -68,8 +68,10 @@ moi scratch clear                           # wipe the whole canvas
   The agent's options deliberately match what the user can pick by hand — neither surface can
   make something the other can't.
 - `add image <path>` embeds a local image file. The server **resizes it to fit the canvas** —
-  `--quality lo` (default, long side ≤1024px) or `hi` (≤2048px) — re-encoding to WebP so a 10MB
-  paste never lands on the canvas whole. EXIF orientation is baked in; images are never enlarged.
+  `--quality lo` (default, long side ≤768px) or `hi` (≤2048px) — re-encoding to WebP so a 10MB
+  paste never lands on the canvas whole. `lo` keeps the constantly-rewritten snapshot light and
+  is well within Claude's vision budget; reach for `hi` only when fine detail (e.g. screenshot
+  text) matters. EXIF orientation is baked in; images are never enlarged.
 - `clear` deletes every shape on the canvas in one shot.
 - Coordinates are tldraw canvas space (origin top-left, y down).
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,26 +37,15 @@ export type ViewInfo = {
 export type ScratchPoint = { x: number; y: number }
 export type ScratchArrowEnd = { name: string } | ScratchPoint
 
-// tldraw's named color palette (DefaultColorStyle). The CLI also accepts an
-// arbitrary hex and snaps it to the nearest of these — tldraw shapes can only
-// hold a palette color, not free hex.
-export type ScratchColor =
-  | 'black'
-  | 'grey'
-  | 'light-violet'
-  | 'violet'
-  | 'blue'
-  | 'light-blue'
-  | 'yellow'
-  | 'orange'
-  | 'green'
-  | 'light-green'
-  | 'light-red'
-  | 'red'
-  | 'white'
+// The Scratchpad's color palette — the same six swatches the UI toolbar offers,
+// so the agent can only paint what the user can. The CLI also accepts an arbitrary
+// hex and snaps it to the nearest of these (tldraw shapes hold a palette color, not
+// free hex).
+export type ScratchColor = 'black' | 'grey' | 'blue' | 'green' | 'yellow' | 'red'
 
-// Stroke/size weight (DefaultSizeStyle): small → extra-large.
-export type ScratchSize = 's' | 'm' | 'l' | 'xl'
+// Stroke weight — the UI's two opinionated sizes (small, large), mapped onto
+// tldraw's DefaultSizeStyle. The CLI takes `small`/`large`; ops carry the tldraw value.
+export type ScratchSize = 'm' | 'xl'
 
 // Optional styling carried by every add op. Omitted fields fall back to the
 // shape's tldraw default.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,10 +29,10 @@ export type ViewInfo = {
   config: ViewConfig
 }
 
-// A Scratchpad draw/view operation, relayed from `moi scratch` to a live tldraw
-// editor in a connected tab. The server assigns each add op a `name` (the
-// `--id`, or a generated one) so the derived tldraw shape id is deterministic —
-// every tab that executes the op converges to the same shape. Arrow endpoints
+// A Scratchpad draw/view operation issued by `moi scratch`. Mutations run
+// server-side against a headless tldraw store; `view` relays to a live tab. The
+// server assigns each add op a `name` (the `--id`, or a generated one) so the
+// derived tldraw shape id is deterministic and addressable later. Arrow endpoints
 // bind to a shape (by name) or sit at a free point. See docs/moi-scratchpad.md.
 export type ScratchPoint = { x: number; y: number }
 export type ScratchArrowEnd = { name: string } | ScratchPoint
@@ -160,9 +160,10 @@ export type ServerMessage =
   | StatusSnapshotMessage
   | ScratchpadOpMessage
 
-// A Scratchpad op relayed to the tab(s) showing `workspaceId`'s canvas. Only a
-// tab with a live editor for that workspace executes it and replies with a
-// matching `scratchpad:op-result` (correlated by `opId`); others ignore it.
+// A Scratchpad op relayed to the tab(s) showing `workspaceId`'s canvas. Only
+// `view` travels this way now (rendering needs the browser); mutations run
+// server-side. The tab with a live editor for that workspace executes it and
+// replies with a matching `scratchpad:op-result` (correlated by `opId`).
 export type ScratchpadOpMessage = {
   type: 'scratchpad:op'
   workspaceId: string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,6 +51,10 @@ export type ScratchSize = 'm' | 'xl'
 // shape's tldraw default.
 export type ScratchStyle = { color?: ScratchColor; size?: ScratchSize }
 
+// Resize preset for `add image`: 'lo' caps the long side smaller (default, keeps
+// the canvas light), 'hi' allows more pixels when detail matters.
+export type ScratchImageQuality = 'lo' | 'hi'
+
 export type ScratchOp =
   | ({ kind: 'add-text'; name: string; x: number; y: number; text: string } & ScratchStyle)
   | ({
@@ -63,6 +67,17 @@ export type ScratchOp =
       text?: string
     } & ScratchStyle)
   | ({ kind: 'add-note'; name: string; x: number; y: number; text: string } & ScratchStyle)
+  // Add an image from a local file `path` — the server resizes it to fit the
+  // canvas and embeds it (color/stroke don't apply, so no ScratchStyle).
+  // `quality` picks the resize preset: 'lo' (default, smaller) or 'hi' (sharper).
+  | {
+      kind: 'add-image'
+      name: string
+      x: number
+      y: number
+      path: string
+      quality?: ScratchImageQuality
+    }
   | ({
       kind: 'add-arrow'
       name: string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,14 +37,55 @@ export type ViewInfo = {
 export type ScratchPoint = { x: number; y: number }
 export type ScratchArrowEnd = { name: string } | ScratchPoint
 
+// tldraw's named color palette (DefaultColorStyle). The CLI also accepts an
+// arbitrary hex and snaps it to the nearest of these — tldraw shapes can only
+// hold a palette color, not free hex.
+export type ScratchColor =
+  | 'black'
+  | 'grey'
+  | 'light-violet'
+  | 'violet'
+  | 'blue'
+  | 'light-blue'
+  | 'yellow'
+  | 'orange'
+  | 'green'
+  | 'light-green'
+  | 'light-red'
+  | 'red'
+  | 'white'
+
+// Stroke/size weight (DefaultSizeStyle): small → extra-large.
+export type ScratchSize = 's' | 'm' | 'l' | 'xl'
+
+// Optional styling carried by every add op. Omitted fields fall back to the
+// shape's tldraw default.
+export type ScratchStyle = { color?: ScratchColor; size?: ScratchSize }
+
 export type ScratchOp =
-  | { kind: 'add-text'; name: string; x: number; y: number; text: string }
-  | { kind: 'add-rect'; name: string; x: number; y: number; w: number; h: number; text?: string }
-  | { kind: 'add-note'; name: string; x: number; y: number; text: string }
-  | { kind: 'add-arrow'; name: string; from: ScratchArrowEnd; to: ScratchArrowEnd }
+  | ({ kind: 'add-text'; name: string; x: number; y: number; text: string } & ScratchStyle)
+  | ({
+      kind: 'add-rect'
+      name: string
+      x: number
+      y: number
+      w: number
+      h: number
+      text?: string
+    } & ScratchStyle)
+  | ({ kind: 'add-note'; name: string; x: number; y: number; text: string } & ScratchStyle)
+  | ({
+      kind: 'add-arrow'
+      name: string
+      from: ScratchArrowEnd
+      to: ScratchArrowEnd
+      // Right-angle (orthogonal) routing for clean diagrams; default is a curved arc.
+      elbow?: boolean
+    } & ScratchStyle)
   | { kind: 'move'; name: string; x: number; y: number }
   | { kind: 'set'; name: string; text: string }
   | { kind: 'delete'; name: string }
+  | { kind: 'clear' }
   | { kind: 'view' }
 
 // What a tab returns after running an op: a shape's `name` for add ops, a PNG

--- a/server/api.ts
+++ b/server/api.ts
@@ -321,8 +321,8 @@ one.put('/config', async c => {
 // ({ document } or { document: null } when empty) for hydration; PUT saves a new
 // snapshot ({ document, origin }) and broadcasts so other open tabs reload.
 // `origin` is the writing tab's id — echoed in the broadcast so that tab can
-// ignore its own save. The browser is the only writer here. See
-// docs/moi-scratchpad.md.
+// ignore its own save. This is the browser's write path; the agent's draws are
+// written server-side (see scratchpad-executor.ts). See docs/moi-scratchpad.md.
 one.get('/scratchpad', async c => {
   return c.json(await loadScratchpadDoc(c.get('ws').path))
 })

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -8,7 +8,7 @@ import pc from 'picocolors'
 
 import { COLOR_THEMES, FONT_THEMES } from '@/lib/themes'
 import type { ColorTheme, FontTheme } from '@/lib/themes'
-import type { ScratchArrowEnd, ScratchOp } from '@/lib/types'
+import type { ScratchArrowEnd, ScratchColor, ScratchOp, ScratchSize } from '@/lib/types'
 
 import { columns } from './cli-ui'
 import { CONTROL_PORT, PORT } from './constants'
@@ -881,6 +881,85 @@ function parseEnd(s: string): ScratchArrowEnd {
   return { name: s }
 }
 
+// tldraw's named palette and each color's light-theme solid hex — used to snap an
+// arbitrary `--color #rrggbb` to the nearest palette entry (tldraw shapes can't
+// hold free hex). Keep in sync with @tldraw/editor's default theme.
+const COLOR_HEX: Record<ScratchColor, string> = {
+  black: '#1d1d1d',
+  grey: '#9fa8b2',
+  'light-violet': '#e085f4',
+  violet: '#ae3ec9',
+  blue: '#4465e9',
+  'light-blue': '#4ba1f1',
+  yellow: '#f1ac4b',
+  orange: '#e16919',
+  green: '#099268',
+  'light-green': '#4cb05e',
+  'light-red': '#f87777',
+  red: '#e03131',
+  white: '#ffffff'
+}
+const COLOR_NAMES = Object.keys(COLOR_HEX) as ScratchColor[]
+const SCRATCH_SIZES: ScratchSize[] = ['s', 'm', 'l', 'xl']
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  let h = hex.trim().replace(/^#/, '')
+  if (h.length === 3) h = h.replace(/(.)/g, '$1$1')
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+}
+
+// Accept a palette name as-is, or snap any hex to the nearest palette color by
+// squared RGB distance. Throws on anything else.
+function parseColor(s: string): ScratchColor {
+  const lower = s.trim().toLowerCase()
+  if ((COLOR_NAMES as string[]).includes(lower)) return lower as ScratchColor
+  const rgb = hexToRgb(s)
+  if (!rgb) {
+    throw new Error(
+      `Unknown color "${s}". Use a hex like "#4465e9" or one of: ${COLOR_NAMES.join(', ')}.`
+    )
+  }
+  let best: ScratchColor = 'black'
+  let bestDist = Infinity
+  for (const name of COLOR_NAMES) {
+    const [r, g, b] = hexToRgb(COLOR_HEX[name])!
+    const d = (r - rgb[0]) ** 2 + (g - rgb[1]) ** 2 + (b - rgb[2]) ** 2
+    if (d < bestDist) {
+      bestDist = d
+      best = name
+    }
+  }
+  return best
+}
+
+function parseSize(s: string): ScratchSize {
+  const lower = s.trim().toLowerCase()
+  if ((SCRATCH_SIZES as string[]).includes(lower)) return lower as ScratchSize
+  throw new Error(`Unknown size "${s}". Use one of: ${SCRATCH_SIZES.join(', ')}.`)
+}
+
+// Shared optional styling on every `add` command. Resolved into op props below.
+const colorArg = {
+  type: 'string',
+  description: 'Color: a palette name (e.g. blue) or any hex (e.g. #4465e9, snapped to nearest)'
+} as const
+const strokeArg = {
+  type: 'string',
+  description: `Stroke / size weight: ${SCRATCH_SIZES.join(', ')}`
+} as const
+
+// Build the optional { color?, size? } props from raw --color/--size args.
+function styleArgs(args: { color?: string; size?: string }): {
+  color?: ScratchColor
+  size?: ScratchSize
+} {
+  return {
+    ...(args.color ? { color: parseColor(args.color) } : {}),
+    ...(args.size ? { size: parseSize(args.size) } : {})
+  }
+}
+
 type ScratchCliOp = ScratchOp | { kind: 'read' }
 
 // Round-trip one op through the control port and hand the reply to `onResult`.
@@ -958,13 +1037,22 @@ const scratchAddText = defineCommand({
     at: { type: 'string', required: true, description: 'Position "x,y"' },
     text: { type: 'string', required: true, description: 'Text content' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    color: colorArg,
+    stroke: strokeArg,
     dir: dirArg
   },
   run({ args }) {
     const { x, y } = parseXY(args.at)
     sendScratch(
       resolve(args.dir),
-      { kind: 'add-text', name: args.id ?? '', x, y, text: args.text },
+      {
+        kind: 'add-text',
+        name: args.id ?? '',
+        x,
+        y,
+        text: args.text,
+        ...styleArgs({ color: args.color, size: args.stroke })
+      },
       printAdded
     )
   }
@@ -977,6 +1065,8 @@ const scratchAddRect = defineCommand({
     size: { type: 'string', required: true, description: 'Size "w,h"' },
     text: { type: 'string', description: 'Optional label' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    color: colorArg,
+    stroke: strokeArg,
     dir: dirArg
   },
   run({ args }) {
@@ -991,7 +1081,8 @@ const scratchAddRect = defineCommand({
         y,
         w,
         h,
-        ...(args.text ? { text: args.text } : {})
+        ...(args.text ? { text: args.text } : {}),
+        ...styleArgs({ color: args.color, size: args.stroke })
       },
       printAdded
     )
@@ -1004,30 +1095,52 @@ const scratchAddNote = defineCommand({
     at: { type: 'string', required: true, description: 'Position "x,y"' },
     text: { type: 'string', required: true, description: 'Note content' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    color: colorArg,
+    stroke: strokeArg,
     dir: dirArg
   },
   run({ args }) {
     const { x, y } = parseXY(args.at)
     sendScratch(
       resolve(args.dir),
-      { kind: 'add-note', name: args.id ?? '', x, y, text: args.text },
+      {
+        kind: 'add-note',
+        name: args.id ?? '',
+        x,
+        y,
+        text: args.text,
+        ...styleArgs({ color: args.color, size: args.stroke })
+      },
       printAdded
     )
   }
 })
 
 const scratchAddArrow = defineCommand({
-  meta: { name: 'arrow', description: 'Add an arrow between shapes or points' },
+  meta: { name: 'arrow', description: 'Add an arrow connecting shapes or points' },
   args: {
     from: { type: 'string', required: true, description: 'Start: a shape name or "x,y"' },
     to: { type: 'string', required: true, description: 'End: a shape name or "x,y"' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    elbow: {
+      type: 'boolean',
+      description: 'Right-angle (squared) routing for diagrams; default is a curved arc'
+    },
+    color: colorArg,
+    stroke: strokeArg,
     dir: dirArg
   },
   run({ args }) {
     sendScratch(
       resolve(args.dir),
-      { kind: 'add-arrow', name: args.id ?? '', from: parseEnd(args.from), to: parseEnd(args.to) },
+      {
+        kind: 'add-arrow',
+        name: args.id ?? '',
+        from: parseEnd(args.from),
+        to: parseEnd(args.to),
+        ...(args.elbow ? { elbow: true } : {}),
+        ...styleArgs({ color: args.color, size: args.stroke })
+      },
       printAdded
     )
   }
@@ -1085,6 +1198,16 @@ const scratchDelete = defineCommand({
   }
 })
 
+const scratchClear = defineCommand({
+  meta: { name: 'clear', description: 'Delete every shape — wipe the whole canvas' },
+  args: { dir: dirArg },
+  run({ args }) {
+    sendScratch(resolve(args.dir), { kind: 'clear' }, () =>
+      console.log('\n' + pc.green('✓') + ' cleared the canvas\n')
+    )
+  }
+})
+
 const scratch = defineCommand({
   meta: {
     name: 'scratch',
@@ -1096,7 +1219,8 @@ const scratch = defineCommand({
     add: scratchAdd,
     move: scratchMove,
     set: scratchSet,
-    delete: scratchDelete
+    delete: scratchDelete,
+    clear: scratchClear
   }
 })
 

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -881,26 +881,23 @@ function parseEnd(s: string): ScratchArrowEnd {
   return { name: s }
 }
 
-// tldraw's named palette and each color's light-theme solid hex — used to snap an
-// arbitrary `--color #rrggbb` to the nearest palette entry (tldraw shapes can't
-// hold free hex). Keep in sync with @tldraw/editor's default theme.
+// The Scratchpad palette (matches the UI toolbar's six swatches) and each color's
+// light-theme solid hex — used to snap an arbitrary `--color #rrggbb` to the nearest
+// palette entry (tldraw shapes can't hold free hex). Keep in sync with the swatches
+// in client/components/Scratchpad.tsx.
 const COLOR_HEX: Record<ScratchColor, string> = {
   black: '#1d1d1d',
-  grey: '#9fa8b2',
-  'light-violet': '#e085f4',
-  violet: '#ae3ec9',
-  blue: '#4465e9',
-  'light-blue': '#4ba1f1',
-  yellow: '#f1ac4b',
-  orange: '#e16919',
-  green: '#099268',
-  'light-green': '#4cb05e',
-  'light-red': '#f87777',
   red: '#e03131',
-  white: '#ffffff'
+  yellow: '#f1ac4b',
+  green: '#099268',
+  blue: '#4465e9',
+  grey: '#9fa8b2'
 }
 const COLOR_NAMES = Object.keys(COLOR_HEX) as ScratchColor[]
-const SCRATCH_SIZES: ScratchSize[] = ['s', 'm', 'l', 'xl']
+
+// The UI offers two opinionated sizes; the CLI mirrors them by name.
+const STROKE_SIZES: Record<string, ScratchSize> = { small: 'm', large: 'xl' }
+const STROKE_NAMES = Object.keys(STROKE_SIZES)
 
 function hexToRgb(hex: string): [number, number, number] | null {
   let h = hex.trim().replace(/^#/, '')
@@ -933,30 +930,30 @@ function parseColor(s: string): ScratchColor {
   return best
 }
 
-function parseSize(s: string): ScratchSize {
-  const lower = s.trim().toLowerCase()
-  if ((SCRATCH_SIZES as string[]).includes(lower)) return lower as ScratchSize
-  throw new Error(`Unknown size "${s}". Use one of: ${SCRATCH_SIZES.join(', ')}.`)
+function parseStroke(s: string): ScratchSize {
+  const size = STROKE_SIZES[s.trim().toLowerCase()]
+  if (!size) throw new Error(`Unknown stroke "${s}". Use one of: ${STROKE_NAMES.join(', ')}.`)
+  return size
 }
 
 // Shared optional styling on every `add` command. Resolved into op props below.
 const colorArg = {
   type: 'string',
-  description: 'Color: a palette name (e.g. blue) or any hex (e.g. #4465e9, snapped to nearest)'
+  description: `Color: ${COLOR_NAMES.join(', ')}, or any hex (snapped to nearest)`
 } as const
 const strokeArg = {
   type: 'string',
-  description: `Stroke / size weight: ${SCRATCH_SIZES.join(', ')}`
+  description: `Stroke weight: ${STROKE_NAMES.join(', ')}`
 } as const
 
-// Build the optional { color?, size? } props from raw --color/--size args.
-function styleArgs(args: { color?: string; size?: string }): {
+// Build the optional { color?, size? } props from raw --color/--stroke args.
+function styleArgs(args: { color?: string; stroke?: string }): {
   color?: ScratchColor
   size?: ScratchSize
 } {
   return {
     ...(args.color ? { color: parseColor(args.color) } : {}),
-    ...(args.size ? { size: parseSize(args.size) } : {})
+    ...(args.stroke ? { size: parseStroke(args.stroke) } : {})
   }
 }
 
@@ -1051,7 +1048,7 @@ const scratchAddText = defineCommand({
         x,
         y,
         text: args.text,
-        ...styleArgs({ color: args.color, size: args.stroke })
+        ...styleArgs({ color: args.color, stroke: args.stroke })
       },
       printAdded
     )
@@ -1082,7 +1079,7 @@ const scratchAddRect = defineCommand({
         w,
         h,
         ...(args.text ? { text: args.text } : {}),
-        ...styleArgs({ color: args.color, size: args.stroke })
+        ...styleArgs({ color: args.color, stroke: args.stroke })
       },
       printAdded
     )
@@ -1109,7 +1106,7 @@ const scratchAddNote = defineCommand({
         x,
         y,
         text: args.text,
-        ...styleArgs({ color: args.color, size: args.stroke })
+        ...styleArgs({ color: args.color, stroke: args.stroke })
       },
       printAdded
     )
@@ -1139,7 +1136,7 @@ const scratchAddArrow = defineCommand({
         from: parseEnd(args.from),
         to: parseEnd(args.to),
         ...(args.elbow ? { elbow: true } : {}),
-        ...styleArgs({ color: args.color, size: args.stroke })
+        ...styleArgs({ color: args.color, stroke: args.stroke })
       },
       printAdded
     )

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -8,7 +8,13 @@ import pc from 'picocolors'
 
 import { COLOR_THEMES, FONT_THEMES } from '@/lib/themes'
 import type { ColorTheme, FontTheme } from '@/lib/themes'
-import type { ScratchArrowEnd, ScratchColor, ScratchOp, ScratchSize } from '@/lib/types'
+import type {
+  ScratchArrowEnd,
+  ScratchColor,
+  ScratchImageQuality,
+  ScratchOp,
+  ScratchSize
+} from '@/lib/types'
 
 import { columns } from './cli-ui'
 import { CONTROL_PORT, PORT } from './constants'
@@ -936,6 +942,14 @@ function parseStroke(s: string): ScratchSize {
   return size
 }
 
+// Resize preset for `add image` — defaults to 'lo' (keep the canvas light).
+function parseImageQuality(s: string | undefined): ScratchImageQuality {
+  if (!s) return 'lo'
+  const q = s.trim().toLowerCase()
+  if (q === 'lo' || q === 'hi') return q
+  throw new Error(`Unknown quality "${s}". Use "lo" or "hi".`)
+}
+
 // Shared optional styling on every `add` command. Resolved into op props below.
 const colorArg = {
   type: 'string',
@@ -957,7 +971,7 @@ function styleArgs(args: { color?: string; stroke?: string }): {
   }
 }
 
-type ScratchCliOp = ScratchOp | { kind: 'read' }
+type ScratchCliOp = ScratchOp | { kind: 'read' } | { kind: 'read-image'; name: string }
 
 // Round-trip one op through the control port and hand the reply to `onResult`.
 // Mirrors the `bundle`/`theme` commands: one socket per invocation, print, exit.
@@ -1023,6 +1037,58 @@ const scratchView = defineCommand({
       const b64 = result.image.replace(/^data:image\/png;base64,/, '')
       const outPath = args.out ? resolve(args.out) : join(tmpdir(), `moi-scratch-${Date.now()}.png`)
       await Bun.write(outPath, Buffer.from(b64, 'base64'))
+      console.log(outPath)
+    })
+  }
+})
+
+// Image data URL mime → file extension, for naming the saved file.
+const IMAGE_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/svg+xml': 'svg'
+}
+
+const scratchReadImage = defineCommand({
+  meta: {
+    name: 'read-image',
+    description: 'Save an image shape to a file by id (served off disk)'
+  },
+  args: {
+    id: { type: 'positional', required: true, description: 'Image shape id (from `scratch read`)' },
+    out: { type: 'string', description: 'Output file path (default: a temp file)' },
+    dir: dirArg
+  },
+  async run({ args }) {
+    sendScratch(resolve(args.dir), { kind: 'read-image', name: args.id }, async res => {
+      const src = res.src as string | undefined
+      if (!src) {
+        console.error(pc.red('No image data'))
+        process.exit(1)
+      }
+      // A remote (http) asset has no local bytes to write — just print the URL.
+      if (/^https?:\/\//.test(src)) {
+        console.log(src)
+        return
+      }
+      const m = src.match(/^data:([^;,]+)(;base64)?,(.*)$/s)
+      if (!m) {
+        console.error(pc.red('Unrecognized image source'))
+        process.exit(1)
+      }
+      const [, mime, base64, data] = m
+      const bytes = base64
+        ? Buffer.from(data, 'base64')
+        : Buffer.from(decodeURIComponent(data), 'utf8')
+      const ext = IMAGE_EXT[mime] ?? 'bin'
+      const safeId = args.id.replace(/[^a-zA-Z0-9_-]/g, '_')
+      const outPath = args.out
+        ? resolve(args.out)
+        : join(tmpdir(), `moi-scratch-${safeId}-${Date.now()}.${ext}`)
+      await Bun.write(outPath, bytes)
       console.log(outPath)
     })
   }
@@ -1143,13 +1209,44 @@ const scratchAddArrow = defineCommand({
   }
 })
 
+const scratchAddImage = defineCommand({
+  meta: { name: 'image', description: 'Add an image from a file (resized to fit the canvas)' },
+  args: {
+    path: {
+      type: 'positional',
+      required: true,
+      description: 'Path to an image file (png/jpg/webp/gif)'
+    },
+    at: { type: 'string', description: 'Top-left position "x,y" (default: 0,0)' },
+    id: { type: 'string', description: 'Stable name to address this shape later' },
+    quality: { type: 'string', description: 'Resize: lo (default, smaller) or hi (sharper)' },
+    dir: dirArg
+  },
+  run({ args }) {
+    const { x, y } = args.at ? parseXY(args.at) : { x: 0, y: 0 }
+    sendScratch(
+      resolve(args.dir),
+      {
+        kind: 'add-image',
+        name: args.id ?? '',
+        x,
+        y,
+        path: resolve(args.path),
+        quality: parseImageQuality(args.quality)
+      },
+      printAdded
+    )
+  }
+})
+
 const scratchAdd = defineCommand({
-  meta: { name: 'add', description: 'Add a shape: text, rect, note, or arrow' },
+  meta: { name: 'add', description: 'Add a shape: text, rect, note, arrow, or image' },
   subCommands: {
     text: scratchAddText,
     rect: scratchAddRect,
     note: scratchAddNote,
-    arrow: scratchAddArrow
+    arrow: scratchAddArrow,
+    image: scratchAddImage
   }
 })
 
@@ -1212,6 +1309,7 @@ const scratch = defineCommand({
   },
   subCommands: {
     read: scratchRead,
+    'read-image': scratchReadImage,
     view: scratchView,
     add: scratchAdd,
     move: scratchMove,

--- a/server/control.ts
+++ b/server/control.ts
@@ -8,7 +8,7 @@ import { loadLayout, saveLayout } from './layout'
 import { publishEvent } from './events'
 import { findWorkspaceForPath, listWorkspaces, registerWorkspace } from './registry'
 import { executeScratchOp } from './scratchpad-executor'
-import { readScratchpadShapes } from './scratchpad'
+import { readScratchpadImage, readScratchpadShapes } from './scratchpad'
 import { relayScratchOp } from './scratchpad-relay'
 import { broadcastAll } from './state'
 import { applyThemeUpdate, matchColorTheme } from './theme'
@@ -206,6 +206,13 @@ export const control = Bun.serve({
           // `read` is served straight off the disk snapshot — no live tab needed.
           if (op.kind === 'read') {
             ws.send(JSON.stringify({ shapes: await readScratchpadShapes(match.path) }))
+            return
+          }
+
+          // `read-image` resolves one image shape's data off disk too — `read`
+          // omits the blob, so this is how the agent pulls a specific image.
+          if (op.kind === 'read-image') {
+            ws.send(JSON.stringify(await readScratchpadImage(match.path, String(op.name))))
             return
           }
 

--- a/server/control.ts
+++ b/server/control.ts
@@ -7,6 +7,7 @@ import { processIcon } from './icon'
 import { loadLayout, saveLayout } from './layout'
 import { publishEvent } from './events'
 import { findWorkspaceForPath, listWorkspaces, registerWorkspace } from './registry'
+import { executeScratchOp } from './scratchpad-executor'
 import { readScratchpadShapes } from './scratchpad'
 import { relayScratchOp } from './scratchpad-relay'
 import { broadcastAll } from './state'
@@ -208,16 +209,20 @@ export const control = Bun.serve({
             return
           }
 
-          // Everything else relays to a live editor, keyed by the workspace id so
-          // the broadcast targets the tab(s) showing *this* workspace's canvas.
           // Assign add ops a stable name when the caller didn't (`--id`), so the
-          // derived tldraw shape id is deterministic across tabs.
+          // derived tldraw shape id is deterministic and addressable later.
           if (op.kind.startsWith('add-') && !op.name) {
             op.name = `s_${crypto.randomUUID().slice(0, 8)}`
           }
 
           try {
-            const result = await relayScratchOp(match.id, op)
+            // `view` renders pixels — only the browser can do that, so it relays to
+            // a live tab (and fails if none is open). Every mutation runs headlessly
+            // against the disk snapshot, so drawing never needs an open canvas.
+            const result =
+              op.kind === 'view'
+                ? await relayScratchOp(match.id, op)
+                : await executeScratchOp(match.path, match.id, op)
             ws.send(JSON.stringify({ ok: true, result }))
           } catch (err) {
             ws.send(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }))

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -144,7 +144,7 @@ function arrowBinding(
 // preset: 'lo' caps the long side smaller (default), 'hi' keeps more pixels.
 // `.rotate()` bakes in EXIF orientation (phone photos).
 const IMAGE_PRESETS: Record<ScratchImageQuality, { dim: number; quality: number }> = {
-  lo: { dim: 1024, quality: 78 },
+  lo: { dim: 768, quality: 78 },
   hi: { dim: 2048, quality: 88 }
 }
 const MAX_IMAGE_BYTES = 50 * 1024 * 1024

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -1,0 +1,306 @@
+import {
+  type IndexKey,
+  type TLPageId,
+  type TLRecord,
+  type TLStore,
+  ZERO_INDEX_KEY,
+  createBindingId,
+  createShapeId,
+  createTLStore,
+  defaultBindingUtils,
+  defaultShapeUtils,
+  getIndexAbove,
+  getSnapshot,
+  loadSnapshot,
+  toRichText
+} from 'tldraw'
+
+import type { ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
+
+import { publishEvent } from './events'
+import { type ScratchpadDoc, loadScratchpadDoc, saveScratchpadDoc } from './scratchpad'
+
+// Server-side Scratchpad writer. The browser is no longer required to draw: we run
+// the same ops against a *headless* tldraw store here, persist the snapshot, and
+// broadcast `scratchpad:updated` so any open tab reloads from disk. Only `view`
+// (rendering pixels) still needs a live tab; `read` is served straight off disk.
+// See docs/moi-scratchpad.md.
+//
+// We drive the store directly rather than an `Editor`, because the Editor needs a
+// DOM + text measurement that don't exist in the server runtime. The store
+// validates every `put`, so a malformed record throws instead of corrupting the
+// file — that validation is what keeps hand-built records honest.
+
+// Each shape type's default props, read once from its ShapeUtil. `getDefaultProps`
+// is an instance method but doesn't touch the editor for the shapes we create, so a
+// throwaway instance is enough; the result is static per type, so we cache it.
+const shapeDefaults = new Map<string, Record<string, unknown>>()
+function defaultProps(type: string): Record<string, unknown> {
+  let cached = shapeDefaults.get(type)
+  if (!cached) {
+    const Util = defaultShapeUtils.find(u => (u as unknown as { type: string }).type === type)
+    if (!Util) throw new Error(`Unknown shape type "${type}"`)
+    // eslint-disable-next-line new-cap -- Util is a class constructor pulled from a list
+    const util = new (Util as unknown as new (editor: unknown) => {
+      getDefaultProps(): Record<string, unknown>
+    })({})
+    cached = util.getDefaultProps()
+    shapeDefaults.set(type, cached)
+  }
+  return { ...cached }
+}
+
+// Map an op's optional color/size onto tldraw shape props (omitted → tldraw default).
+function styleProps(style: ScratchStyle): Record<string, unknown> {
+  return {
+    ...(style.color ? { color: style.color } : {}),
+    ...(style.size ? { size: style.size } : {})
+  }
+}
+
+// A fresh headless store hydrated from the saved snapshot (or empty). The
+// snapshot shape (`{ document }`) matches what the browser PUTs and loads.
+function buildStore(doc: ScratchpadDoc | null): TLStore {
+  const store = createTLStore({ shapeUtils: defaultShapeUtils, bindingUtils: defaultBindingUtils })
+  if (doc?.store) {
+    loadSnapshot(store, { document: doc } as unknown as Parameters<typeof loadSnapshot>[1])
+  }
+  // Seed the document/page records a fresh (or partial) store needs to be valid.
+  store.ensureStoreIsUsable()
+  return store
+}
+
+function firstPageId(store: TLStore): TLPageId {
+  for (const record of store.allRecords()) {
+    if (record.typeName === 'page') return record.id
+  }
+  // ensureStoreIsUsable always leaves a page; this is unreachable in practice.
+  throw new Error('Scratchpad has no page')
+}
+
+// The next fractional index above every shape on the page, so a new shape lands on
+// top. IndexKeys sort lexicographically, so a string max is a valid ordering.
+function nextIndex(store: TLStore, pageId: TLPageId): IndexKey {
+  let max: IndexKey = ZERO_INDEX_KEY
+  for (const record of store.allRecords()) {
+    if (record.typeName === 'shape' && record.parentId === pageId && record.index > max) {
+      max = record.index
+    }
+  }
+  return getIndexAbove(max)
+}
+
+// Hand-build a shape record. TS can't correlate `type` with its matching props
+// variant across the TLRecord union, so we assert — `store.put` validates the
+// result at runtime, which is the real guarantee.
+function shapeRecord(fields: {
+  id: ReturnType<typeof createShapeId>
+  type: string
+  x: number
+  y: number
+  index: IndexKey
+  parentId: TLPageId
+  props: Record<string, unknown>
+}): TLRecord {
+  return {
+    typeName: 'shape',
+    rotation: 0,
+    isLocked: false,
+    opacity: 1,
+    meta: {},
+    ...fields
+  } as unknown as TLRecord
+}
+
+// Bind one arrow terminal to a target shape, so the arrow follows when it moves.
+function arrowBinding(
+  arrowId: ReturnType<typeof createShapeId>,
+  targetId: ReturnType<typeof createShapeId>,
+  terminal: 'start' | 'end'
+): TLRecord {
+  return {
+    id: createBindingId(),
+    typeName: 'binding',
+    type: 'arrow',
+    fromId: arrowId,
+    toId: targetId,
+    meta: {},
+    props: {
+      terminal,
+      normalizedAnchor: { x: 0.5, y: 0.5 },
+      isPrecise: false,
+      isExact: false,
+      snap: 'none'
+    }
+  } as unknown as TLRecord
+}
+
+// Apply one mutating op to the store. `read` and `view` are handled elsewhere
+// (disk / browser) and never reach here. Returns the op's result.
+function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
+  const pageId = firstPageId(store)
+  const requireShape = (name: string) => {
+    const shape = store.get(createShapeId(name))
+    if (!shape || shape.typeName !== 'shape') throw new Error(`No shape named "${name}"`)
+    return shape
+  }
+
+  switch (op.kind) {
+    case 'add-rect': {
+      store.put([
+        shapeRecord({
+          id: createShapeId(op.name),
+          type: 'geo',
+          x: op.x,
+          y: op.y,
+          index: nextIndex(store, pageId),
+          parentId: pageId,
+          props: {
+            ...defaultProps('geo'),
+            geo: 'rectangle',
+            w: op.w,
+            h: op.h,
+            ...styleProps(op),
+            ...(op.text ? { richText: toRichText(op.text) } : {})
+          }
+        })
+      ])
+      return { name: op.name }
+    }
+    case 'add-text': {
+      store.put([
+        shapeRecord({
+          id: createShapeId(op.name),
+          type: 'text',
+          x: op.x,
+          y: op.y,
+          index: nextIndex(store, pageId),
+          parentId: pageId,
+          props: { ...defaultProps('text'), richText: toRichText(op.text), ...styleProps(op) }
+        })
+      ])
+      return { name: op.name }
+    }
+    case 'add-note': {
+      store.put([
+        shapeRecord({
+          id: createShapeId(op.name),
+          type: 'note',
+          x: op.x,
+          y: op.y,
+          index: nextIndex(store, pageId),
+          parentId: pageId,
+          props: { ...defaultProps('note'), richText: toRichText(op.text), ...styleProps(op) }
+        })
+      ])
+      return { name: op.name }
+    }
+    case 'add-arrow': {
+      // Validate named endpoints up front — better a clear error than a dangling
+      // binding that corrupts the snapshot.
+      if ('name' in op.from) requireShape(op.from.name)
+      if ('name' in op.to) requireShape(op.to.name)
+      const arrowId = createShapeId(op.name)
+      // Point endpoints carry absolute coords; bound endpoints get placeholders the
+      // binding then drives. `elbow` routes with right angles; default is a curved arc.
+      store.put([
+        shapeRecord({
+          id: arrowId,
+          type: 'arrow',
+          x: 0,
+          y: 0,
+          index: nextIndex(store, pageId),
+          parentId: pageId,
+          props: {
+            ...defaultProps('arrow'),
+            ...styleProps(op),
+            ...(op.elbow ? { kind: 'elbow' } : {}),
+            start: 'name' in op.from ? { x: 0, y: 0 } : { x: op.from.x, y: op.from.y },
+            end: 'name' in op.to ? { x: 100, y: 0 } : { x: op.to.x, y: op.to.y }
+          }
+        })
+      ])
+      const bindings: TLRecord[] = []
+      if ('name' in op.from)
+        bindings.push(arrowBinding(arrowId, createShapeId(op.from.name), 'start'))
+      if ('name' in op.to) bindings.push(arrowBinding(arrowId, createShapeId(op.to.name), 'end'))
+      if (bindings.length > 0) store.put(bindings)
+      return { name: op.name }
+    }
+    case 'move': {
+      const shape = requireShape(op.name)
+      store.put([{ ...shape, x: op.x, y: op.y }])
+      return { ok: true }
+    }
+    case 'set': {
+      const shape = requireShape(op.name)
+      store.put([
+        { ...shape, props: { ...shape.props, richText: toRichText(op.text) } } as TLRecord
+      ])
+      return { ok: true }
+    }
+    case 'delete': {
+      const id = createShapeId(op.name)
+      // Remove the shape plus any binding that references it, or the leftover
+      // binding would dangle and invalidate the snapshot.
+      const ids = [id, ...bindingsTouching(store, op.name)]
+      store.remove(ids)
+      return { ok: true }
+    }
+    case 'clear': {
+      const ids = store
+        .allRecords()
+        .filter(r => r.typeName === 'shape' || r.typeName === 'binding')
+        .map(r => r.id)
+      if (ids.length > 0) store.remove(ids)
+      return { ok: true }
+    }
+    default:
+      // 'read' (disk) and 'view' (browser) are routed before this; anything else
+      // is an unknown op kind.
+      throw new Error(`Cannot execute op "${op.kind}" on the server`)
+  }
+}
+
+// Ids of bindings whose start/end is the named shape.
+function bindingsTouching(store: TLStore, name: string): TLRecord['id'][] {
+  const target = createShapeId(name)
+  const ids: TLRecord['id'][] = []
+  for (const record of store.allRecords()) {
+    if (record.typeName !== 'binding') continue
+    const b = record as unknown as { fromId?: string; toId?: string }
+    if (b.fromId === target || b.toId === target) ids.push(record.id)
+  }
+  return ids
+}
+
+// Serialize writes per workspace so two concurrent ops can't load-load-save-save
+// and lose one. Each op reads the latest disk snapshot, mutates, and writes back.
+const chains = new Map<string, Promise<unknown>>()
+function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = (chains.get(key) ?? Promise.resolve()).catch(() => {})
+  const run = prev.then(fn)
+  chains.set(
+    key,
+    run.catch(() => {})
+  )
+  return run
+}
+
+// Execute a mutating Scratchpad op headlessly: load the snapshot, apply, persist,
+// and notify open tabs to reload. No browser tab required.
+export function executeScratchOp(
+  workspacePath: string,
+  workspaceId: string,
+  op: ScratchOp
+): Promise<ScratchOpResult> {
+  return withLock(workspacePath, async () => {
+    const { document } = await loadScratchpadDoc(workspacePath)
+    const store = buildStore(document)
+    const result = applyOp(store, op)
+    const next = getSnapshot(store).document as unknown as ScratchpadDoc
+    await saveScratchpadDoc(next, workspacePath)
+    publishEvent({ type: 'scratchpad:updated', workspaceId })
+    return result
+  })
+}

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -1,8 +1,12 @@
+import { basename } from 'path'
+import sharp from 'sharp'
+
 import {
   type IndexKey,
   type TLPageId,
   type TLRecord,
   type TLStore,
+  AssetRecordType,
   ZERO_INDEX_KEY,
   createBindingId,
   createShapeId,
@@ -15,7 +19,7 @@ import {
   toRichText
 } from 'tldraw'
 
-import type { ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
+import type { ScratchImageQuality, ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
 
 import { publishEvent } from './events'
 import { type ScratchpadDoc, loadScratchpadDoc, saveScratchpadDoc } from './scratchpad'
@@ -133,6 +137,74 @@ function arrowBinding(
       snap: 'none'
     }
   } as unknown as TLRecord
+}
+
+// Resize an image file to fit the canvas and embed it as a webp data URL, never
+// enlarging — so a 10MB paste becomes a lightweight asset. `quality` picks the
+// preset: 'lo' caps the long side smaller (default), 'hi' keeps more pixels.
+// `.rotate()` bakes in EXIF orientation (phone photos).
+const IMAGE_PRESETS: Record<ScratchImageQuality, { dim: number; quality: number }> = {
+  lo: { dim: 1024, quality: 78 },
+  hi: { dim: 2048, quality: 88 }
+}
+const MAX_IMAGE_BYTES = 50 * 1024 * 1024
+
+async function processCanvasImage(
+  path: string,
+  quality: ScratchImageQuality
+): Promise<{ src: string; w: number; h: number; mimeType: string; name: string }> {
+  const file = Bun.file(path)
+  if (!(await file.exists())) throw new Error(`Image file not found: ${path}`)
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  if (bytes.length === 0) throw new Error(`Image file is empty: ${path}`)
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new Error(`Image is too large (${Math.round(bytes.length / 1e6)}MB, max 50MB): ${path}`)
+  }
+  const preset = IMAGE_PRESETS[quality]
+  const { data, info } = await sharp(bytes)
+    .rotate()
+    .resize(preset.dim, preset.dim, { fit: 'inside', withoutEnlargement: true })
+    .webp({ quality: preset.quality })
+    .toBuffer({ resolveWithObject: true })
+  return {
+    src: `data:image/webp;base64,${data.toString('base64')}`,
+    w: info.width,
+    h: info.height,
+    mimeType: 'image/webp',
+    name: basename(path)
+  }
+}
+
+// Create an image shape and its backing asset from a file. Async — unlike the
+// other ops — because it decodes and resizes the image first.
+async function applyAddImage(
+  store: TLStore,
+  op: Extract<ScratchOp, { kind: 'add-image' }>
+): Promise<ScratchOpResult> {
+  const pageId = firstPageId(store)
+  const { src, w, h, mimeType, name } = await processCanvasImage(op.path, op.quality ?? 'lo')
+  const assetId = AssetRecordType.createId()
+  store.put([
+    {
+      id: assetId,
+      typeName: 'asset',
+      type: 'image',
+      meta: {},
+      props: { name, src, w, h, mimeType, isAnimated: false }
+    } as unknown as TLRecord
+  ])
+  store.put([
+    shapeRecord({
+      id: createShapeId(op.name),
+      type: 'image',
+      x: op.x,
+      y: op.y,
+      index: nextIndex(store, pageId),
+      parentId: pageId,
+      props: { ...defaultProps('image'), w, h, assetId }
+    })
+  ])
+  return { name: op.name }
 }
 
 // Apply one mutating op to the store. `read` and `view` are handled elsewhere
@@ -297,7 +369,8 @@ export function executeScratchOp(
   return withLock(workspacePath, async () => {
     const { document } = await loadScratchpadDoc(workspacePath)
     const store = buildStore(document)
-    const result = applyOp(store, op)
+    // add-image decodes/resizes the file first, so it's the one async op.
+    const result = op.kind === 'add-image' ? await applyAddImage(store, op) : applyOp(store, op)
     const next = getSnapshot(store).document as unknown as ScratchpadDoc
     await saveScratchpadDoc(next, workspacePath)
     publishEvent({ type: 'scratchpad:updated', workspaceId })

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -20,6 +20,9 @@ export type ScratchShape = {
   w?: number
   h?: number
   text?: string
+  // Image/asset src. Base64 data URLs are omitted (see omitBase64) — the agent
+  // calls `moi scratch view` to actually see pixels; only the URL kind passes through.
+  src?: string
 }
 
 export function getScratchpadPath(workspacePath: string): string {
@@ -42,6 +45,16 @@ export async function saveScratchpadDoc(
   workspacePath: string
 ): Promise<void> {
   await Bun.write(getScratchpadPath(workspacePath), JSON.stringify({ document }, null, 2))
+}
+
+// tldraw embeds pasted/dropped images as `data:<mime>;base64,<blob>` URLs (on
+// asset records, and occasionally inline in rich text). Those blobs are huge and
+// useless for reasoning about structure, so we replace each one with a short
+// marker — the agent calls `moi scratch view` when it actually needs the pixels.
+// Non-base64 srcs (e.g. https URLs) pass through untouched.
+const BASE64_DATA_URL_RE = /data:[\w.+-]*\/?[\w.+-]*;base64,[A-Za-z0-9+/=]+/g
+function omitBase64(text: string): string {
+  return text.replace(BASE64_DATA_URL_RE, 'base64:omitted')
 }
 
 // Pull readable text out of a shape's props. tldraw stores labels as `richText`
@@ -74,6 +87,17 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
   const store = document?.store
   if (!store || typeof store !== 'object') return []
 
+  // Images live as `asset` records (typeName 'asset'); a shape references one by
+  // `props.assetId`. Index asset src first so we can surface it on the shape —
+  // with base64 blobs omitted — without dumping the asset record itself.
+  const assetSrc = new Map<string, string>()
+  for (const record of Object.values(store)) {
+    if (!record || typeof record !== 'object') continue
+    const a = record as { typeName?: string; id?: string; props?: { src?: unknown } }
+    if (a.typeName !== 'asset' || typeof a.id !== 'string') continue
+    if (typeof a.props?.src === 'string') assetSrc.set(a.id, a.props.src)
+  }
+
   const shapes: ScratchShape[] = []
   for (const record of Object.values(store)) {
     if (!record || typeof record !== 'object') continue
@@ -83,11 +107,12 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
       type?: string
       x?: number
       y?: number
-      props?: { w?: unknown; h?: unknown }
+      props?: { w?: unknown; h?: unknown; assetId?: unknown }
     }
     if (r.typeName !== 'shape') continue
     const w = typeof r.props?.w === 'number' ? r.props.w : undefined
     const h = typeof r.props?.h === 'number' ? r.props.h : undefined
+    const rawSrc = typeof r.props?.assetId === 'string' ? assetSrc.get(r.props.assetId) : undefined
     shapes.push({
       id: (r.id ?? '').replace(/^shape:/, ''),
       type: r.type ?? 'unknown',
@@ -97,8 +122,9 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
       ...(h !== undefined ? { h } : {}),
       ...(() => {
         const text = extractText(r.props)
-        return text !== undefined ? { text } : {}
-      })()
+        return text !== undefined ? { text: omitBase64(text) } : {}
+      })(),
+      ...(rawSrc !== undefined ? { src: omitBase64(rawSrc) } : {})
     })
   }
   return shapes

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -79,7 +79,44 @@ function extractText(props: unknown): string | undefined {
   return undefined
 }
 
-// Parse the saved snapshot into a flat shape listing — served straight off disk,
+// Resolve a single image shape's source by id, straight off the disk snapshot —
+// no browser. The shape references an `asset` record by `props.assetId`; we return
+// that asset's `src` (a `data:` URL for pasted/dropped images, or an `https:` URL).
+// `moi scratch read` deliberately omits these blobs, so this is how the agent pulls
+// the actual pixels for one image. Ids match with or without the `shape:` prefix
+// (read surfaces them stripped).
+export async function readScratchpadImage(
+  workspacePath: string,
+  id: string
+): Promise<{ src: string } | { error: string }> {
+  const { document } = await loadScratchpadDoc(workspacePath)
+  const store = document?.store
+  if (!store || typeof store !== 'object') return { error: `No shape named "${id}"` }
+
+  const target = id.replace(/^shape:/, '')
+  let assetId: string | undefined
+  let found = false
+  for (const record of Object.values(store)) {
+    if (!record || typeof record !== 'object') continue
+    const r = record as { typeName?: string; id?: string; props?: { assetId?: unknown } }
+    if (r.typeName !== 'shape' || (r.id ?? '').replace(/^shape:/, '') !== target) continue
+    found = true
+    if (typeof r.props?.assetId === 'string') assetId = r.props.assetId
+    break
+  }
+  if (!found) return { error: `No shape named "${id}"` }
+  if (!assetId) return { error: `Shape "${id}" is not an image` }
+
+  for (const record of Object.values(store)) {
+    if (!record || typeof record !== 'object') continue
+    const a = record as { typeName?: string; id?: string; props?: { src?: unknown } }
+    if (a.typeName === 'asset' && a.id === assetId && typeof a.props?.src === 'string') {
+      return { src: a.props.src }
+    }
+  }
+  return { error: `Image "${id}" has no stored data` }
+}
+
 // no browser needed. Ids are reported without tldraw's `shape:` prefix so they
 // round-trip with `createShapeId(name)` on the draw side.
 export async function readScratchpadShapes(workspacePath: string): Promise<ScratchShape[]> {

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -1,10 +1,10 @@
 import { join } from 'path'
 
-// The Scratchpad is a shared tldraw canvas per workspace. The browser is the
-// only writer to disk — it autosaves a tldraw *document* snapshot here (the
-// per-tab `session` is intentionally dropped). The server is a relay + store:
-// it serves this file for hydration and parses it for `moi scratch read`, but
-// never reconstructs tldraw shapes itself. See docs/moi-scratchpad.md.
+// The Scratchpad is a shared tldraw canvas per workspace, persisted as a tldraw
+// *document* snapshot here (the per-tab `session` is intentionally dropped). Two
+// writers: the browser autosaves on user edits, and the server writes on agent
+// draws (see scratchpad-executor.ts). This module owns the on-disk shape: load,
+// save, and the `moi scratch read` parser. See docs/moi-scratchpad.md.
 
 // A tldraw document snapshot: `getSnapshot(store).document`. Opaque to us apart
 // from `.store` (the record map) which `read` walks. `null` means empty canvas.

--- a/server/test/scratchpad-executor.test.ts
+++ b/server/test/scratchpad-executor.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'path'
+import sharp from 'sharp'
 
 import { createTLStore, defaultBindingUtils, defaultShapeUtils, loadSnapshot } from 'tldraw'
 
 import type { ScratchOp } from '@/lib/types'
 
 import { executeScratchOp } from '../scratchpad-executor'
-import { getScratchpadPath, loadScratchpadDoc, readScratchpadShapes } from '../scratchpad'
+import {
+  getScratchpadPath,
+  loadScratchpadDoc,
+  readScratchpadImage,
+  readScratchpadShapes
+} from '../scratchpad'
 
 // The headless write path: `executeScratchOp` must produce a snapshot that (a)
 // `read` reflects and (b) the *browser* could load — i.e. it survives a fresh
@@ -96,5 +102,48 @@ describe('executeScratchOp (headless)', () => {
   test('persists nothing but a single scratchpad.json under .moi', async () => {
     await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
     expect(await Bun.file(getScratchpadPath(WS)).exists()).toBe(true)
+  })
+
+  test('add-image resizes to fit, embeds it, and read-image pulls it back', async () => {
+    // A 4000×2000 source — larger than both presets, so it's always scaled down.
+    const file = join(WS, 'big.png')
+    await sharp({
+      create: { width: 4000, height: 2000, channels: 3, background: { r: 10, g: 120, b: 200 } }
+    })
+      .png()
+      .toFile(file)
+
+    await run({ kind: 'add-image', name: 'pic', x: 40, y: 50, path: file })
+
+    expect(await assertLoadable()).toBe(1)
+    const shape = (await readScratchpadShapes(WS)).find(s => s.id === 'pic')
+    // Default 'lo' caps the long side at 1024, aspect preserved (2:1 → 1024×512).
+    expect(shape).toMatchObject({ type: 'image', x: 40, y: 50, w: 1024, h: 512 })
+    // read omits the blob; read-image returns the actual (re-encoded webp) data URL.
+    expect(shape?.src).toBe('base64:omitted')
+    const img = await readScratchpadImage(WS, 'pic')
+    expect(img).toEqual({ src: expect.stringMatching(/^data:image\/webp;base64,/) })
+  })
+
+  test('add-image --quality hi keeps more pixels', async () => {
+    const file = join(WS, 'big.png')
+    await sharp({
+      create: { width: 4000, height: 2000, channels: 3, background: { r: 200, g: 40, b: 90 } }
+    })
+      .png()
+      .toFile(file)
+
+    await run({ kind: 'add-image', name: 'sharp', x: 0, y: 0, path: file, quality: 'hi' })
+    // 'hi' caps the long side at 2048 (2:1 → 2048×1024).
+    const shape = (await readScratchpadShapes(WS)).find(s => s.id === 'sharp')
+    expect(shape).toMatchObject({ type: 'image', w: 2048, h: 1024 })
+  })
+
+  test('read-image errors clearly for a missing or non-image shape', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
+    expect(await readScratchpadImage(WS, 'nope')).toEqual({ error: expect.stringMatching(/nope/) })
+    expect(await readScratchpadImage(WS, 'box')).toEqual({
+      error: expect.stringMatching(/not an image/)
+    })
   })
 })

--- a/server/test/scratchpad-executor.test.ts
+++ b/server/test/scratchpad-executor.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'path'
+
+import { createTLStore, defaultBindingUtils, defaultShapeUtils, loadSnapshot } from 'tldraw'
+
+import type { ScratchOp } from '@/lib/types'
+
+import { executeScratchOp } from '../scratchpad-executor'
+import { getScratchpadPath, loadScratchpadDoc, readScratchpadShapes } from '../scratchpad'
+
+// The headless write path: `executeScratchOp` must produce a snapshot that (a)
+// `read` reflects and (b) the *browser* could load — i.e. it survives a fresh
+// tldraw `loadSnapshot` without a validation error. No browser tab involved.
+
+let WS: string
+beforeEach(() => {
+  WS = mkdtempSync(join(import.meta.dir, 'scratch-exec-test-'))
+})
+afterEach(() => {
+  rmSync(WS, { recursive: true, force: true })
+})
+
+const run = (op: ScratchOp) => executeScratchOp(WS, 'ws-test', op)
+
+// Loads the persisted snapshot into a fresh store the way the browser does. Throws
+// (failing the test) if any record is invalid, then returns the shape count.
+async function assertLoadable(): Promise<number> {
+  const { document } = await loadScratchpadDoc(WS)
+  const store = createTLStore({ shapeUtils: defaultShapeUtils, bindingUtils: defaultBindingUtils })
+  loadSnapshot(store, { document } as unknown as Parameters<typeof loadSnapshot>[1])
+  return store.allRecords().filter(r => r.typeName === 'shape').length
+}
+
+describe('executeScratchOp (headless)', () => {
+  test('draws to disk with no browser, and the snapshot is browser-loadable', async () => {
+    await run({ kind: 'add-rect', name: 'box1', x: 10, y: 20, w: 100, h: 80, text: 'hello' })
+    await run({ kind: 'add-text', name: 'label', x: 200, y: 20, text: 'a label' })
+    await run({ kind: 'add-note', name: 'note1', x: 300, y: 20, text: 'a note' })
+    await run({ kind: 'add-rect', name: 'box2', x: 400, y: 200, w: 60, h: 60 })
+    await run({
+      kind: 'add-arrow',
+      name: 'arr',
+      from: { name: 'box1' },
+      to: { name: 'box2' },
+      elbow: true
+    })
+
+    expect(await assertLoadable()).toBe(5)
+
+    const shapes = await readScratchpadShapes(WS)
+    const byId = Object.fromEntries(shapes.map(s => [s.id, s]))
+    expect(byId.box1).toMatchObject({ type: 'geo', x: 10, y: 20, w: 100, h: 80, text: 'hello' })
+    expect(byId.label).toMatchObject({ type: 'text', text: 'a label' })
+    expect(byId.note1).toMatchObject({ type: 'note', text: 'a note' })
+    expect(byId.arr.type).toBe('arrow')
+  })
+
+  test('move / set / delete / clear mutate the snapshot', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 50, h: 50, text: 'old' })
+
+    await run({ kind: 'move', name: 'box', x: 123, y: 456 })
+    await run({ kind: 'set', name: 'box', text: 'new' })
+    let box = (await readScratchpadShapes(WS)).find(s => s.id === 'box')
+    expect(box).toMatchObject({ x: 123, y: 456, text: 'new' })
+
+    await run({ kind: 'delete', name: 'box' })
+    expect((await readScratchpadShapes(WS)).some(s => s.id === 'box')).toBe(false)
+
+    await run({ kind: 'add-rect', name: 'a', x: 0, y: 0, w: 10, h: 10 })
+    await run({ kind: 'add-rect', name: 'b', x: 20, y: 0, w: 10, h: 10 })
+    await run({ kind: 'clear' })
+    expect(await readScratchpadShapes(WS)).toHaveLength(0)
+    // An empty canvas still persists a valid (loadable) document.
+    expect(await assertLoadable()).toBe(0)
+  })
+
+  test('deleting an arrow endpoint removes the dangling binding too', async () => {
+    await run({ kind: 'add-rect', name: 'from', x: 0, y: 0, w: 10, h: 10 })
+    await run({ kind: 'add-rect', name: 'to', x: 100, y: 0, w: 10, h: 10 })
+    await run({ kind: 'add-arrow', name: 'arr', from: { name: 'from' }, to: { name: 'to' } })
+
+    await run({ kind: 'delete', name: 'to' })
+    // Arrow remains, 'to' is gone, and the snapshot is still browser-loadable
+    // (a leftover binding to a missing shape would throw on load).
+    expect(await assertLoadable()).toBe(2)
+  })
+
+  test('addressing a missing shape throws a clear error', async () => {
+    await expect(run({ kind: 'move', name: 'ghost', x: 0, y: 0 })).rejects.toThrow(/ghost/)
+    await expect(
+      run({ kind: 'add-arrow', name: 'a', from: { name: 'ghost' }, to: { x: 0, y: 0 } })
+    ).rejects.toThrow(/ghost/)
+  })
+
+  test('persists nothing but a single scratchpad.json under .moi', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
+    expect(await Bun.file(getScratchpadPath(WS)).exists()).toBe(true)
+  })
+})

--- a/server/test/scratchpad-executor.test.ts
+++ b/server/test/scratchpad-executor.test.ts
@@ -117,8 +117,8 @@ describe('executeScratchOp (headless)', () => {
 
     expect(await assertLoadable()).toBe(1)
     const shape = (await readScratchpadShapes(WS)).find(s => s.id === 'pic')
-    // Default 'lo' caps the long side at 1024, aspect preserved (2:1 → 1024×512).
-    expect(shape).toMatchObject({ type: 'image', x: 40, y: 50, w: 1024, h: 512 })
+    // Default 'lo' caps the long side at 768, aspect preserved (2:1 → 768×384).
+    expect(shape).toMatchObject({ type: 'image', x: 40, y: 50, w: 768, h: 384 })
     // read omits the blob; read-image returns the actual (re-encoded webp) data URL.
     expect(shape?.src).toBe('base64:omitted')
     const img = await readScratchpadImage(WS, 'pic')

--- a/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
+++ b/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
@@ -1,5 +1,62 @@
-Scratchpad design & API — TBD.
+# Scratchpad
 
-The Scratchpad (the shared low-fi canvas) isn't documented yet. If the user asks you to build on,
-draw to, or modify the Scratchpad, say the feature isn't documented yet and ask how they'd like to
-proceed rather than guessing at an API.
+The Scratchpad is the workspace's **shared whiteboard** — one freeform [tldraw](https://tldraw.dev)
+canvas that the user draws on by hand and the agent drives through the `moi scratch` CLI. Same
+canvas, two authors; disk is the source of truth. Use it to sketch, diagram, annotate the user's
+drawing, or lay out boxes together.
+
+You work the canvas through `moi scratch`, run from the workspace directory. It both **sees** and
+**draws**.
+
+## Seeing
+
+- `moi scratch read` — dump the canvas as JSON: each shape's `id`, `type`, position, size, and
+  text. Use this to reason about exact shapes — what's where, what to move, what to relabel. Served
+  off disk, so it works whether or not a browser tab is open. Image shapes report a `src`, but
+  base64 blobs come back as `base64:omitted` — call `view` to actually see them.
+- `moi scratch view` — render the canvas to a PNG (prints the file path). Use this to _see_ what the
+  user drew — freehand, layout, anything structure can't capture. Needs an open Scratchpad tab.
+
+`read` is for logic; `view` is for vision.
+
+## Drawing
+
+```
+moi scratch add text   --at <x,y> --text "..."           [--id NAME] [--color C] [--stroke W]
+moi scratch add rect   --at <x,y> --size <w,h> [--text]   [--id NAME] [--color C] [--stroke W]
+moi scratch add note   --at <x,y> --text "..."            [--id NAME] [--color C] [--stroke W]
+moi scratch add arrow  --from <id|x,y> --to <id|x,y>      [--id NAME] [--color C] [--stroke W] [--elbow]
+moi scratch move   <id> --to <x,y>
+moi scratch set    <id> --text "..."        # relabel / edit a shape's text
+moi scratch delete <id>
+moi scratch clear                           # wipe the whole canvas
+```
+
+- **`--id`** gives a shape a stable handle so later commands can address it (`move`, `set`,
+  `delete`, or as an arrow endpoint). Without it, the command prints the generated id.
+- **Arrows connect shapes.** `add arrow --from box1 --to box2` binds the endpoints to those shapes,
+  so the arrow follows when they move — the connector you want in a diagram. Endpoints can also be
+  bare `x,y` points. Add `--elbow` for right-angle (squared) routing instead of a curved arc.
+- **`--color`** is one of `black`, `red`, `yellow`, `green`, `blue`, `grey`, **or any hex** (e.g.
+  `#4465e9`, snapped to the nearest of those six). **`--stroke`** is `small` or `large`. Omit
+  either to keep the default.
+- **`clear`** removes every shape at once.
+- Coordinates are tldraw canvas space (origin top-left, y down).
+
+## Keep parity with the user
+
+Your toolset is deliberately the same surface the user has in the UI toolbar — the same six colors,
+the same two stroke sizes, rectangles/notes/text/arrows. Don't reach for shapes or styles the user
+can't pick by hand; neither side should be able to make something the other can't represent.
+
+## How it works
+
+The canvas is a real tldraw editor in the **browser** — that's where drawing and rendering happen.
+The moi server is a relay and disk store, not a tldraw runtime.
+
+- **`read`** is parsed straight off the saved snapshot on disk — no browser needed.
+- **`view` and the draw ops** (`add`/`move`/`set`/`delete`/`clear`) relay to the live editor in a
+  connected tab, which runs them against tldraw and replies. If no tab is showing **this**
+  workspace's Scratchpad, those commands report "No live canvas" — ask the user to open the
+  Scratchpad tab. (`read` still works off disk.)
+- Edits are **last-write-wins** and autosaved; a clobbered change is cheap to redo. No locking.

--- a/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
+++ b/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
@@ -51,12 +51,13 @@ can't pick by hand; neither side should be able to make something the other can'
 
 ## How it works
 
-The canvas is a real tldraw editor in the **browser** — that's where drawing and rendering happen.
-The moi server is a relay and disk store, not a tldraw runtime.
+Almost everything works **without the Scratchpad tab open** — the user can close it and you can
+still draw. The disk snapshot (`.moi/scratchpad.json`) is the source of truth.
 
-- **`read`** is parsed straight off the saved snapshot on disk — no browser needed.
-- **`view` and the draw ops** (`add`/`move`/`set`/`delete`/`clear`) relay to the live editor in a
-  connected tab, which runs them against tldraw and replies. If no tab is showing **this**
-  workspace's Scratchpad, those commands report "No live canvas" — ask the user to open the
-  Scratchpad tab. (`read` still works off disk.)
-- Edits are **last-write-wins** and autosaved; a clobbered change is cheap to redo. No locking.
+- **`read`** parses the saved snapshot straight off disk — no browser.
+- **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server against a headless tldraw
+  store, writes the snapshot, and nudges any open tab to reload. No live tab needed.
+- **`view`** is the one exception: rasterizing the canvas needs the browser, so it relays to a
+  connected tab. With none showing **this** workspace's Scratchpad it reports "No live canvas" —
+  ask the user to open the Scratchpad tab. Every other command still works off disk.
+- Edits are **last-write-wins** between you and the user; a clobbered change is cheap to redo.

--- a/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
+++ b/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
@@ -1,23 +1,18 @@
 # Scratchpad
 
-The Scratchpad is the workspace's **shared whiteboard** — one freeform [tldraw](https://tldraw.dev)
-canvas that the user draws on by hand and the agent drives through the `moi scratch` CLI. Same
-canvas, two authors; disk is the source of truth. Use it to sketch, diagram, annotate the user's
-drawing, or lay out boxes together.
-
-You work the canvas through `moi scratch`, run from the workspace directory. It both **sees** and
-**draws**.
+The Scratchpad is the workspace's **shared whiteboard** — one freeform tldraw canvas the user
+draws on by hand and you drive through `moi scratch`. Same canvas, two authors; disk is the
+source of truth. Use it to sketch, diagram, annotate the user's drawing, or lay out boxes.
 
 ## Seeing
 
 - `moi scratch read` — dump the canvas as JSON: each shape's `id`, `type`, position, size, and
-  text. Use this to reason about exact shapes — what's where, what to move, what to relabel. Served
-  off disk, so it works whether or not a browser tab is open. Image shapes report a `src`, but
-  base64 blobs come back as `base64:omitted` — call `view` to actually see them.
-- `moi scratch view` — render the canvas to a PNG (prints the file path). Use this to _see_ what the
-  user drew — freehand, layout, anything structure can't capture. Needs an open Scratchpad tab.
+  text. Off disk, so it works whether or not a browser tab is open.
+- `moi scratch read-image <id>` — save one image shape to a file (its actual bytes; `read` omits
+  the blob). Off disk too.
+- `moi scratch view` — render the whole canvas to a PNG. Needs an open Scratchpad tab.
 
-`read` is for logic; `view` is for vision.
+`read` is for logic; `view` / `read-image` are for vision.
 
 ## Drawing
 
@@ -26,38 +21,25 @@ moi scratch add text   --at <x,y> --text "..."           [--id NAME] [--color C]
 moi scratch add rect   --at <x,y> --size <w,h> [--text]   [--id NAME] [--color C] [--stroke W]
 moi scratch add note   --at <x,y> --text "..."            [--id NAME] [--color C] [--stroke W]
 moi scratch add arrow  --from <id|x,y> --to <id|x,y>      [--id NAME] [--color C] [--stroke W] [--elbow]
+moi scratch add image  <path>                             [--at <x,y>] [--id NAME] [--quality lo|hi]
 moi scratch move   <id> --to <x,y>
-moi scratch set    <id> --text "..."        # relabel / edit a shape's text
+moi scratch set    <id> --text "..."
 moi scratch delete <id>
-moi scratch clear                           # wipe the whole canvas
+moi scratch clear
 ```
 
-- **`--id`** gives a shape a stable handle so later commands can address it (`move`, `set`,
-  `delete`, or as an arrow endpoint). Without it, the command prints the generated id.
-- **Arrows connect shapes.** `add arrow --from box1 --to box2` binds the endpoints to those shapes,
-  so the arrow follows when they move — the connector you want in a diagram. Endpoints can also be
-  bare `x,y` points. Add `--elbow` for right-angle (squared) routing instead of a curved arc.
-- **`--color`** is one of `black`, `red`, `yellow`, `green`, `blue`, `grey`, **or any hex** (e.g.
-  `#4465e9`, snapped to the nearest of those six). **`--stroke`** is `small` or `large`. Omit
-  either to keep the default.
-- **`clear`** removes every shape at once.
+- `--id` names a shape so later commands can address it (`move` / `set` / `delete`, or as an
+  arrow endpoint). Without it, the command prints the generated id.
+- `add arrow --from box1 --to box2` binds endpoints to those shapes, so the arrow follows when
+  they move. Endpoints can also be bare `x,y`. `--elbow` routes with right angles.
+- `add image` resizes to fit the canvas — `--quality lo` (default) or `hi` for more pixels — so a
+  huge file never gets embedded whole.
+- `--color` is `black|red|yellow|green|blue|grey` or any hex (snapped to nearest); `--stroke` is
+  `small|large`. These match the UI toolbar — you can only make what the user can make by hand.
 - Coordinates are tldraw canvas space (origin top-left, y down).
 
-## Keep parity with the user
+## Implementation details
 
-Your toolset is deliberately the same surface the user has in the UI toolbar — the same six colors,
-the same two stroke sizes, rectangles/notes/text/arrows. Don't reach for shapes or styles the user
-can't pick by hand; neither side should be able to make something the other can't represent.
-
-## How it works
-
-Almost everything works **without the Scratchpad tab open** — the user can close it and you can
-still draw. The disk snapshot (`.moi/scratchpad.json`) is the source of truth.
-
-- **`read`** parses the saved snapshot straight off disk — no browser.
-- **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server against a headless tldraw
-  store, writes the snapshot, and nudges any open tab to reload. No live tab needed.
-- **`view`** is the one exception: rasterizing the canvas needs the browser, so it relays to a
-  connected tab. With none showing **this** workspace's Scratchpad it reports "No live canvas" —
-  ask the user to open the Scratchpad tab. Every other command still works off disk.
-- Edits are **last-write-wins** between you and the user; a clobbered change is cheap to redo.
+`moi scratch` → server → `.moi/scratchpad.json` (internal — never edit it by hand). Reads and
+draws hit that snapshot directly, so they work with no tab open; `view` is the exception — it goes
+to the browser to rasterize the live canvas. Edits are last-write-wins between you and the user.

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -245,4 +245,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.3.0" />
+<moi-skill version="0.2.0" />

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -245,4 +245,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.1.0" />
+<moi-skill version="0.2.0" />

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -245,4 +245,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.2.0" />
+<moi-skill version="0.3.0" />


### PR DESCRIPTION
tldraw embeds pasted/dropped images as `data:...;base64,...` URLs on asset
records. Surface an image shape's `src` in `moi scratch read` but replace
base64 blobs with a `base64:omitted` marker (URL srcs pass through), and scrub
the same out of shape text. The blob is huge and unreadable as text — the agent
calls `moi scratch view` when it needs the actual pixels.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01APZwdNPHSqApt1xGgA6zwv