### PR TITLE
Disable ANSI colors in CLI when stdout is not a TTY

### DIFF
--- a/server/cli-colors.ts
+++ b/server/cli-colors.ts
@@ -1,0 +1,17 @@
+// Disable ANSI color when stdout is not a TTY — e.g. an agent capturing
+// `moi scratch --help` through a pipe.
+//
+// citty colors its usage and error output *unconditionally*: its color helper
+// keys off env vars (`NO_COLOR`/`TERM`/`CI`/`TEST`) and never checks `isTTY`, so
+// without this an agent sees literal `[36m`/`[1m` escape noise instead of
+// readable help. We set `NO_COLOR` here so citty's color helpers no-op. This
+// module is imported *first* in `cli.ts` so it runs before citty's module is
+// evaluated (citty computes its `noColor` flag once, at import time).
+//
+// picocolors (our own coloring) already auto-detects `isTTY`, so this only
+// closes citty's gap. `FORCE_COLOR` and an explicit `NO_COLOR` are honored: if
+// the user opted in or out of color, we leave their choice untouched.
+
+if (!process.stdout.isTTY && !process.env.FORCE_COLOR && process.env.NO_COLOR == null) {
+  process.env.NO_COLOR = '1'
+}

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import './cli-colors' // must precede citty: sets NO_COLOR before its color flag is computed
 import { defineCommand, runMain, showUsage } from 'citty'
 import { existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'


### PR DESCRIPTION
## Summary

Fixes CLI help and error output displaying raw ANSI escape sequences (e.g., `[36m`, `[1m`) when stdout is piped or captured by an agent, rather than being rendered as colors.

## Changes

- **New file `server/cli-colors.ts`**: Sets `NO_COLOR=1` environment variable before citty is imported, but only when stdout is not a TTY and the user hasn't explicitly opted in/out via `FORCE_COLOR` or `NO_COLOR`.
- **Modified `server/cli.ts`**: Imports the new `cli-colors` module at the very top, before citty, ensuring the environment variable is set during citty's module initialization when it computes its color flag.

## Implementation Details

The issue stems from citty unconditionally coloring its output based on environment variables (`NO_COLOR`, `TERM`, `CI`, `TEST`) without checking `isTTY`. When an agent pipes `moi scratch --help`, citty outputs literal escape codes instead of readable text.

By importing `cli-colors` first in `cli.ts`, we set `NO_COLOR` before citty evaluates its color flag (which happens once at import time). This respects user preferences: if `FORCE_COLOR` is set or `NO_COLOR` is already defined, we leave it untouched. Our own coloring library (picocolors) already auto-detects `isTTY`, so this only closes citty's gap.

https://claude.ai/code/session_01QVA8bV1mcxtkm7HoMq8QhH