### PR TITLE
Add file and image attachments to chat composer

### DIFF
--- a/client/components/ChatInput.tsx
+++ b/client/components/ChatInput.tsx
@@ -1,9 +1,18 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 
-import { IconArrowUp, IconPlayerStop } from '@tabler/icons-react'
+import {
+  IconArrowUp,
+  IconFile,
+  IconLoader2,
+  IconPaperclip,
+  IconPlayerStop,
+  IconX
+} from '@tabler/icons-react'
 
+import { cn } from '@/client/lib/cn'
 import { useWorkspaceId } from '@/client/lib/WorkspaceContext'
-import { draftKey, liveStore, useLive } from '@/client/store/live'
+import { uploadFiles } from '@/client/lib/uploads'
+import { type ChatAttachment, draftKey, liveStore, useLive } from '@/client/store/live'
 
 import { ModelPicker } from './ModelPicker'
 import { Button } from './ui/button'
@@ -17,19 +26,60 @@ type ChatInputProps = {
 // The composer owns the draft: it reads/writes the per-thread draft in the live
 // store directly, so a keystroke re-renders only this component — not the chat
 // panel, message list, or surrounding workspace. The draft is keyed by the
-// active thread, so switching threads swaps the unsent text with you.
+// active thread, so switching threads swaps the unsent text with you. Attachments
+// (drag/drop, paste, attach button) are tracked the same way and cleared on send.
 export function ChatInput({ onSend, onStop, processing }: ChatInputProps) {
   const ref = useRef<HTMLTextAreaElement>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
   const workspaceId = useWorkspaceId()
   const sessionId = useLive(s => s.activeByWorkspace[workspaceId] ?? null)
   const value = useLive(s => s.drafts[draftKey(workspaceId, sessionId)] ?? '')
+  const attachments = useLive(s => s.attachments[draftKey(workspaceId, sessionId)] ?? EMPTY)
+  const [dragOver, setDragOver] = useState(false)
+
+  const uploading = attachments.some(a => a.status === 'uploading')
+  const hasReady = attachments.some(a => a.status === 'ready')
+  const canSend = (value.trim().length > 0 || hasReady) && !uploading
 
   const onChange = (next: string) => liveStore.getState().setDraft(workspaceId, sessionId, next)
+
+  // Upload each picked file immediately, tracking its in-flight status so the
+  // thumbnail row can show a spinner / error per file.
+  const addFiles = (files: File[]) => {
+    if (files.length === 0) return
+    const store = liveStore.getState()
+    const items: ChatAttachment[] = files.map(f => ({
+      localId: crypto.randomUUID(),
+      name: f.name || 'file',
+      mediaType: f.type || 'application/octet-stream',
+      previewUrl: f.type.startsWith('image/') ? URL.createObjectURL(f) : undefined,
+      status: 'uploading'
+    }))
+    store.addAttachments(workspaceId, sessionId, items)
+    items.forEach((item, i) => {
+      uploadFiles(workspaceId, [files[i]])
+        .then(([info]) =>
+          liveStore.getState().updateAttachment(workspaceId, sessionId, item.localId, {
+            status: 'ready',
+            upload: info,
+            mediaType: info.mediaType
+          })
+        )
+        .catch((err: unknown) =>
+          liveStore.getState().updateAttachment(workspaceId, sessionId, item.localId, {
+            status: 'error',
+            error: err instanceof Error ? err.message : 'Upload failed'
+          })
+        )
+    })
+  }
+
   const send = () => {
+    if (!canSend) return
     onSend(value)
     // Clear under the current key. On a new chat `sessionId` is still null, so
     // this clears the `'new'` draft; `send` then mints the real id and the input
-    // re-renders empty under the new key.
+    // re-renders empty under the new key. (Attachments are cleared by `send`.)
     liveStore.getState().setDraft(workspaceId, sessionId, '')
   }
 
@@ -44,8 +94,41 @@ export function ChatInput({ onSend, onStop, processing }: ChatInputProps) {
         e.preventDefault()
         ref.current?.focus()
       }}
-      className="flex w-full cursor-text flex-col gap-1 rounded-lg bg-white p-2 shadow-xs transition-[color,box-shadow] outline-none focus-within:shadow-sm"
+      onDragOver={e => {
+        if (!e.dataTransfer.types.includes('Files')) return
+        e.preventDefault()
+        setDragOver(true)
+      }}
+      onDragLeave={e => {
+        // Ignore leaves into child elements — only reset when leaving the form.
+        if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+        setDragOver(false)
+      }}
+      onDrop={e => {
+        if (!e.dataTransfer.types.includes('Files')) return
+        e.preventDefault()
+        setDragOver(false)
+        addFiles(Array.from(e.dataTransfer.files))
+      }}
+      className={cn(
+        'flex w-full cursor-text flex-col gap-1 rounded-lg bg-white p-2 shadow-xs transition-[color,box-shadow] outline-none focus-within:shadow-sm',
+        dragOver && 'ring-2 ring-ring/60'
+      )}
     >
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-1 pt-1 pb-0.5">
+          {attachments.map(a => (
+            <AttachmentChip
+              key={a.localId}
+              attachment={a}
+              onRemove={() =>
+                liveStore.getState().removeAttachment(workspaceId, sessionId, a.localId)
+              }
+            />
+          ))}
+        </div>
+      )}
+
       <textarea
         ref={ref}
         id="chat-input"
@@ -58,23 +141,103 @@ export function ChatInput({ onSend, onStop, processing }: ChatInputProps) {
             send()
           }
         }}
+        onPaste={e => {
+          const files = Array.from(e.clipboardData?.files ?? [])
+          if (files.length === 0) return
+          e.preventDefault()
+          addFiles(files)
+        }}
         placeholder={processing ? 'Queue a follow-up...' : 'Ask anything...'}
         autoFocus
         rows={1}
         className="field-sizing-content max-h-40 w-full resize-none bg-transparent px-2 py-1 text-sm leading-relaxed outline-none placeholder:text-muted-foreground disabled:opacity-50"
       />
       <div className="flex items-center justify-end gap-1.5">
+        <input
+          ref={fileRef}
+          type="file"
+          multiple
+          hidden
+          onChange={e => {
+            addFiles(Array.from(e.target.files ?? []))
+            e.target.value = ''
+          }}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="mr-auto"
+          onClick={() => fileRef.current?.click()}
+          aria-label="Attach files"
+        >
+          <IconPaperclip stroke={1.5} />
+        </Button>
         <ModelPicker />
         {processing ? (
           <Button type="button" size="icon" onClick={onStop} aria-label="Stop agent">
             <IconPlayerStop stroke={1.5} />
           </Button>
         ) : (
-          <Button type="submit" size="icon" disabled={!value.trim()} aria-label="Send message">
+          <Button type="submit" size="icon" disabled={!canSend} aria-label="Send message">
             <IconArrowUp stroke={1.5} />
           </Button>
         )}
       </div>
     </form>
+  )
+}
+
+const EMPTY: ChatAttachment[] = []
+
+type AttachmentChipProps = {
+  attachment: ChatAttachment
+  onRemove: () => void
+}
+
+// A composer attachment preview: an image thumbnail or a labelled file chip,
+// with an upload spinner / error overlay and a remove button.
+function AttachmentChip({ attachment, onRemove }: AttachmentChipProps) {
+  const { name, previewUrl, status, error } = attachment
+  const isImage = !!previewUrl
+
+  return (
+    <div
+      className={cn(
+        'group relative flex items-center gap-2 overflow-hidden rounded-md border border-black/10 bg-black/[0.03]',
+        isImage ? 'size-14' : 'h-10 max-w-52 pr-2 pl-2',
+        status === 'error' && 'border-red-300'
+      )}
+      title={error ?? name}
+    >
+      {isImage ? (
+        <img src={previewUrl} alt={name} className="size-full object-cover" />
+      ) : (
+        <>
+          <IconFile size={16} stroke={1.5} className="shrink-0 text-muted-foreground" />
+          <span className="truncate text-xs text-foreground/80">{name}</span>
+        </>
+      )}
+
+      {status === 'uploading' && (
+        <div className="absolute inset-0 flex items-center justify-center bg-white/60">
+          <IconLoader2 size={16} stroke={1.5} className="animate-spin text-muted-foreground" />
+        </div>
+      )}
+      {status === 'error' && (
+        <div className="absolute inset-0 flex items-center justify-center bg-red-50/80 text-[10px] text-red-700">
+          Failed
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${name}`}
+        className="absolute top-0.5 right-0.5 flex size-4 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity group-hover:opacity-100"
+      >
+        <IconX size={10} stroke={2} />
+      </button>
+    </div>
   )
 }

--- a/client/components/TurnView.tsx
+++ b/client/components/TurnView.tsx
@@ -1,5 +1,7 @@
 import { memo } from 'react'
 
+import { IconFile } from '@tabler/icons-react'
+
 import { MarkdownContent } from '@/client/components/MarkdownContent'
 import { ToolCallGroup } from '@/client/components/tool-group/ToolCallGroup'
 import { useWorkspaceLayoutCtx } from '@/client/lib/WorkspaceLayoutContext'
@@ -71,16 +73,27 @@ export const TurnView = memo(function TurnView({ turn, processing = false }: Tur
   if (turn.origin.kind === 'subagent-prompt') return null
 
   if (turn.role === 'user' && turn.origin.kind === 'user-input') {
-    // Plain user input — right-aligned bubble (only text is typical here).
+    // Plain user input — right-aligned. Attachments (images/files) stack above
+    // the text bubble.
+    const fileParts = turn.parts.filter(
+      (p): p is Extract<Part, { type: 'file' }> => p.type === 'file'
+    )
     const text = turn.parts
       .filter(p => p.type === 'text')
       .map(p => (p.type === 'text' ? p.text : ''))
       .join('\n')
-    if (!text) return null
+    if (!text && fileParts.length === 0) return null
     return (
-      <p className="ml-8 self-end rounded-md bg-black/[0.07] px-4 py-2 text-sm leading-normal whitespace-pre-wrap">
-        {text}
-      </p>
+      <div className="ml-8 flex flex-col items-end gap-1.5">
+        {fileParts.map((p, i) => (
+          <FilePart key={i} mediaType={p.mediaType} url={p.url} filename={p.filename} />
+        ))}
+        {text && (
+          <p className="rounded-md bg-black/[0.07] px-4 py-2 text-sm leading-normal whitespace-pre-wrap">
+            {text}
+          </p>
+        )}
+      </div>
     )
   }
 
@@ -133,9 +146,22 @@ function PartRenderer({ part }: PartRendererProps) {
 
 type FilePartProps = { mediaType: string; url: string; filename?: string }
 function FilePart({ mediaType, url, filename }: FilePartProps) {
+  // Images (data/object/remote URLs) render as a thumbnail; everything else is a
+  // labelled chip. A file with no usable url (e.g. a non-image attachment whose
+  // bytes live only server-side) still shows its name.
+  if (mediaType.startsWith('image/') && url) {
+    return (
+      <img
+        src={url}
+        alt={filename ?? 'attachment'}
+        className="max-h-64 max-w-full rounded-md border border-black/10 object-contain"
+      />
+    )
+  }
   return (
-    <div className="text-xs text-muted-foreground">
-      📎 {filename ?? url} ({mediaType})
+    <div className="flex items-center gap-1.5 rounded-md border border-black/10 bg-black/[0.03] px-2.5 py-1.5 text-xs text-muted-foreground">
+      <IconFile size={14} stroke={1.5} />
+      <span className="truncate">{filename ?? mediaType}</span>
     </div>
   )
 }

--- a/client/hooks/useChat.ts
+++ b/client/hooks/useChat.ts
@@ -11,9 +11,9 @@ import {
 import { useWorkspaceId } from '@/client/lib/WorkspaceContext'
 import { useWorkspaceLayoutCtx } from '@/client/lib/WorkspaceLayoutContext'
 import { sendMessage } from '@/client/lib/connection'
-import { liveStore, useLive } from '@/client/store/live'
+import { draftKey, liveStore, useLive } from '@/client/store/live'
 import { applyEvent, emptyViewState } from '@/lib/format'
-import type { ViewState } from '@/lib/types'
+import type { Part, ViewState } from '@/lib/types'
 
 const EMPTY: ViewState = emptyViewState()
 
@@ -46,9 +46,14 @@ export function useChat() {
   const send = useCallback(
     (draft: string) => {
       const text = draft.trim()
+      // Attachments for the active thread, keyed exactly like the draft. Only
+      // fully-uploaded ones are sent; the composer disables send while any are
+      // still uploading, so in practice they're all ready here.
+      const pending = liveStore.getState().attachments[draftKey(workspaceId, activeSessionId)] ?? []
+      const ready = pending.filter(a => a.status === 'ready' && a.upload)
       // No `processing` guard: sending while a turn is in flight QUEUES the
       // message into the same live server session (streaming-input mode).
-      if (!text) return
+      if (!text && ready.length === 0) return
 
       let sid = activeSessionId
       let isNew = false
@@ -60,8 +65,19 @@ export function useChat() {
 
       // Optimistic user turn — primed into the RQ transcript cache so it renders
       // immediately. The server re-ids the SDK's user echo to optimisticId so it
-      // upserts in place rather than duplicating.
+      // upserts in place rather than duplicating. Image attachments render from
+      // their local object URL until the server's broadcast (with a data URL)
+      // upserts in place.
       const optimisticId = `optimistic:${crypto.randomUUID()}`
+      const parts: Part[] = []
+      for (const a of ready) {
+        if (a.upload?.kind === 'image' && a.previewUrl) {
+          parts.push({ type: 'file', mediaType: a.mediaType, url: a.previewUrl, filename: a.name })
+        } else {
+          parts.push({ type: 'file', mediaType: a.mediaType, url: '', filename: a.name })
+        }
+      }
+      if (text) parts.push({ type: 'text', text })
       qc.setQueryData<ViewState>(workspaceKeys.events(workspaceId, sid), prev =>
         applyEvent(prev ?? emptyViewState(), {
           kind: 'turn',
@@ -69,7 +85,7 @@ export function useChat() {
             id: optimisticId,
             role: 'user',
             origin: { kind: 'user-input' },
-            parts: [{ type: 'text', text }],
+            parts,
             timestamp: new Date().toISOString()
           }
         })
@@ -100,8 +116,13 @@ export function useChat() {
         isNew,
         optimisticId,
         model,
-        effort
+        effort,
+        ...(ready.length > 0 ? { attachments: ready.map(a => a.upload!.id) } : {})
       })
+      // Drop the thread's attachments now that they've been sent (revokes the
+      // preview object URLs). Keyed by the pre-mint id, matching where they were
+      // stored by the composer.
+      liveStore.getState().clearAttachments(workspaceId, activeSessionId)
     },
     [
       activeSessionId,

--- a/client/lib/uploads.ts
+++ b/client/lib/uploads.ts
@@ -1,0 +1,18 @@
+import type { UploadInfo } from '@/lib/types'
+
+// POST one or more files to a workspace's upload endpoint and return the server's
+// `UploadInfo` for each (in request order). The chat composer calls this as soon
+// as files are added (drop/paste/pick) so the upload ids are ready by send time.
+export async function uploadFiles(workspaceId: string, files: File[]): Promise<UploadInfo[]> {
+  const form = new FormData()
+  for (const f of files) form.append('files', f)
+  const res = await fetch(`/api/workspaces/${workspaceId}/uploads`, {
+    method: 'POST',
+    body: form
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(detail || `Upload failed (${res.status})`)
+  }
+  return res.json()
+}

--- a/client/store/live.ts
+++ b/client/store/live.ts
@@ -1,6 +1,22 @@
 import { useStore } from 'zustand'
 import { createStore } from 'zustand/vanilla'
 
+import type { UploadInfo } from '@/lib/types'
+
+// One composer attachment, tracked per thread until the message is sent. It is
+// uploaded as soon as it's added (drop/paste/pick); `status` reflects that
+// in-flight upload, and `upload` holds the server handle once ready. `previewUrl`
+// is a local object URL for image thumbnails (revoked on remove/clear).
+export type ChatAttachment = {
+  localId: string
+  name: string
+  mediaType: string
+  previewUrl?: string
+  status: 'uploading' | 'ready' | 'error'
+  upload?: UploadInfo
+  error?: string
+}
+
 // App-level ephemeral chat state — the bits that are *pushed* from the server
 // over the WebSocket and can't be re-fetched as request/response data:
 //   - which thread is active per workspace (a UI selection),
@@ -37,6 +53,9 @@ export type LiveStore = {
   // subscribes), not the whole workspace, and the draft survives the chat
   // panel's remounts on mode switch.
   drafts: Record<string, string>
+  // Composer attachments, keyed per thread exactly like `drafts` (so they follow
+  // the active thread and survive composer remounts). Cleared on send.
+  attachments: Record<string, ChatAttachment[]>
 
   setActive: (workspaceId: string, sessionId: string | null) => void
   setProcessing: (workspaceId: string, sessionId: string, value: boolean) => void
@@ -46,6 +65,15 @@ export type LiveStore = {
   reconcileProcessing: (running: { workspaceId: string; sessionId: string }[]) => void
   setError: (workspaceId: string, sessionId: string, message: string | null) => void
   setDraft: (workspaceId: string, sessionId: string | null, value: string) => void
+  addAttachments: (workspaceId: string, sessionId: string | null, items: ChatAttachment[]) => void
+  updateAttachment: (
+    workspaceId: string,
+    sessionId: string | null,
+    localId: string,
+    patch: Partial<ChatAttachment>
+  ) => void
+  removeAttachment: (workspaceId: string, sessionId: string | null, localId: string) => void
+  clearAttachments: (workspaceId: string, sessionId: string | null) => void
   renameSession: (workspaceId: string, from: string, to: string) => void
 }
 
@@ -54,6 +82,7 @@ export const liveStore = createStore<LiveStore>()(set => ({
   processing: {},
   errors: {},
   drafts: {},
+  attachments: {},
 
   setActive: (workspaceId, sessionId) =>
     set(s => ({ activeByWorkspace: { ...s.activeByWorkspace, [workspaceId]: sessionId } })),
@@ -71,6 +100,46 @@ export const liveStore = createStore<LiveStore>()(set => ({
 
   setDraft: (workspaceId, sessionId, value) =>
     set(s => ({ drafts: { ...s.drafts, [draftKey(workspaceId, sessionId)]: value } })),
+
+  addAttachments: (workspaceId, sessionId, items) =>
+    set(s => {
+      const k = draftKey(workspaceId, sessionId)
+      return { attachments: { ...s.attachments, [k]: [...(s.attachments[k] ?? []), ...items] } }
+    }),
+
+  updateAttachment: (workspaceId, sessionId, localId, patch) =>
+    set(s => {
+      const k = draftKey(workspaceId, sessionId)
+      const list = s.attachments[k]
+      if (!list) return {}
+      return {
+        attachments: {
+          ...s.attachments,
+          [k]: list.map(a => (a.localId === localId ? { ...a, ...patch } : a))
+        }
+      }
+    }),
+
+  removeAttachment: (workspaceId, sessionId, localId) =>
+    set(s => {
+      const k = draftKey(workspaceId, sessionId)
+      const list = s.attachments[k]
+      if (!list) return {}
+      const target = list.find(a => a.localId === localId)
+      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl)
+      return { attachments: { ...s.attachments, [k]: list.filter(a => a.localId !== localId) } }
+    }),
+
+  clearAttachments: (workspaceId, sessionId) =>
+    set(s => {
+      const k = draftKey(workspaceId, sessionId)
+      for (const a of s.attachments[k] ?? []) {
+        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl)
+      }
+      const next = { ...s.attachments }
+      delete next[k]
+      return { attachments: next }
+    }),
 
   renameSession: (workspaceId, from, to) =>
     set(s => {

--- a/dev/file-uploads.md
+++ b/dev/file-uploads.md
@@ -1,0 +1,121 @@
+# File / image attachments
+
+Drag-drop, paste, or attach files in the chat composer — like the Claude Code
+desktop app. This documents how it works, what the Agent SDK expects, and how the
+pipeline extends to OpenClaw and future adapters.
+
+## What Claude Code / the Agent SDK expects
+
+A streaming-input session yields `SDKUserMessage`s whose `message` is an Anthropic
+`MessageParam`:
+
+```ts
+type MessageParam = { role: 'user' | 'assistant'; content: string | ContentBlockParam[] }
+```
+
+`content` may be a plain string **or** an array of content blocks. For
+attachments the relevant blocks are:
+
+- `ImageBlockParam` — `{ type: 'image', source: { type: 'base64', media_type, data } }`
+  (also accepts a `url` source). `media_type` is one of
+  `image/jpeg | image/png | image/gif | image/webp`.
+- `DocumentBlockParam` — PDFs (`application/pdf` base64) and plain-text sources.
+
+The SDK persists whatever blocks you send into the session `.jsonl`, so an
+attached image is stored inline as base64 in the transcript — there is no
+separate sidecar file. That means **persistence and cold-reload come for free**:
+we only need the adapter to parse those blocks back out when replaying a session.
+
+Anthropic's guidance: downscale images to a long edge ≤ 1568px for the best
+cost/latency (no quality loss for the model), keep ≤ ~5MB per image, and inline
+small images as base64 rather than round-tripping the Files API.
+
+## moi's pipeline (Claude Code)
+
+```
+composer (drop/paste/attach)
+  → POST /api/workspaces/:id/uploads        (multipart, one or many files)
+      → server/uploads.ts: sharp downscale/transcode, stash bytes in-memory (TTL)
+      ← UploadInfo[] { id, kind, mediaType, filename, size, width?, height? }
+  → WS chat frame { content, attachments: uploadId[] }
+      → server/cc-session.ts: resolveUploads → build SDKUserMessage content:
+          images  → base64 image blocks (native vision)
+          files   → written to a temp path, referenced in the prompt text
+        and broadcast the user turn with `file` display parts (data URLs)
+  → agent runs; SDK persists the image blocks to the session .jsonl
+  → on reload, state.ts replays the .jsonl through ClaudeAdapter, which turns
+    base64 image blocks back into `file` parts → thumbnails render again
+```
+
+Why an HTTP upload instead of base64 over the WebSocket:
+
+- Keeps chat frames (and the user-turn broadcast that fans out to every tab)
+  small — a 4MB screenshot would otherwise bloat every frame.
+- Lets us downscale once, server-side, with `sharp` (already a dependency).
+- Gives non-image files a real path the agent can `Read`.
+
+Upload bytes are short-lived (a 30-minute TTL in the in-memory store); the
+durable copy is the base64 block the SDK writes to the `.jsonl`.
+
+### Key files
+
+- `server/uploads.ts` — upload store, `sharp` processing, `resolveUploads`,
+  display-part / data-URL / `materializeToPath` helpers.
+- `server/api.ts` — `POST /api/workspaces/:id/uploads`.
+- `server/cc-session.ts` — `buildUserMessage()` turns text + uploads into the
+  SDK content blocks and the broadcast display parts.
+- `lib/claude-adapter.ts` — parses persisted `image`/`document` blocks
+  (base64 or url source) into `file` parts.
+- `client/lib/uploads.ts` — `uploadFiles()`.
+- `client/store/live.ts` — per-thread `attachments` state (mirrors `drafts`).
+- `client/components/ChatInput.tsx` — attach button, paste, drag-drop, thumbnails.
+- `client/components/TurnView.tsx` — renders image/file parts in the bubble.
+
+## OpenClaw (basic support today)
+
+The OpenClaw gateway's `sessions.send` RPC currently accepts only a **string**
+message — there is no content-block channel. So `sendOpenClawMessage` does the
+honest minimal thing: it materializes each upload to a temp file
+(`materializeToPath`) and appends the paths to the message text, so an OpenClaw
+agent with file/vision tools can open them. There is no inline vision and the
+appended paths are visible in the rendered turn.
+
+To make OpenClaw first-class, the gateway needs a content-block message API
+(images as base64 or file ids, à la the Anthropic shape). When that lands:
+
+1. Extend the `sessions.send` payload with a `content` array (text + image/file
+   blocks), keeping `message` for back-compat.
+2. In `sendOpenClawMessage`, build blocks from `resolveUploads` instead of
+   appending paths (reuse the `buildUserMessage` logic, factored into a shared
+   helper).
+3. Teach `server/openclaw-adapter.ts` `blockToPart` to map the gateway's stored
+   image/file blocks into `file` parts (it already has the `default: return null`
+   slot where image blocks are currently dropped), so reloads render thumbnails.
+
+## Adding a new adapter
+
+The display format is agent-agnostic: a `Part` of `{ type: 'file', mediaType,
+url, filename }` is all the UI needs (`url` may be a data URL or a served URL).
+For a new backend:
+
+1. **Inbound** — convert resolved uploads into whatever the backend's message API
+   accepts (base64 blocks preferred; a file path or upload id otherwise). The
+   `StoredUpload` record exposes `data` (image bytes), `path` (file uploads), and
+   `materializeToPath()` to cover both.
+2. **Display** — emit a `file` part for the user's turn (use
+   `uploadToDisplayPart` for live turns).
+3. **Persistence/reload** — in the adapter that replays the backend's transcript,
+   map its stored image/document blocks back into `file` parts so attachments
+   survive a reload.
+
+The client (`ChatInput`, the live-store `attachments`, `useChat.send`) is fully
+adapter-independent — it always uploads via the same endpoint and sends upload
+ids. Only the server-side send path and the replay adapter are per-backend.
+
+## Limits & follow-ups
+
+- Images are downscaled to ≤ 1568px long edge; non-vision image types transcode
+  to PNG; GIFs pass through. Per-file cap: 32MB raw upload.
+- Not yet done: PDF `document` blocks (the plumbing supports it — add a `kind`
+  and a `DocumentBlockParam` branch in `buildUserMessage`), a dedicated GET route
+  to stream uploads (we inline data URLs instead), and richer non-image previews.

--- a/dev/file-uploads.md
+++ b/dev/file-uploads.md
@@ -1,121 +1,161 @@
-# File / image attachments
+# File uploads — the one plan
 
-Drag-drop, paste, or attach files in the chat composer — like the Claude Code
-desktop app. This documents how it works, what the Agent SDK expects, and how the
-pipeline extends to OpenClaw and future adapters.
+This is the canonical spec for how attachments work in moi: how Claude Code
+itself does it (verified empirically, CLI + desktop), the one constraint we can't
+design around, the target design for moi, and an honest gap analysis against
+what's shipped today.
 
-## What Claude Code / the Agent SDK expects
+---
 
-A streaming-input session yields `SDKUserMessage`s whose `message` is an Anthropic
-`MessageParam`:
+## Part 1 — Ground truth: how Claude Code handles uploads
 
-```ts
-type MessageParam = { role: 'user' | 'assistant'; content: string | ContentBlockParam[] }
+There are **two completely separate mechanisms**. Conflating them is the source
+of every "wait, is it copied or read live?" confusion.
+
+|                                  | **A. Image / binary attach** (paste, drag, ⌘-attach)                                                                   | **B. `@`-mention** (typed path)                                                                                                                          |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trigger                          | Paste/drag an image into the prompt                                                                                    | Type `@"/path/to/file"`                                                                                                                                  |
+| How the model receives it        | Decoded pixels **inline, same turn** — `{"source":{"type":"base64","media_type":"image/png","data":…}}`. No tool call. | File **text inline, same turn** — expanded into an `attachment` record of `type:"file"` (`content.file.content`, `filename`, `displayPath`, `numLines`). |
+| Live vs snapshot                 | **Snapshot** — frozen at send time; survives deleting the original                                                     | **Live read** at send time; edit + re-reference → new content. Re-reference → `already_read_file` dedup record.                                          |
+| Disk copy outside the transcript | **CLI: yes** → `~/.claude/image-cache/<session>/<N>.png`. **Desktop: no.**                                             | Neither — no `/tmp`, no staging, original path only                                                                                                      |
+| In the transcript `.jsonl`       | Full base64 embedded inline (both clients)                                                                             | Text embedded once                                                                                                                                       |
+| Non-image / huge file            | (attach is image-oriented)                                                                                             | Lands as raw/garbled text — no special handling                                                                                                          |
+
+**CLI ↔ desktop divergence (the only real one):** both deliver images to the
+model identically (inline base64 — seen instantly, no tool call). They differ
+only in the _extra_ on-disk artifact:
+
+- **Desktop:** inline base64 in the `.jsonl` is the **only** copy.
+- **CLI:** _additionally_ writes `~/.claude/image-cache/<session>/<N>.png` —
+  re-encoded to PNG, mode `0600`, `<N>` is a **session-global counter** (not
+  per-message), **no dedup**, and the cache is **ephemeral** (GC'd between
+  sessions). The message also carries an `[Image: source: …/N.png]` path token
+  alongside the base64.
+
+**What reaches the model each turn:** images → decoded pixels inline (both
+clients); `@`-mentions → file text inline. A tool call only fires when the agent
+_chooses_ to `Read`/`ls` to verify disk state — never to receive the content.
+
+**Where it persists:**
+
+```
+~/.claude/projects/<encoded-cwd>/<session>.jsonl   durable: text + full base64 of
+                                                   every image + expanded mention text
+~/.claude/image-cache/<session>/<N>.png            CLI only: 0600, ephemeral
+[Anthropic API]                                    all of the above, sent per turn
 ```
 
-`content` may be a plain string **or** an array of content blocks. For
-attachments the relevant blocks are:
+**Three verified rough edges** (true of both clients):
 
-- `ImageBlockParam` — `{ type: 'image', source: { type: 'base64', media_type, data } }`
-  (also accepts a `url` source). `media_type` is one of
-  `image/jpeg | image/png | image/gif | image/webp`.
-- `DocumentBlockParam` — PDFs (`application/pdf` base64) and plain-text sources.
+1. **Base64 is inlined into the transcript** → a couple of screenshots bloated a
+   real session to ~1.5 MB.
+2. **No dedup anywhere** → a bit-for-bit identical image re-pasted is stored a
+   second full copy (verified: same SHA-256, two/three full base64 blocks).
+3. **No lifecycle / redaction** → uploads are unencrypted-on-disk (CLI) +
+   in-transcript + sent-to-API with no GC or scrub. `@`-mentioning a sensitive
+   file writes its plaintext into the `.jsonl` even though no temp copy is made.
 
-The SDK persists whatever blocks you send into the session `.jsonl`, so an
-attached image is stored inline as base64 in the transcript — there is no
-separate sidecar file. That means **persistence and cold-reload come for free**:
-we only need the adapter to parse those blocks back out when replaying a session.
+---
 
-Anthropic's guidance: downscale images to a long edge ≤ 1568px for the best
-cost/latency (no quality loss for the model), keep ≤ ~5MB per image, and inline
-small images as base64 rather than round-tripping the Files API.
+## Part 2 — The one constraint we can't design around
 
-## moi's pipeline (Claude Code)
+The model sees an image **only** if the bytes are in the message content as a
+base64 `image` block (or a URL/`file_id` source). The Agent SDK then **persists
+whatever blocks we send into the session `.jsonl`** — that transcript is
+SDK-owned, not moi-owned.
 
-```
-composer (drop/paste/attach)
-  → POST /api/workspaces/:id/uploads        (multipart, one or many files)
-      → server/uploads.ts: sharp downscale/transcode, stash bytes in-memory (TTL)
-      ← UploadInfo[] { id, kind, mediaType, filename, size, width?, height? }
-  → WS chat frame { content, attachments: uploadId[] }
-      → server/cc-session.ts: resolveUploads → build SDKUserMessage content:
-          images  → base64 image blocks (native vision)
-          files   → written to a temp path, referenced in the prompt text
-        and broadcast the user turn with `file` display parts (data URLs)
-  → agent runs; SDK persists the image blocks to the session .jsonl
-  → on reload, state.ts replays the .jsonl through ClaudeAdapter, which turns
-    base64 image blocks back into `file` parts → thumbnails render again
-```
+So for any agent that runs through the SDK, **base64 in the transcript is
+unavoidable for vision** — exactly why both Claude Code clients do it. moi cannot
+dedup or de-inline the _SDK transcript_ without intercepting SDK persistence
+(fragile, out of scope).
 
-Why an HTTP upload instead of base64 over the WebSocket:
+The design lever moi _does_ control is **its own layers** — upload storage,
+WebSocket transport, the React Query cache, and the rendered display. Those
+should never re-inline base64; that's where the bloat is fixable.
 
-- Keeps chat frames (and the user-turn broadcast that fans out to every tab)
-  small — a 4MB screenshot would otherwise bloat every frame.
-- Lets us downscale once, server-side, with `sharp` (already a dependency).
-- Gives non-image files a real path the agent can `Read`.
+---
 
-Upload bytes are short-lived (a 30-minute TTL in the in-memory store); the
-durable copy is the base64 block the SDK writes to the `.jsonl`.
+## Part 3 — Target design for moi
 
-### Key files
+Three input pipelines, mirroring Claude Code's mental model but adapted to moi's
+WS + adapter architecture.
 
-- `server/uploads.ts` — upload store, `sharp` processing, `resolveUploads`,
-  display-part / data-URL / `materializeToPath` helpers.
-- `server/api.ts` — `POST /api/workspaces/:id/uploads`.
-- `server/cc-session.ts` — `buildUserMessage()` turns text + uploads into the
-  SDK content blocks and the broadcast display parts.
-- `lib/claude-adapter.ts` — parses persisted `image`/`document` blocks
-  (base64 or url source) into `file` parts.
-- `client/lib/uploads.ts` — `uploadFiles()`.
-- `client/store/live.ts` — per-thread `attachments` state (mirrors `drafts`).
-- `client/components/ChatInput.tsx` — attach button, paste, drag-drop, thumbnails.
-- `client/components/TurnView.tsx` — renders image/file parts in the bubble.
+### Pipeline 1 — Image / binary attach (paste, drag, attach button)
 
-## OpenClaw (basic support today)
+1. **Upload** to `POST /api/workspaces/:id/uploads` (multipart). Server:
+   - downscales images with `sharp` (≤1568px long edge), normalizes to a
+     vision-safe media type (or PNG);
+   - **content-addresses** the bytes: `id = sha256(bytes-after-processing)`, so a
+     re-pasted identical image resolves to the same stored entry (**dedup**);
+   - stores bytes in the in-memory TTL store; non-images go to a temp path.
+2. **Transport:** the chat WS frame carries only upload **ids** (never base64).
+3. **To the agent:** `cc-session` builds base64 `image` blocks + text. _(This — and
+   only this — inlines base64, because the SDK transcript requires it.)_
+4. **Display:** the broadcast user turn references images by a **served URL**
+   (`GET /api/workspaces/:id/uploads/:id`), **not** a data URL — so base64 never
+   travels over the WS broadcast or sits in the RQ cache. On cold reload the
+   adapter reconstructs from the `.jsonl` base64 (the one place it must).
 
-The OpenClaw gateway's `sessions.send` RPC currently accepts only a **string**
-message — there is no content-block channel. So `sendOpenClawMessage` does the
-honest minimal thing: it materializes each upload to a temp file
-(`materializeToPath`) and appends the paths to the message text, so an OpenClaw
-agent with file/vision tools can open them. There is no inline vision and the
-appended paths are visible in the rendered turn.
+### Pipeline 2 — Path / workspace-file reference (the `@`-mention analogue) — _new_
 
-To make OpenClaw first-class, the gateway needs a content-block message API
-(images as base64 or file ids, à la the Anthropic shape). When that lands:
+For files **already in the workspace**, copying bytes is wasteful and loses the
+"live read" semantics. Add an `@`-style picker / path token that:
 
-1. Extend the `sessions.send` payload with a `content` array (text + image/file
-   blocks), keeping `message` for back-compat.
-2. In `sendOpenClawMessage`, build blocks from `resolveUploads` instead of
-   appending paths (reuse the `buildUserMessage` logic, factored into a shared
-   helper).
-3. Teach `server/openclaw-adapter.ts` `blockToPart` to map the gateway's stored
-   image/file blocks into `file` parts (it already has the `default: return null`
-   slot where image blocks are currently dropped), so reloads render thumbnails.
+- inserts a path reference (no upload, no copy);
+- the agent reads **live** via its `Read` tool at use time (sees current content);
+- displays as a file chip, not a thumbnail.
 
-## Adding a new adapter
+This is the cheap, correct path for repo files — it's how power users expect it to
+work and it sidesteps base64 entirely.
+
+### Pipeline 3 — Non-image files (PDF, csv, binaries)
+
+Written to a temp path; the path is referenced in the prompt so the agent
+`Read`s it. PDFs can later upgrade to native `document` blocks (the plumbing
+already supports a `kind`).
+
+### Cross-cutting: lifecycle & redaction
+
+- Upload store: TTL eviction (already 30 min); content-addressed entries dedup
+  naturally.
+- Temp files: namespaced under `$TMPDIR/moi-uploads/<id>/`; GC on TTL.
+- Redaction: a "remove attachment from thread" affordance that drops the display
+  reference. (The SDK `.jsonl` copy is SDK-owned; document that limitation rather
+  than pretend we can scrub it.)
+
+---
+
+## Part 4 — Gap analysis: shipped (PR #13) vs. target
+
+| Area                                            | Shipped today                                  | Target                                     | Action                                               |
+| ----------------------------------------------- | ---------------------------------------------- | ------------------------------------------ | ---------------------------------------------------- |
+| Upload transport                                | HTTP multipart + WS carries ids only ✅        | same                                       | done                                                 |
+| Image downscale/normalize (`sharp`)             | ✅                                             | same                                       | done                                                 |
+| Agent vision (base64 blocks)                    | ✅                                             | same (unavoidable)                         | done                                                 |
+| Persist/reload (adapter parses `.jsonl` base64) | ✅                                             | same                                       | done                                                 |
+| **Dedup**                                       | ❌ random-UUID keys                            | content-hash (`sha256`) keys               | **change `addUpload` to hash**                       |
+| **Display transport**                           | ❌ inlines base64 data URLs over WS + RQ cache | served URL (`GET …/uploads/:id`)           | **add GET route; `uploadToDisplayPart` returns URL** |
+| **Path / `@`-mention**                          | ❌ not supported                               | workspace-file reference, live read        | **new feature (pipeline 2)**                         |
+| Lifecycle TTL                                   | ✅ 30 min                                      | same                                       | done                                                 |
+| Redaction affordance                            | ❌                                             | remove-from-thread                         | nice-to-have                                         |
+| OpenClaw                                        | basic (temp path appended to string message)   | content-block API when gateway supports it | tracked                                              |
+
+**Net:** the transport and agent-vision halves match the target. The three
+fixable rough edges Claude Code exhibits — **base64 bloat in moi's own
+display/transport, no dedup, no path-mention** — are exactly the items still open
+for moi. The first two are small, well-scoped changes (content-hash keys + a GET
+route + return a URL from `uploadToDisplayPart`); the third (`@`-mention) is the
+one genuinely new feature.
+
+---
+
+## Part 5 — Adding a new adapter
 
 The display format is agent-agnostic: a `Part` of `{ type: 'file', mediaType,
-url, filename }` is all the UI needs (`url` may be a data URL or a served URL).
-For a new backend:
-
-1. **Inbound** — convert resolved uploads into whatever the backend's message API
-   accepts (base64 blocks preferred; a file path or upload id otherwise). The
-   `StoredUpload` record exposes `data` (image bytes), `path` (file uploads), and
-   `materializeToPath()` to cover both.
-2. **Display** — emit a `file` part for the user's turn (use
-   `uploadToDisplayPart` for live turns).
-3. **Persistence/reload** — in the adapter that replays the backend's transcript,
-   map its stored image/document blocks back into `file` parts so attachments
-   survive a reload.
-
-The client (`ChatInput`, the live-store `attachments`, `useChat.send`) is fully
-adapter-independent — it always uploads via the same endpoint and sends upload
-ids. Only the server-side send path and the replay adapter are per-backend.
-
-## Limits & follow-ups
-
-- Images are downscaled to ≤ 1568px long edge; non-vision image types transcode
-  to PNG; GIFs pass through. Per-file cap: 32MB raw upload.
-- Not yet done: PDF `document` blocks (the plumbing supports it — add a `kind`
-  and a `DocumentBlockParam` branch in `buildUserMessage`), a dedicated GET route
-  to stream uploads (we inline data URLs instead), and richer non-image previews.
+url, filename }` (url = served URL preferred, data URL only as a reload
+fallback). For a new backend: (1) convert resolved uploads into the backend's
+message shape (base64 blocks preferred; path/file-id otherwise — `StoredUpload`
+exposes `data`, `path`, and `materializeToPath()`); (2) emit `file` display
+parts; (3) in the replay adapter, map the backend's stored image/document blocks
+back into `file` parts so reloads render. The client (`ChatInput`, the live-store
+`attachments`, `useChat.send`) is fully backend-independent.

--- a/lib/claude-adapter.ts
+++ b/lib/claude-adapter.ts
@@ -31,6 +31,13 @@ type ContentBlock = {
   media_type?: string
   filename?: string
   source_id?: string
+  // Image/document blocks carry their payload here (base64) or as a bare `url`.
+  source?: {
+    type?: string
+    media_type?: string
+    data?: string
+    url?: string
+  }
 }
 
 type SdkMessage = {
@@ -339,16 +346,26 @@ export class ClaudeAdapter {
         }
         case 'file':
         case 'image':
-        case 'document':
-          if (b.url) {
-            parts.push({
-              type: 'file',
-              mediaType: b.media_type ?? b.type,
-              url: b.url,
-              filename: b.filename
-            })
+        case 'document': {
+          // A bare `url` (legacy) or an Anthropic source block: base64 → data
+          // URL so the persisted attachment re-renders on cold load, or a
+          // source `url` passed through as-is.
+          const src = b.source
+          let url = b.url
+          let mediaType = b.media_type ?? src?.media_type ?? b.type
+          if (!url && src) {
+            if (src.type === 'base64' && src.data && src.media_type) {
+              url = `data:${src.media_type};base64,${src.data}`
+              mediaType = src.media_type
+            } else if (src.url) {
+              url = src.url
+            }
+          }
+          if (url) {
+            parts.push({ type: 'file', mediaType, url, filename: b.filename })
           }
           break
+        }
       }
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -96,6 +96,24 @@ export type ScratchOp =
 // data URL for `view`, or a bare ack for mutations.
 export type ScratchOpResult = { name: string } | { image: string } | { ok: true }
 
+// An attachment uploaded ahead of a chat message. The bytes live server-side in
+// an in-memory upload store (see server/uploads.ts); a chat frame references it
+// by `id`. `kind` splits the two delivery paths: an `image` is inlined as a
+// base64 vision block in the agent message, a `file` is written to a temp path
+// the agent can `Read`. Returned by POST /api/workspaces/:id/uploads.
+export type UploadKind = 'image' | 'file'
+export type UploadInfo = {
+  id: string
+  kind: UploadKind
+  // Normalized media type (images are re-encoded to a vision-safe type).
+  mediaType: string
+  filename: string
+  size: number
+  // Pixel dimensions, for images only — lets the composer reserve space.
+  width?: number
+  height?: number
+}
+
 // Client → Server messages.
 // The chat WebSocket is app-wide (one socket for the whole client, not scoped to
 // a workspace), so every message carries the `workspaceId` it targets.
@@ -106,6 +124,10 @@ export type ClientMessage =
       content: string
       sessionId: string
       isNew: boolean
+      // Upload ids (from POST .../uploads) to attach to this turn. The server
+      // resolves each from its upload store and turns it into a vision block
+      // (image) or a temp-file path reference (other files). Order is preserved.
+      attachments?: string[]
       // Client-chosen stable id for the user's turn. The server tells the
       // adapter to use this id when the SDK echoes the user input back, so
       // the optimistic bubble the client rendered gets upserted in place.

--- a/server/api.ts
+++ b/server/api.ts
@@ -3,7 +3,13 @@ import { serveStatic } from 'hono/bun'
 import { createMiddleware } from 'hono/factory'
 import { basename } from 'node:path'
 
-import type { EnvScope, WorkspaceEntry, WorkspaceModels, WorkspaceType } from '@/lib/types'
+import type {
+  EnvScope,
+  UploadInfo,
+  WorkspaceEntry,
+  WorkspaceModels,
+  WorkspaceType
+} from '@/lib/types'
 
 import { getClaudeModels } from './agent'
 import { apiBaseFor, parseAppletTail, serveWorkspaceFile } from './applets'
@@ -28,6 +34,7 @@ import { DIST_DIR, prebuilt } from './static'
 import { getSessionEvents, getSessions } from './state'
 import { getThreadConfig, saveThreadConfig } from './thread-config'
 import type { ThreadConfigPatch } from './thread-config'
+import { MAX_UPLOAD_BYTES, addUpload } from './uploads'
 import { collectViewRequiredEnv, listViews, serveView } from './views'
 import { collectRequiredEnv, listWidgets, serveWidget } from './widgets'
 import { getWorkspaceConfig, setWorkspaceConfig } from './workspace-config'
@@ -146,6 +153,46 @@ one.post('/rpc/*', c => {
   const id = c.req.param('id')
   const tail = new URL(c.req.url).pathname.split(`/api/workspaces/${id}/rpc/`)[1] ?? ''
   return handleFunctionCall(c.req.raw, tail, c.get('ws').path)
+})
+
+// Chat attachments. The composer POSTs files here (drag/drop, paste, or the
+// attach button) ahead of sending; we process + stash them and hand back opaque
+// upload ids the chat WS frame references. Images are downscaled and inlined as
+// vision blocks at send time; other files are referenced by a temp path. See
+// server/uploads.ts and dev/file-uploads.md.
+one.post('/uploads', async c => {
+  const id = c.req.param('id')
+  let form: FormData
+  try {
+    form = await c.req.formData()
+  } catch {
+    return c.text('Expected multipart/form-data', 400)
+  }
+  const files = form.getAll('files').filter((f): f is File => f instanceof File)
+  if (files.length === 0) return c.text('No files', 400)
+  if (files.length > 20) return c.text('Too many files (max 20)', 400)
+
+  const out: UploadInfo[] = []
+  for (const file of files) {
+    if (file.size > MAX_UPLOAD_BYTES) {
+      return c.text(`"${file.name}" is too large (max ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB)`, 413)
+    }
+    try {
+      const bytes = Buffer.from(await file.arrayBuffer())
+      out.push(
+        await addUpload({
+          workspaceId: id,
+          filename: file.name || 'file',
+          mediaType: file.type || 'application/octet-stream',
+          bytes
+        })
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to process upload'
+      return c.text(`"${file.name}": ${message}`, 400)
+    }
+  }
+  return c.json(out)
 })
 
 one.get('/sessions', async c => {

--- a/server/cc-session.ts
+++ b/server/cc-session.ts
@@ -19,10 +19,63 @@ import {
 } from '@anthropic-ai/claude-agent-sdk'
 
 import { ClaudeAdapter } from '@/lib/claude-adapter'
+import type { Part } from '@/lib/format'
 
 import { broadcast } from './state'
 import { hasThreadConfig, renameThreadConfig, saveThreadConfig } from './thread-config'
+import { type StoredUpload, resolveUploads, uploadToDisplayPart } from './uploads'
 import { resolveWorkspaceEnv } from './workspace-env'
+
+// Media types Claude vision accepts; uploads.ts guarantees every image upload is
+// normalized to one of these, so the cast on `media_type` below is sound.
+type ImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'
+
+// What the SDK's streaming-input prompt accepts for one message's content:
+// a plain string or an array of Anthropic content blocks (text/image/…).
+type MessageContent = SDKUserMessage['message']['content']
+
+// Turn a typed text + resolved uploads into (a) the content the agent receives
+// and (b) the display parts we broadcast for the user's bubble. Images become
+// base64 vision blocks; other files are referenced by their temp path so the
+// agent can Read them. Display text stays the user's text (no path note).
+function buildUserMessage(
+  text: string,
+  uploads: StoredUpload[]
+): { content: MessageContent; parts: Part[] } {
+  const parts: Part[] = []
+  for (const u of uploads) {
+    const part = uploadToDisplayPart(u)
+    if (part) parts.push(part)
+  }
+  if (text) parts.push({ type: 'text', text })
+
+  if (uploads.length === 0) return { content: text, parts }
+
+  const blocks: Exclude<MessageContent, string> = []
+  for (const u of uploads) {
+    if (u.kind === 'image' && u.data) {
+      blocks.push({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: u.mediaType as ImageMediaType,
+          data: u.data.toString('base64')
+        }
+      })
+    }
+  }
+
+  const files = uploads.filter(u => u.kind === 'file' && u.path)
+  let agentText = text
+  if (files.length > 0) {
+    const list = files.map(f => `- ${f.filename}: ${f.path}`).join('\n')
+    agentText =
+      `${text}\n\nThe user attached the following file(s); read them as needed:\n${list}`.trim()
+  }
+  // Always end with a text block so an image-only message still has a prompt.
+  blocks.push({ type: 'text', text: agentText || '(see attached files)' })
+  return { content: blocks, parts }
+}
 
 // Cap on concurrently-held live sessions (each = one claude subprocess). When
 // exceeded, the least-recently-active IDLE session is closed; a busy session is
@@ -44,7 +97,7 @@ const ALLOWED_TOOLS = [
 
 type InputQueue = {
   iterator: AsyncGenerator<SDKUserMessage>
-  push: (text: string) => void
+  push: (content: MessageContent) => void
   clear: () => void
   close: () => void
 }
@@ -125,10 +178,10 @@ function createInputQueue(): InputQueue {
 
   return {
     iterator: gen(),
-    push(text: string) {
+    push(content: MessageContent) {
       buffer.push({
         type: 'user',
-        message: { role: 'user', content: text },
+        message: { role: 'user', content },
         parent_tool_use_id: null
       })
       wake?.()
@@ -321,6 +374,8 @@ export async function sendCCMessage(input: {
   sessionId: string
   isNew: boolean
   content: string
+  // Upload ids attached to this turn (resolved from the upload store here).
+  attachments?: string[]
   optimisticId?: string
   model?: string
   effort?: string
@@ -362,6 +417,13 @@ export async function sendCCMessage(input: {
     s.desiredEffort = input.effort
   }
 
+  // Resolve any attachments into agent content blocks + display parts. Unknown
+  // or expired ids are silently dropped (resolveUploads filters them).
+  const uploads = input.attachments?.length
+    ? resolveUploads(input.workspaceId, input.attachments)
+    : []
+  const { content, parts } = buildUserMessage(input.content, uploads)
+
   // Streaming-input mode does NOT echo the pushed user message back in the
   // output stream (string-prompt mode did — that's what expectUserEcho was
   // for), so the adapter never emits a user turn. Synthesize and broadcast it
@@ -376,7 +438,7 @@ export async function sendCCMessage(input: {
       id: turnId,
       role: 'user',
       origin: { kind: 'user-input' },
-      parts: [{ type: 'text', text: input.content }],
+      parts,
       timestamp: new Date().toISOString()
     }
   })
@@ -388,7 +450,7 @@ export async function sendCCMessage(input: {
   const wasIdle = s.pendingTurns === 0
   s.pendingTurns++
   if (wasIdle) broadcastProcessing(s, true)
-  s.input.push(input.content)
+  s.input.push(content)
 }
 
 // Interrupt the current turn and drop any queued messages, but keep the session

--- a/server/cc-session.ts
+++ b/server/cc-session.ts
@@ -38,7 +38,8 @@ type MessageContent = SDKUserMessage['message']['content']
 // and (b) the display parts we broadcast for the user's bubble. Images become
 // base64 vision blocks; other files are referenced by their temp path so the
 // agent can Read them. Display text stays the user's text (no path note).
-function buildUserMessage(
+// Exported for unit tests.
+export function buildUserMessage(
   text: string,
   uploads: StoredUpload[]
 ): { content: MessageContent; parts: Part[] } {

--- a/server/openclaw-session.ts
+++ b/server/openclaw-session.ts
@@ -27,6 +27,7 @@ import {
 } from './openclaw-adapter'
 import { getGateway, onGatewayReconnected } from './openclaw-gateway'
 import { broadcast } from './state'
+import { materializeToPath, resolveUploads } from './uploads'
 
 type OpenClawSessionKey = string // the gateway-side composite key, e.g. `agent:main:main`
 
@@ -360,6 +361,37 @@ export function viewAsEvents(rec: SessionRecord): StreamEvent[] {
 }
 
 export async function sendOpenClawMessage(input: {
+  workspaceId: string
+  workspacePath: string
+  agentId: string
+  sessionId: string
+  isNew: boolean
+  content: string
+  // Upload ids. Basic support: the gateway's `sessions.send` only takes a string
+  // message, so we materialize each upload to a temp file and append the paths
+  // for the agent to read. Rich vision blocks await a gateway content-block API
+  // (see dev/file-uploads.md).
+  attachments?: string[]
+  optimisticId?: string
+}): Promise<void> {
+  // Fold any attachments into the message text as file-path references.
+  let content = input.content
+  if (input.attachments?.length) {
+    const uploads = resolveUploads(input.workspaceId, input.attachments)
+    const paths: string[] = []
+    for (const u of uploads) {
+      const p = await materializeToPath(u)
+      if (p) paths.push(`- ${u.filename}: ${p}`)
+    }
+    if (paths.length > 0) {
+      content =
+        `${input.content}\n\nThe user attached the following file(s); read them as needed:\n${paths.join('\n')}`.trim()
+    }
+  }
+  return sendOpenClawMessageImpl({ ...input, content })
+}
+
+async function sendOpenClawMessageImpl(input: {
   workspaceId: string
   workspacePath: string
   agentId: string

--- a/server/test/attachments.test.ts
+++ b/server/test/attachments.test.ts
@@ -1,58 +1,366 @@
 import { describe, expect, test } from 'bun:test'
+import sharp from 'sharp'
 
 import { ClaudeAdapter } from '@/lib/claude-adapter'
 import type { Part } from '@/lib/format'
 
-// A persisted user message with an inline base64 image block (what the SDK
-// writes to the session .jsonl when an image is attached) should reconstruct
-// into a `file` part with a data URL, so the attachment re-renders on cold load.
-describe('ClaudeAdapter image attachments', () => {
-  test('base64 image source → file part with data URL', () => {
+import { buildUserMessage } from '../cc-session'
+import {
+  addUpload,
+  materializeToPath,
+  resolveUploads,
+  uploadDataUrl,
+  uploadToDisplayPart
+} from '../uploads'
+
+// Helpers ------------------------------------------------------------------
+
+async function pngBuffer(w: number, h: number) {
+  return sharp({
+    create: { width: w, height: h, channels: 3, background: { r: 10, g: 20, b: 30 } }
+  })
+    .png()
+    .toBuffer()
+}
+
+async function addImage(workspaceId: string, name = 'shot.png') {
+  const bytes = await pngBuffer(3000, 2000)
+  const info = await addUpload({ workspaceId, filename: name, mediaType: 'image/png', bytes })
+  return resolveUploads(workspaceId, [info.id])[0]
+}
+
+function fileParts(parts: Part[]) {
+  return parts.filter((p): p is Extract<Part, { type: 'file' }> => p.type === 'file')
+}
+function textPart(parts: Part[]) {
+  return parts.find((p): p is Extract<Part, { type: 'text' }> => p.type === 'text')
+}
+
+type Block = {
+  type: string
+  text?: string
+  source?: { type?: string; media_type?: string; data?: string }
+}
+function asBlocks(content: string | unknown[]): Block[] {
+  if (typeof content === 'string') throw new Error('expected content blocks, got a string')
+  return content as Block[]
+}
+
+// uploads.ts ---------------------------------------------------------------
+
+describe('uploads: image processing', () => {
+  test('downscales to <=1568px long edge, keeps format + dims', async () => {
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'big.png',
+      mediaType: 'image/png',
+      bytes: await pngBuffer(3000, 2000)
+    })
+    expect(info.kind).toBe('image')
+    expect(info.mediaType).toBe('image/png')
+    expect(info.width).toBe(1568)
+    expect(info.height).toBe(1045)
+  })
+
+  test('does not upscale a small image', async () => {
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'small.png',
+      mediaType: 'image/png',
+      bytes: await pngBuffer(100, 80)
+    })
+    expect(info.width).toBe(100)
+    expect(info.height).toBe(80)
+  })
+
+  test('transcodes a non-vision image type to PNG', async () => {
+    // Feed webp bytes but label as bmp — uploads should transcode to png.
+    const webp = await sharp({
+      create: { width: 64, height: 64, channels: 3, background: { r: 1, g: 2, b: 3 } }
+    })
+      .webp()
+      .toBuffer()
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'x.bmp',
+      mediaType: 'image/bmp',
+      bytes: webp
+    })
+    expect(info.kind).toBe('image')
+    expect(info.mediaType).toBe('image/png')
+  })
+
+  test('passes a GIF through unchanged (no transcode)', async () => {
+    const gifBytes = Buffer.from('GIF89a-not-a-real-gif')
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'a.gif',
+      mediaType: 'image/gif',
+      bytes: gifBytes
+    })
+    expect(info.kind).toBe('image')
+    expect(info.mediaType).toBe('image/gif')
+    const [u] = resolveUploads('ws', [info.id])
+    expect(u.data?.equals(gifBytes)).toBe(true)
+  })
+
+  test('keeps a vision-safe JPEG as JPEG', async () => {
+    const jpeg = await sharp({
+      create: { width: 200, height: 200, channels: 3, background: { r: 5, g: 6, b: 7 } }
+    })
+      .jpeg()
+      .toBuffer()
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'p.jpg',
+      mediaType: 'image/jpeg',
+      bytes: jpeg
+    })
+    expect(info.mediaType).toBe('image/jpeg')
+  })
+})
+
+describe('uploads: non-image files', () => {
+  test('writes bytes to a temp path readable by the agent', async () => {
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'notes.txt',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('hello world')
+    })
+    expect(info.kind).toBe('file')
+    const [u] = resolveUploads('ws', [info.id])
+    expect(u.path).toBeTruthy()
+    expect(await Bun.file(u.path!).text()).toBe('hello world')
+  })
+
+  test('defaults a missing media type to octet-stream', async () => {
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: 'blob.bin',
+      mediaType: '',
+      bytes: Buffer.from([1, 2, 3])
+    })
+    expect(info.mediaType).toBe('application/octet-stream')
+  })
+
+  test('sanitizes path-traversal filenames', async () => {
+    const info = await addUpload({
+      workspaceId: 'ws',
+      filename: '../../etc/passwd',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('x')
+    })
+    expect(info.filename).not.toContain('/')
+    expect(info.filename).not.toContain('..')
+  })
+})
+
+describe('uploads: resolve + display helpers', () => {
+  test('resolveUploads preserves order and drops unknown ids', async () => {
+    const a = await addUpload({
+      workspaceId: 'wsx',
+      filename: 'a.txt',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('a')
+    })
+    const b = await addUpload({
+      workspaceId: 'wsx',
+      filename: 'b.txt',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('b')
+    })
+    const out = resolveUploads('wsx', [b.id, 'nope', a.id])
+    expect(out.map(u => u.filename)).toEqual(['b.txt', 'a.txt'])
+  })
+
+  test('resolveUploads is scoped to its workspace', async () => {
+    const info = await addUpload({
+      workspaceId: 'owner',
+      filename: 'a.txt',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('a')
+    })
+    expect(resolveUploads('intruder', [info.id])).toHaveLength(0)
+    expect(resolveUploads('owner', [info.id])).toHaveLength(1)
+  })
+
+  test('uploadDataUrl returns a data URL for images, null for files', async () => {
+    const img = await addImage('wsd')
+    expect(uploadDataUrl(img)?.startsWith('data:image/png;base64,')).toBe(true)
+    const fileInfo = await addUpload({
+      workspaceId: 'wsd',
+      filename: 'f.txt',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('x')
+    })
+    const [file] = resolveUploads('wsd', [fileInfo.id])
+    expect(uploadDataUrl(file)).toBeNull()
+  })
+
+  test('uploadToDisplayPart: image → data URL, file → path chip', async () => {
+    const img = await addImage('wsp')
+    const imgPart = uploadToDisplayPart(img)
+    expect(imgPart?.type).toBe('file')
+    if (imgPart?.type === 'file') {
+      expect(imgPart.mediaType).toBe('image/png')
+      expect(imgPart.url.startsWith('data:image/png;base64,')).toBe(true)
+    }
+
+    const fileInfo = await addUpload({
+      workspaceId: 'wsp',
+      filename: 'doc.txt',
+      mediaType: 'text/plain',
+      bytes: Buffer.from('x')
+    })
+    const [file] = resolveUploads('wsp', [fileInfo.id])
+    const filePart = uploadToDisplayPart(file)
+    if (filePart?.type === 'file') {
+      expect(filePart.filename).toBe('doc.txt')
+      expect(filePart.url).toBe(file.path)
+    }
+  })
+
+  test('materializeToPath writes image bytes and is idempotent', async () => {
+    const img = await addImage('wsm')
+    const p1 = await materializeToPath(img)
+    expect(p1).toBeTruthy()
+    expect((await Bun.file(p1!).arrayBuffer()).byteLength).toBe(img.data!.byteLength)
+    const p2 = await materializeToPath(img)
+    expect(p2).toBe(p1) // reuses the existing path
+  })
+})
+
+// cc-session: buildUserMessage --------------------------------------------
+
+describe('buildUserMessage', () => {
+  test('no attachments → plain string content', () => {
+    const { content, parts } = buildUserMessage('hi there', [])
+    expect(content).toBe('hi there')
+    expect(parts).toHaveLength(1)
+    expect(textPart(parts)?.text).toBe('hi there')
+  })
+
+  test('image attachment → base64 image block + trailing text block', async () => {
+    const img = await addImage('wsb')
+    const { content, parts } = buildUserMessage('describe', [img])
+    const blocks = asBlocks(content as unknown[])
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].type).toBe('image')
+    expect(blocks[0].source?.type).toBe('base64')
+    expect(blocks[0].source?.media_type).toBe('image/png')
+    expect(blocks[0].source?.data).toBe(img.data!.toString('base64'))
+    expect(blocks[1].type).toBe('text')
+    expect(blocks[1].text).toBe('describe')
+
+    // Display parts: attachment first, then text.
+    expect(parts[0].type).toBe('file')
+    expect(parts[1].type).toBe('text')
+  })
+
+  test('image-only message still ends with a text block', async () => {
+    const img = await addImage('wsb2')
+    const { content, parts } = buildUserMessage('', [img])
+    const blocks = asBlocks(content as unknown[])
+    expect(blocks[0].type).toBe('image')
+    expect(blocks.at(-1)?.type).toBe('text')
+    expect(blocks.at(-1)?.text).toBe('(see attached files)')
+    // No empty text display part for an image-only turn.
+    expect(textPart(parts)).toBeUndefined()
+    expect(fileParts(parts)).toHaveLength(1)
+  })
+
+  test('non-image file → path note appended to the agent text only', async () => {
+    const info = await addUpload({
+      workspaceId: 'wsf',
+      filename: 'report.csv',
+      mediaType: 'text/csv',
+      bytes: Buffer.from('a,b\n1,2')
+    })
+    const [u] = resolveUploads('wsf', [info.id])
+    const { content, parts } = buildUserMessage('summarize this', [u])
+    const blocks = asBlocks(content as unknown[])
+    // Only a text block (no image), carrying the path note.
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('text')
+    expect(blocks[0].text).toContain('summarize this')
+    expect(blocks[0].text).toContain('report.csv')
+    expect(blocks[0].text).toContain(u.path!)
+    // Display text stays the user's text (no path note leaking into the bubble).
+    expect(textPart(parts)?.text).toBe('summarize this')
+    expect(fileParts(parts)).toHaveLength(1)
+  })
+
+  test('mixed image + file → image block then path-note text block', async () => {
+    const img = await addImage('wsmix')
+    const fInfo = await addUpload({
+      workspaceId: 'wsmix',
+      filename: 'data.json',
+      mediaType: 'application/json',
+      bytes: Buffer.from('{}')
+    })
+    const [file] = resolveUploads('wsmix', [fInfo.id])
+    const { content } = buildUserMessage('look', [img, file])
+    const blocks = asBlocks(content as unknown[])
+    expect(blocks[0].type).toBe('image')
+    expect(blocks.at(-1)?.type).toBe('text')
+    expect(blocks.at(-1)?.text).toContain('data.json')
+  })
+})
+
+// Round-trip: build → persist shape → adapter replay ----------------------
+
+describe('persist/reload round-trip', () => {
+  test('image block built for the agent re-parses into a file part', async () => {
+    const img = await addImage('wsr')
+    const { content } = buildUserMessage('hi', [img])
+    // Simulate what the SDK persists to the session .jsonl: a user message whose
+    // content is exactly the blocks we sent.
+    const adapter = new ClaudeAdapter()
+    const events = adapter.ingest({ type: 'user', uuid: 'r1', message: { role: 'user', content } })
+    const turn = events.find(e => e.kind === 'turn')
+    if (turn?.kind !== 'turn') throw new Error('expected a turn')
+    const file = fileParts(turn.turn.parts)[0]
+    expect(file.mediaType).toBe('image/png')
+    expect(file.url).toBe(`data:image/png;base64,${img.data!.toString('base64')}`)
+  })
+
+  test('persisted base64 document (PDF) block → file part', () => {
     const adapter = new ClaudeAdapter()
     const events = adapter.ingest({
       type: 'user',
-      uuid: 'u1',
+      uuid: 'r2',
       message: {
         role: 'user',
         content: [
           {
-            type: 'image',
-            source: { type: 'base64', media_type: 'image/png', data: 'AAAA' }
-          },
-          { type: 'text', text: 'what is this?' }
+            type: 'document',
+            source: { type: 'base64', media_type: 'application/pdf', data: 'JVBER' },
+            filename: 'spec.pdf'
+          }
         ]
       }
     })
-
     const turn = events.find(e => e.kind === 'turn')
-    expect(turn).toBeDefined()
-    if (turn?.kind !== 'turn') throw new Error('expected a turn event')
-
-    const parts = turn.turn.parts
-    const file = parts.find((p): p is Extract<Part, { type: 'file' }> => p.type === 'file')
-    expect(file).toBeDefined()
-    expect(file?.mediaType).toBe('image/png')
-    expect(file?.url).toBe('data:image/png;base64,AAAA')
-
-    const text = parts.find(p => p.type === 'text')
-    expect(text).toBeDefined()
+    if (turn?.kind !== 'turn') throw new Error('expected a turn')
+    const file = fileParts(turn.turn.parts)[0]
+    expect(file.mediaType).toBe('application/pdf')
+    expect(file.url).toBe('data:application/pdf;base64,JVBER')
+    expect(file.filename).toBe('spec.pdf')
   })
 
-  test('image block with a bare url is passed through', () => {
+  test('bare-url image block is passed through unchanged', () => {
     const adapter = new ClaudeAdapter()
     const events = adapter.ingest({
       type: 'user',
-      uuid: 'u2',
+      uuid: 'r3',
       message: {
         role: 'user',
         content: [{ type: 'image', media_type: 'image/jpeg', url: 'https://x/y.jpg' }]
       }
     })
     const turn = events.find(e => e.kind === 'turn')
-    if (turn?.kind !== 'turn') throw new Error('expected a turn event')
-    const file = turn.turn.parts.find(
-      (p): p is Extract<Part, { type: 'file' }> => p.type === 'file'
-    )
-    expect(file?.url).toBe('https://x/y.jpg')
+    if (turn?.kind !== 'turn') throw new Error('expected a turn')
+    expect(fileParts(turn.turn.parts)[0].url).toBe('https://x/y.jpg')
   })
 })

--- a/server/test/attachments.test.ts
+++ b/server/test/attachments.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+
+import { ClaudeAdapter } from '@/lib/claude-adapter'
+import type { Part } from '@/lib/format'
+
+// A persisted user message with an inline base64 image block (what the SDK
+// writes to the session .jsonl when an image is attached) should reconstruct
+// into a `file` part with a data URL, so the attachment re-renders on cold load.
+describe('ClaudeAdapter image attachments', () => {
+  test('base64 image source → file part with data URL', () => {
+    const adapter = new ClaudeAdapter()
+    const events = adapter.ingest({
+      type: 'user',
+      uuid: 'u1',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: 'AAAA' }
+          },
+          { type: 'text', text: 'what is this?' }
+        ]
+      }
+    })
+
+    const turn = events.find(e => e.kind === 'turn')
+    expect(turn).toBeDefined()
+    if (turn?.kind !== 'turn') throw new Error('expected a turn event')
+
+    const parts = turn.turn.parts
+    const file = parts.find((p): p is Extract<Part, { type: 'file' }> => p.type === 'file')
+    expect(file).toBeDefined()
+    expect(file?.mediaType).toBe('image/png')
+    expect(file?.url).toBe('data:image/png;base64,AAAA')
+
+    const text = parts.find(p => p.type === 'text')
+    expect(text).toBeDefined()
+  })
+
+  test('image block with a bare url is passed through', () => {
+    const adapter = new ClaudeAdapter()
+    const events = adapter.ingest({
+      type: 'user',
+      uuid: 'u2',
+      message: {
+        role: 'user',
+        content: [{ type: 'image', media_type: 'image/jpeg', url: 'https://x/y.jpg' }]
+      }
+    })
+    const turn = events.find(e => e.kind === 'turn')
+    if (turn?.kind !== 'turn') throw new Error('expected a turn event')
+    const file = turn.turn.parts.find(
+      (p): p is Extract<Part, { type: 'file' }> => p.type === 'file'
+    )
+    expect(file?.url).toBe('https://x/y.jpg')
+  })
+})

--- a/server/uploads.ts
+++ b/server/uploads.ts
@@ -1,0 +1,206 @@
+// In-memory store for chat attachments uploaded ahead of a message.
+//
+// Flow: the client POSTs files to /api/workspaces/:id/uploads *before* (or while
+// composing) a chat message; we process them here and hand back a lightweight
+// `UploadInfo` with an opaque `id`. The chat WS frame then references those ids,
+// and `cc-session` resolves them back to bytes when it builds the agent message.
+//
+// Why a store and not base64-over-the-WS: keeps chat frames small (a 4 MB
+// screenshot would otherwise bloat every broadcast), lets us downscale images
+// with sharp once at upload time, and gives the agent a real file path for
+// non-image attachments. Entries are evicted on a TTL so unsent uploads don't
+// leak — the bytes are short-lived; once the agent message is built the durable
+// copy is the base64 block the SDK persists to the session `.jsonl`.
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import sharp from 'sharp'
+
+import type { Part } from '@/lib/format'
+import type { UploadInfo, UploadKind } from '@/lib/types'
+
+// Media types Claude vision accepts directly. Anything else that is still an
+// image gets transcoded to PNG; non-images are delivered as a file path.
+const VISION_MEDIA_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
+
+// Anthropic recommends a long edge <= 1568px for the best cost/latency without
+// quality loss — larger images are downscaled to fit. GIFs pass through (sharp
+// animation handling is heavier and rarely needed for attachments).
+const MAX_IMAGE_EDGE = 1568
+// Per-file ceiling for the raw upload (post-resize images are far smaller).
+export const MAX_UPLOAD_BYTES = 32 * 1024 * 1024
+const TTL_MS = 30 * 60_000
+
+export type StoredUpload = {
+  id: string
+  workspaceId: string
+  kind: UploadKind
+  mediaType: string
+  filename: string
+  size: number
+  width?: number
+  height?: number
+  // For images: the (possibly transcoded/resized) bytes, base64-inlined into the
+  // agent message. For files: undefined — see `path`.
+  data?: Buffer
+  // For non-image files: an absolute temp path the agent can `Read`.
+  path?: string
+  createdAt: number
+}
+
+const uploads = new Map<string, StoredUpload>()
+
+function evictExpired() {
+  const now = Date.now()
+  for (const [id, u] of uploads) {
+    if (now - u.createdAt > TTL_MS) uploads.delete(id)
+  }
+}
+
+function sanitizeFilename(name: string): string {
+  // Strip path separators and control chars; keep it human-readable for the
+  // temp filename and the display label.
+  const base = name.split(/[\\/]/).pop() ?? 'file'
+  return base.replace(/[^\w.\-() ]+/g, '_').slice(0, 200) || 'file'
+}
+
+// Process one uploaded file into a StoredUpload. Images are normalized to a
+// vision-safe media type and downscaled; everything else is written to a temp
+// file the agent can open.
+export async function addUpload(input: {
+  workspaceId: string
+  filename: string
+  mediaType: string
+  bytes: Buffer
+}): Promise<UploadInfo> {
+  evictExpired()
+  const id = crypto.randomUUID()
+  const filename = sanitizeFilename(input.filename)
+  const isImage = input.mediaType.startsWith('image/')
+
+  if (isImage && input.mediaType !== 'image/gif') {
+    // Resize to fit MAX_IMAGE_EDGE and re-encode. Keep the format when it's
+    // vision-safe; otherwise (heic, avif, bmp, …) transcode to PNG.
+    const keepFormat = VISION_MEDIA_TYPES.has(input.mediaType)
+    const pipeline = sharp(input.bytes).rotate().resize(MAX_IMAGE_EDGE, MAX_IMAGE_EDGE, {
+      fit: 'inside',
+      withoutEnlargement: true
+    })
+    const out = keepFormat ? pipeline : pipeline.png()
+    const { data, info } = await out.toBuffer({ resolveWithObject: true })
+    const mediaType = keepFormat ? input.mediaType : 'image/png'
+    const stored: StoredUpload = {
+      id,
+      workspaceId: input.workspaceId,
+      kind: 'image',
+      mediaType,
+      filename,
+      size: data.byteLength,
+      width: info.width,
+      height: info.height,
+      data,
+      createdAt: Date.now()
+    }
+    uploads.set(id, stored)
+    return toInfo(stored)
+  }
+
+  if (input.mediaType === 'image/gif') {
+    const meta = await sharp(input.bytes)
+      .metadata()
+      .catch(() => null)
+    const stored: StoredUpload = {
+      id,
+      workspaceId: input.workspaceId,
+      kind: 'image',
+      mediaType: 'image/gif',
+      filename,
+      size: input.bytes.byteLength,
+      width: meta?.width,
+      height: meta?.height,
+      data: input.bytes,
+      createdAt: Date.now()
+    }
+    uploads.set(id, stored)
+    return toInfo(stored)
+  }
+
+  // Non-image: persist to a temp file and reference it by path. The agent reads
+  // it with its Read tool; we don't inline arbitrary file bytes into the prompt.
+  const dir = join(tmpdir(), 'moi-uploads', id)
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, filename)
+  await writeFile(path, input.bytes)
+  const stored: StoredUpload = {
+    id,
+    workspaceId: input.workspaceId,
+    kind: 'file',
+    mediaType: input.mediaType || 'application/octet-stream',
+    filename,
+    size: input.bytes.byteLength,
+    path,
+    createdAt: Date.now()
+  }
+  uploads.set(id, stored)
+  return toInfo(stored)
+}
+
+function toInfo(u: StoredUpload): UploadInfo {
+  return {
+    id: u.id,
+    kind: u.kind,
+    mediaType: u.mediaType,
+    filename: u.filename,
+    size: u.size,
+    ...(u.width != null ? { width: u.width } : {}),
+    ...(u.height != null ? { height: u.height } : {})
+  }
+}
+
+// Resolve upload ids to their stored records (skipping unknown/expired ids and
+// any that don't belong to the workspace). Order follows the input ids.
+export function resolveUploads(workspaceId: string, ids: string[]): StoredUpload[] {
+  evictExpired()
+  const out: StoredUpload[] = []
+  for (const id of ids) {
+    const u = uploads.get(id)
+    if (u && u.workspaceId === workspaceId) out.push(u)
+  }
+  return out
+}
+
+// Ensure an upload exists as a real file on disk and return its absolute path.
+// Images live in memory by default (they're inlined as base64 for Claude); some
+// adapters (e.g. OpenClaw, whose gateway only accepts a string message) need a
+// path instead, so we lazily write the bytes out here.
+export async function materializeToPath(u: StoredUpload): Promise<string | null> {
+  if (u.path) return u.path
+  if (!u.data) return null
+  const dir = join(tmpdir(), 'moi-uploads', u.id)
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, u.filename)
+  await writeFile(path, u.data)
+  u.path = path
+  return path
+}
+
+// A base64 data URL for an image upload, used both for live display (the user
+// turn we broadcast) and as the inline source for the agent message.
+export function uploadDataUrl(u: StoredUpload): string | null {
+  if (!u.data) return null
+  return `data:${u.mediaType};base64,${u.data.toString('base64')}`
+}
+
+// The display `Part` for one upload — an inline image thumbnail (data URL) or a
+// labelled file chip. Mirrors what the adapter reconstructs from a persisted
+// message, so live and reloaded transcripts render identically.
+export function uploadToDisplayPart(u: StoredUpload): Part | null {
+  if (u.kind === 'image') {
+    const url = uploadDataUrl(u)
+    if (!url) return null
+    return { type: 'file', mediaType: u.mediaType, url, filename: u.filename }
+  }
+  // Non-image: a chip pointing at the temp path (no inline bytes).
+  return { type: 'file', mediaType: u.mediaType, url: u.path ?? '', filename: u.filename }
+}

--- a/server/web.ts
+++ b/server/web.ts
@@ -44,6 +44,7 @@ function isClientMessage(value: unknown): value is ClientMessage {
     optimisticId?: unknown
     model?: unknown
     effort?: unknown
+    attachments?: unknown
     opId?: unknown
   }
   if (v.type === 'chat')
@@ -54,7 +55,9 @@ function isClientMessage(value: unknown): value is ClientMessage {
       typeof v.isNew === 'boolean' &&
       (v.optimisticId === undefined || typeof v.optimisticId === 'string') &&
       (v.model === undefined || typeof v.model === 'string') &&
-      (v.effort === undefined || typeof v.effort === 'string')
+      (v.effort === undefined || typeof v.effort === 'string') &&
+      (v.attachments === undefined ||
+        (Array.isArray(v.attachments) && v.attachments.every(a => typeof a === 'string')))
     )
   if (v.type === 'stop') return typeof v.workspaceId === 'string' && typeof v.sessionId === 'string'
   if (v.type === 'scratchpad:op-result') return typeof v.opId === 'string'
@@ -121,7 +124,8 @@ export const app = Bun.serve<WsData>({
         const data = JSON.parse(String(message))
         if (!isClientMessage(data)) return
 
-        if (data.type === 'chat' && data.content?.trim()) {
+        // Allow a message that carries only attachments (no text).
+        if (data.type === 'chat' && (data.content?.trim() || data.attachments?.length)) {
           const workspace = await getWorkspace(data.workspaceId)
           if (!workspace) return
           if (workspace.type === 'openclaw' && workspace.agentId) {
@@ -132,6 +136,7 @@ export const app = Bun.serve<WsData>({
               sessionId: data.sessionId,
               isNew: data.isNew,
               content: data.content.trim(),
+              attachments: data.attachments,
               optimisticId: data.optimisticId
             })
           } else {
@@ -141,6 +146,7 @@ export const app = Bun.serve<WsData>({
               sessionId: data.sessionId,
               isNew: data.isNew,
               content: data.content.trim(),
+              attachments: data.attachments,
               optimisticId: data.optimisticId,
               model: data.model,
               effort: data.effort


### PR DESCRIPTION
## Summary

Implements drag-drop, paste, and attach-button support for files and images in the chat composer. Attachments are uploaded immediately to a server-side store, processed (images downscaled/transcoded), and referenced by opaque IDs in chat frames. Images are inlined as base64 vision blocks in agent messages; other files are written to temp paths the agent can read.

## Key Changes

**Server-side upload pipeline:**
- `server/uploads.ts` — New in-memory upload store with TTL eviction. Processes images with `sharp` (downscale to ≤1568px, transcode non-vision types to PNG, pass through GIFs). Non-image files written to temp paths. Exports `addUpload()`, `resolveUploads()`, `materializeToPath()`, and display helpers.
- `server/api.ts` — New `POST /api/workspaces/:id/uploads` endpoint accepting multipart form data. Validates file count (≤20) and size (≤32MB per file).
- `server/cc-session.ts` — New `buildUserMessage()` helper converts text + resolved uploads into agent content blocks (base64 image blocks + file-path text references) and display parts. Updated `sendCCMessage()` to accept and process `attachments` IDs.
- `server/openclaw-session.ts` — Basic OpenClaw support: materializes uploads to temp files and appends paths to message text (awaits gateway content-block API for rich vision support).

**Client-side composer:**
- `client/components/ChatInput.tsx` — Drag-drop, paste, and attach-button file input. Displays attachment thumbnails (images) and file chips with upload spinners/error states. Disables send while uploads are in flight.
- `client/lib/uploads.ts` — New `uploadFiles()` helper POSTs files to the server endpoint.
- `client/store/live.ts` — New `ChatAttachment` type and `attachments` state (keyed per thread like drafts). Tracks upload status (`uploading` | `ready` | `error`), server handle, and preview URLs. Methods: `addAttachments()`, `updateAttachment()`, `removeAttachment()`, `clearAttachments()`.
- `client/hooks/useChat.ts` — Updated `send()` to include ready attachments in the chat frame and clear them after send.

**Display and persistence:**
- `client/components/TurnView.tsx` — Renders image thumbnails and file chips in user turns. Images display inline; files show a labeled chip.
- `lib/claude-adapter.ts` — Updated to parse persisted base64 image/document blocks (from SDK `.jsonl`) back into `file` parts with data URLs, so attachments survive cold reload.
- `lib/types.ts` — New `UploadInfo` and `UploadKind` types.

**Testing & documentation:**
- `server/test/attachments.test.ts` — Tests that persisted base64 image blocks reconstruct into file parts with data URLs.
- `dev/file-uploads.md` — Comprehensive guide covering the pipeline, SDK expectations, adapter integration, and future work (PDFs, richer previews, OpenClaw gateway upgrade).

## Implementation Details

- **Upload store TTL**: 30 minutes. Bytes are short-lived; the durable copy is the base64 block the SDK persists to the session `.jsonl`.
- **Image processing**: Downscaled to fit ≤1568px long edge (Anthropic's recommendation), re-encoded to vision-safe types (JPEG/PNG/GIF/WebP) or transcoded to PNG. GIFs pass through unchanged.
- **File handling**: Non-image files are written to `$TMPDIR/moi-uploads/{id}/{filename}` and referenced by path in agent prompts.
- **Display parts**: Attachments render as `file` parts (type, mediaType, url, filename) in both live and persisted turns, enabling consistent rendering across reload.
- **Adapter-agnostic client**: The composer and live store are fully independent of the backend; only the server-side send path and replay adapter are per-backend.

https://claude.ai/code/session_01NyZCFFTAXqBVpZSYpgXoYX