### PR TITLE
Add workspace creation UI and unify provisioning logic

### DIFF
--- a/client/api/workspaces.ts
+++ b/client/api/workspaces.ts
@@ -34,6 +34,7 @@ export type WorkspaceLayoutResponse = WorkspaceLayout & {
 export const workspaceKeys = {
   all: ['workspaces'] as const,
   discover: ['workspaces', 'discover'] as const,
+  createInfo: ['workspaces', 'create-info'] as const,
   preview: (id: string) => ['workspaces', 'preview', id] as const,
   layout: (id: string) => ['workspaces', 'layout', id] as const,
   widgets: (id: string) => ['workspaces', 'widgets', id] as const,
@@ -356,6 +357,9 @@ export function useAddWorkspace() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(discovered)
       })
+      // The server provisions (skills + `.moi/`) before registering, so a
+      // failure comes back as a plain-text error, not an entry.
+      if (!res.ok) throw new Error(await res.text())
       return res.json()
     },
     onSuccess: (entry, suggestion) => {
@@ -363,6 +367,46 @@ export function useAddWorkspace() {
       qc.setQueryData<DiscoveredWorkspace[]>(workspaceKeys.discover, prev =>
         (prev ?? []).filter(s => s.path !== suggestion.path)
       )
+    }
+  })
+}
+
+// Where `/workspace/create` places new folders on disk. `displayRoot` is the
+// home-relative form (e.g. "~/moi") shown in the create form.
+export type CreateWorkspaceInfo = {
+  root: string
+  displayRoot: string
+}
+
+export function useCreateWorkspaceInfo() {
+  return useQuery<CreateWorkspaceInfo>({
+    queryKey: workspaceKeys.createInfo,
+    queryFn: () => fetch('/api/workspaces/create').then(r => r.json()),
+    staleTime: Infinity
+  })
+}
+
+export type CreateWorkspaceInput = {
+  name: string
+  type: WorkspaceType
+}
+
+// Create a brand-new workspace folder (server provisions skills + `.moi/` and
+// registers it). Non-2xx responses carry a user-facing message in the body.
+export function useCreateWorkspace() {
+  const qc = useQueryClient()
+  return useMutation<WorkspaceEntry, Error, CreateWorkspaceInput>({
+    mutationFn: async input => {
+      const res = await fetch('/api/workspaces/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input)
+      })
+      if (!res.ok) throw new Error(await res.text())
+      return res.json()
+    },
+    onSuccess: entry => {
+      qc.setQueryData<WorkspaceEntry[]>(workspaceKeys.all, prev => [...(prev ?? []), entry])
     }
   })
 }

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -8,6 +8,7 @@ import { HomePage } from './HomePage'
 import { PlaygroundPage } from './playground/PlaygroundPage'
 import { ToolCallsPage } from './playground/ToolCallsPage'
 import { WorkspaceRoute } from './routes/workspace/[id]'
+import { CreateWorkspacePage } from './routes/workspace/create'
 
 // Top-level router — sets up all client-side routes
 export function AppRouter() {
@@ -25,6 +26,9 @@ export function AppRouter() {
       <Route path="/" component={HomePage} />
       <Route path="/playground/tool-calls" component={ToolCallsPage} />
       <Route path="/playground" component={PlaygroundPage} />
+      {/* Must precede `/workspace/:id` — the Switch matches in order, so the
+          literal route wins over the id pattern. */}
+      <Route path="/workspace/create" component={CreateWorkspacePage} />
       <Route path="/workspace/:id">
         {/* Key by id so switching workspaces mounts a fresh subtree — the
             per-workspace chat store (and its websocket) tears down and resets

--- a/client/components/WorkspacesPage.tsx
+++ b/client/components/WorkspacesPage.tsx
@@ -1,4 +1,5 @@
 import { IconDots, IconLoader2, IconPlus, IconTrash } from '@tabler/icons-react'
+import { Link } from 'wouter'
 
 import {
   useAddWorkspace,
@@ -21,19 +22,24 @@ import type { DiscoveredWorkspace, WorkspaceEntry, WorkspaceType } from '@/lib/t
 
 import { WorkspacePreview } from './WorkspacePreview'
 
-const typeIconSrc: Record<WorkspaceType, string> = {
+export const typeIconSrc: Record<WorkspaceType, string> = {
   'claude-code': claudeIcon,
   openclaw: openclawIcon,
   hermes: hermesIcon
 }
 
-const typeLabel: Record<WorkspaceType, string> = {
+export const typeLabel: Record<WorkspaceType, string> = {
   'claude-code': 'Claude Code',
   openclaw: 'OpenClaw',
   hermes: 'Hermes'
 }
 
-function TypeIcon({ type, className }: { type: WorkspaceType; className?: string }) {
+type TypeIconProps = {
+  type: WorkspaceType
+  className?: string
+}
+
+export function TypeIcon({ type, className }: TypeIconProps) {
   return (
     <img
       src={typeIconSrc[type]}
@@ -74,22 +80,21 @@ export function WorkspacesPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-8 pt-14 pb-16">
-      {count > 0 && (
-        <div className="mb-10 grid grid-cols-2 gap-3">
-          {workspaces.map(ws => (
-            <WorkspaceCard
-              key={ws.id}
-              workspace={ws}
-              onRemove={entry => removeMutation.mutate(entry)}
-            />
-          ))}
-        </div>
-      )}
+      <div className="mb-10 grid grid-cols-2 gap-3">
+        {workspaces.map(ws => (
+          <WorkspaceCard
+            key={ws.id}
+            workspace={ws}
+            onRemove={entry => removeMutation.mutate(entry)}
+          />
+        ))}
+        <NewWorkspaceCard />
+      </div>
 
       {count === 0 && discovered.length === 0 && (
         <p className="mb-10 text-sm text-muted-foreground">
-          No workspaces yet. Run{' '}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">moi start</code> in a
+          No workspaces yet. Create one above, or run{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">moi init</code> in a
           project directory.
         </p>
       )}
@@ -110,6 +115,9 @@ export function WorkspacesPage() {
               />
             ))}
           </ul>
+          {importMutation.isError && (
+            <p className="mt-3 text-xs text-destructive">{importMutation.error.message}</p>
+          )}
         </section>
       )}
     </div>
@@ -184,6 +192,23 @@ function WorkspaceCard({ workspace, onRemove }: WorkspaceCardProps) {
         <div className="text-xs text-muted-foreground">{meta}</div>
       </div>
     </a>
+  )
+}
+
+// Dashed grid cell linking to the create view — always the grid's last card,
+// and the only card on a fresh install.
+function NewWorkspaceCard() {
+  return (
+    <Link
+      href="/workspace/create"
+      className={cn(
+        'flex min-h-28 items-center justify-center gap-2 rounded-xl border border-dashed border-border',
+        'text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground'
+      )}
+    >
+      <IconPlus size={16} stroke={1.5} />
+      New workspace
+    </Link>
   )
 }
 

--- a/client/components/WorkspacesPage.tsx
+++ b/client/components/WorkspacesPage.tsx
@@ -1,5 +1,4 @@
 import { IconDots, IconLoader2, IconPlus, IconTrash } from '@tabler/icons-react'
-import { Link } from 'wouter'
 
 import {
   useAddWorkspace,
@@ -80,20 +79,21 @@ export function WorkspacesPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl px-8 pt-14 pb-16">
-      <div className="mb-10 grid grid-cols-2 gap-3">
-        {workspaces.map(ws => (
-          <WorkspaceCard
-            key={ws.id}
-            workspace={ws}
-            onRemove={entry => removeMutation.mutate(entry)}
-          />
-        ))}
-        <NewWorkspaceCard />
-      </div>
+      {count > 0 && (
+        <div className="mb-10 grid grid-cols-2 gap-3">
+          {workspaces.map(ws => (
+            <WorkspaceCard
+              key={ws.id}
+              workspace={ws}
+              onRemove={entry => removeMutation.mutate(entry)}
+            />
+          ))}
+        </div>
+      )}
 
       {count === 0 && discovered.length === 0 && (
         <p className="mb-10 text-sm text-muted-foreground">
-          No workspaces yet. Create one above, or run{' '}
+          No workspaces yet. Run{' '}
           <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">moi init</code> in a
           project directory.
         </p>
@@ -192,23 +192,6 @@ function WorkspaceCard({ workspace, onRemove }: WorkspaceCardProps) {
         <div className="text-xs text-muted-foreground">{meta}</div>
       </div>
     </a>
-  )
-}
-
-// Dashed grid cell linking to the create view — always the grid's last card,
-// and the only card on a fresh install.
-function NewWorkspaceCard() {
-  return (
-    <Link
-      href="/workspace/create"
-      className={cn(
-        'flex min-h-28 items-center justify-center gap-2 rounded-xl border border-dashed border-border',
-        'text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground'
-      )}
-    >
-      <IconPlus size={16} stroke={1.5} />
-      New workspace
-    </Link>
   )
 }
 

--- a/client/components/layout/SidebarLayout.tsx
+++ b/client/components/layout/SidebarLayout.tsx
@@ -185,7 +185,7 @@ function Sidebar({ collapsed, workspaces, logoEffect }: SidebarProps) {
         <div className={cn('flex items-center justify-between pl-2', collapsed && 'invisible')}>
           <span className="text-[13px] font-medium text-muted-foreground">Workspaces</span>
           <Link
-            href="/"
+            href="/workspace/create"
             aria-label="Add workspace"
             className="flex size-6 items-center justify-center rounded-[6px] border border-border bg-background text-foreground/60 hover:bg-muted hover:text-foreground"
           >

--- a/client/components/routes/workspace/create.tsx
+++ b/client/components/routes/workspace/create.tsx
@@ -1,0 +1,155 @@
+import { type FormEvent, useState } from 'react'
+
+import { IconLoader2, IconPlus } from '@tabler/icons-react'
+import { useLocation } from 'wouter'
+
+import { useCreateWorkspace, useCreateWorkspaceInfo } from '@/client/api/workspaces'
+import { TypeIcon, typeLabel } from '@/client/components/WorkspacesPage'
+import { PanelHeader, SidebarLayout, SidebarToggle } from '@/client/components/layout/SidebarLayout'
+import { Button } from '@/client/components/ui/button'
+import { Input } from '@/client/components/ui/input'
+import { cn } from '@/client/lib/cn'
+import type { WorkspaceType } from '@/lib/types'
+
+// Mirrors the server's validateWorkspaceFolderName (workspace-init.ts) for
+// instant feedback; the server remains the authority and re-validates.
+function folderNameError(name: string): string | null {
+  if (!name) return null // an empty field just disables the submit, no nagging
+  if (name.length > 64) return 'Folder name is too long (max 64 characters)'
+  if (!/^[A-Za-z0-9][A-Za-z0-9._ -]*$/.test(name)) {
+    return 'Use letters, numbers, dots, dashes, underscores and spaces, starting with a letter or number'
+  }
+  if (name.endsWith('.') || name.endsWith(' ')) return 'Folder name cannot end with a dot or space'
+  return null
+}
+
+type AgentOption = {
+  type: WorkspaceType
+  hint: string
+  disabled?: boolean
+}
+
+// Only Claude Code workspaces can be created from scratch for now. OpenClaw
+// workspaces belong to their agents — they arrive via discovery on the home
+// page — and Hermes has no init path yet.
+const AGENT_OPTIONS: AgentOption[] = [
+  { type: 'claude-code', hint: 'Powered by the Claude Agent SDK' },
+  { type: 'openclaw', hint: 'Import a discovered agent from Home', disabled: true },
+  { type: 'hermes', hint: 'Coming soon', disabled: true }
+]
+
+// The `/workspace/create` route: name a folder, get a provisioned (skills +
+// `.moi/` scaffold) and registered workspace under the server's workspaces
+// root, then land in it.
+export function CreateWorkspacePage() {
+  const [, navigate] = useLocation()
+  const info = useCreateWorkspaceInfo()
+  const createMutation = useCreateWorkspace()
+
+  const [name, setName] = useState('')
+  const [type, setType] = useState<WorkspaceType>('claude-code')
+
+  const trimmed = name.trim()
+  const nameError = folderNameError(trimmed)
+  const canSubmit = trimmed.length > 0 && !nameError && !createMutation.isPending
+  const root = info.data?.displayRoot ?? '…'
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    createMutation.mutate(
+      { name: trimmed, type },
+      { onSuccess: entry => navigate(`/workspace/${entry.id}`) }
+    )
+  }
+
+  return (
+    <SidebarLayout>
+      <PanelHeader>
+        <SidebarToggle />
+        <span className="text-sm font-medium text-foreground">New workspace</span>
+      </PanelHeader>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <form onSubmit={handleSubmit} className="mx-auto w-full max-w-xl px-8 pt-14 pb-16">
+          <h1 className="mb-1.5 text-base font-semibold text-foreground">Create a workspace</h1>
+          <p className="mb-8 text-sm text-muted-foreground">
+            A new folder in <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{root}</code>,
+            set up with moi skills and widgets, ready to chat.
+          </p>
+
+          <fieldset className="mb-6">
+            <legend className="mb-2 text-sm font-medium text-foreground">Agent</legend>
+            <div className="grid grid-cols-3 gap-2">
+              {AGENT_OPTIONS.map(option => (
+                <button
+                  key={option.type}
+                  type="button"
+                  disabled={option.disabled}
+                  onClick={() => setType(option.type)}
+                  aria-pressed={type === option.type}
+                  className={cn(
+                    'flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors',
+                    type === option.type
+                      ? 'border-ring bg-muted/50 shadow-[inset_0_0_0_1px_var(--ring)]'
+                      : 'border-border hover:bg-muted/40',
+                    option.disabled && 'cursor-not-allowed opacity-50 hover:bg-transparent'
+                  )}
+                >
+                  <span className="flex items-center gap-2">
+                    <TypeIcon type={option.type} />
+                    <span className="text-sm font-medium text-foreground">
+                      {typeLabel[option.type]}
+                    </span>
+                  </span>
+                  <span className="text-xs text-muted-foreground">{option.hint}</span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="mb-2">
+            <label htmlFor="workspace-name" className="mb-2 block text-sm font-medium text-foreground">
+              Folder name
+            </label>
+            <Input
+              id="workspace-name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="my-workspace"
+              autoFocus
+              aria-invalid={!!nameError}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+          {nameError ? (
+            <p className="mb-6 text-xs text-destructive">{nameError}</p>
+          ) : (
+            <p className="mb-6 font-mono text-xs text-muted-foreground">
+              {root}/{trimmed || 'my-workspace'}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3">
+            <Button type="submit" disabled={!canSubmit}>
+              {createMutation.isPending ? (
+                <IconLoader2 stroke={1.5} className="animate-spin" />
+              ) : (
+                <IconPlus stroke={1.5} />
+              )}
+              Create workspace
+            </Button>
+            {createMutation.isPending && (
+              <span className="text-xs text-muted-foreground">
+                Setting up skills and widgets…
+              </span>
+            )}
+          </div>
+          {createMutation.isError && (
+            <p className="mt-3 text-xs text-destructive">{createMutation.error.message}</p>
+          )}
+        </form>
+      </div>
+    </SidebarLayout>
+  )
+}

--- a/server/api.ts
+++ b/server/api.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono'
 import { serveStatic } from 'hono/bun'
 import { createMiddleware } from 'hono/factory'
-import { basename } from 'node:path'
+import { existsSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
 
 import type {
   EnvScope,
@@ -27,7 +28,8 @@ import {
   getWorkspace,
   listWorkspaces,
   registerWorkspace,
-  removeWorkspace
+  removeWorkspace,
+  tildify
 } from './registry'
 import { loadScratchpadDoc, saveScratchpadDoc } from './scratchpad'
 import { DIST_DIR, prebuilt } from './static'
@@ -39,6 +41,11 @@ import { MAX_UPLOAD_BYTES, addUpload, getUpload } from './uploads'
 import { collectViewRequiredEnv, listViews, serveView } from './views'
 import { collectRequiredEnv, listWidgets, serveWidget } from './widgets'
 import { getWorkspaceConfig, setWorkspaceConfig } from './workspace-config'
+import {
+  CREATED_WORKSPACES_ROOT,
+  provisionWorkspace,
+  validateWorkspaceFolderName
+} from './workspace-init'
 import {
   getWorkspaceEnvView,
   isValidEnvKey,
@@ -500,7 +507,17 @@ workspaces.post('/', async c => {
   if (!body?.path) return c.text('Missing path', 400)
   const rawType = body?.type
   const type = rawType === 'claude-code' || rawType === 'openclaw' ? rawType : undefined
-  const entry = await registerWorkspace(String(body.path), {
+  const path = resolve(String(body.path))
+  // Importing IS initializing: lay down the bundled skills (in the backend's
+  // skills dir) and the `.moi/` scaffold, exactly like `moi init` — a workspace
+  // added from the UI must be indistinguishable from one added via the CLI.
+  try {
+    await provisionWorkspace(path, type)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return c.text(`Could not initialize workspace: ${message}`, 500)
+  }
+  const entry = await registerWorkspace(path, {
     type,
     name: typeof body?.name === 'string' ? body.name : undefined,
     agentId: typeof body?.agentId === 'string' ? body.agentId : undefined,
@@ -511,6 +528,38 @@ workspaces.post('/', async c => {
 })
 
 workspaces.get('/discover', async c => c.json(await discoverWorkspaces()))
+
+// Where `/workspace/create` places new folders — the client shows the resolved
+// location while the user types a name.
+workspaces.get('/create', c =>
+  c.json({ root: CREATED_WORKSPACES_ROOT, displayRoot: tildify(CREATED_WORKSPACES_ROOT) })
+)
+
+// Create a brand-new workspace: a fresh folder under CREATED_WORKSPACES_ROOT,
+// provisioned (skills + `.moi/` scaffold) and registered. Claude Code only for
+// now — OpenClaw workspaces belong to their agents and arrive via discovery.
+workspaces.post('/create', async c => {
+  const body = await c.req.json()
+  const type = body?.type ?? 'claude-code'
+  if (type !== 'claude-code') {
+    return c.text('Only Claude Code workspaces can be created for now', 400)
+  }
+  const name = typeof body?.name === 'string' ? body.name.trim() : ''
+  const invalid = validateWorkspaceFolderName(name)
+  if (invalid) return c.text(invalid, 400)
+  const path = join(CREATED_WORKSPACES_ROOT, name)
+  if (existsSync(path)) return c.text('A folder with that name already exists', 409)
+  try {
+    await provisionWorkspace(path, 'claude-code')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return c.text(`Could not create workspace: ${message}`, 500)
+  }
+  const entry = await registerWorkspace(path, { type: 'claude-code' })
+  // Nudge every connected client (the sidebar list) to refetch.
+  publishEvent({ type: 'workspace:updated' })
+  return c.json(entry, 201)
+})
 
 // `/:id` is registered after the static `/discover` so the literal path wins.
 // `/api/workspaces/ws` (the live-event WebSocket) is intercepted by Bun's routes

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -2,7 +2,6 @@
 import './cli-colors' // must precede citty: sets NO_COLOR before its color flag is computed
 import { defineCommand, runMain, showUsage } from 'citty'
 import { existsSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'path'
 import pc from 'picocolors'
@@ -19,18 +18,18 @@ import type {
 
 import { columns } from './cli-ui'
 import { CONTROL_PORT, PORT } from './constants'
-import { scaffoldMoiDir } from './moi-scaffold'
 import { type OpenClawAgent, discoverOpenClawAgents } from './openclaw'
 import { liftToWorkspaceRoot, registerWorkspace } from './registry'
 import {
   type SkillStatus,
   isBehind,
   isMinorBehind,
-  resolveWorkspaceRoot,
+  resolveWorkspace,
   skillStatuses,
   staleSkillNotice
 } from './skill-version'
 import { installBundledSkills } from './skills-template'
+import { provisionWorkspace, skillsDirFor } from './workspace-init'
 
 // ---- helpers ----------------------------------------------------------------
 
@@ -211,13 +210,28 @@ const init = defineCommand({
     const projectRoot = join(import.meta.dir, '..')
     const isInteractive = process.stdout.isTTY
 
-    await mkdir(target, { recursive: true })
-    await installBundledSkills(join(target, '.claude', 'skills'))
+    // Detect an OpenClaw agent workspace before provisioning: skills must land
+    // in `skills/` (not `.claude/skills/`) and the registry entry must carry
+    // the agent metadata — same as `moi openclaw init <agent>`. Discovery
+    // returns [] when the gateway is down, so this never blocks a plain init.
+    const agent = (await discoverOpenClawAgents()).find(a => a.path === target) ?? null
+    if (agent) {
+      console.log(
+        '\n' +
+          pc.yellow('◆') +
+          ' Detected an OpenClaw agent workspace ' +
+          pc.dim('(' + agent.agentId + (agent.name ? ', ' + agent.name : '') + ')') +
+          ' — initializing for OpenClaw.'
+      )
+    }
 
-    // Bootstrap the `.moi/` root (widgets dir + package.json + bun install)
-    // for a fresh workspace; an existing `.moi/` is left untouched.
+    // Provision: bundled skills + the `.moi/` bootstrap (widgets dir +
+    // package.json + bun install). An existing `.moi/` is left untouched.
     console.log()
-    const scaffold = await scaffoldMoiDir(target)
+    const { scaffold, skillsDir } = await provisionWorkspace(
+      target,
+      agent ? 'openclaw' : 'claude-code'
+    )
     if (scaffold !== 'exists') {
       console.log(pc.dim('  Installed widget dependencies in .moi/'))
       if (scaffold !== 0) {
@@ -226,10 +240,27 @@ const init = defineCommand({
     }
 
     // Always register the workspace in the persistent registry
-    const entry = await registerWorkspace(target)
+    const entry = await registerWorkspace(
+      target,
+      agent
+        ? {
+            type: 'openclaw',
+            name: agent.name,
+            agentId: agent.agentId,
+            isDefault: agent.isDefault,
+            lastRunAt: agent.lastRunAt
+          }
+        : { type: 'claude-code' }
+    )
 
     console.log(pc.green('✓') + ' Initialized ' + pc.bold(target))
-    console.log('  Skills installed — ask Claude to build a widget to get started\n')
+    console.log(
+      '  Skills installed to ' +
+        pc.dim(skillsDir) +
+        ' — ask ' +
+        (agent ? 'your agent' : 'Claude') +
+        ' to build a widget to get started\n'
+    )
 
     // If --web and server not running, start it (stay alive as wrapper)
     let running = await isServerRunning()
@@ -701,15 +732,12 @@ const openclawInit = defineCommand({
       process.exit(1)
     }
 
-    // Copy each shipped skill folder into <agent-workspace>/skills/<name>/.
-    // OpenClaw resolves <workspace>/skills with the highest precedence, so
-    // these win over any same-named bundled or per-user skill.
-    const skillsRoot = join(target.path, 'skills')
-    await installBundledSkills(skillsRoot)
-
-    // Same `.moi/` bootstrap as `moi init` — the widgets skill assumes the
-    // folder and its dependencies exist. Existing `.moi/` stays untouched.
-    const scaffold = await scaffoldMoiDir(target.path)
+    // Shared provisioning path with `moi init`: skills land in
+    // <agent-workspace>/skills/<name>/ (OpenClaw resolves <workspace>/skills
+    // with the highest precedence, so these win over any same-named bundled or
+    // per-user skill), plus the `.moi/` bootstrap — the widgets skill assumes
+    // the folder and its dependencies exist. Existing `.moi/` stays untouched.
+    const { scaffold, skillsDir: skillsRoot } = await provisionWorkspace(target.path, 'openclaw')
     if (scaffold !== 'exists') {
       console.log('\n' + pc.dim('  Installed widget dependencies in .moi/'))
       if (scaffold !== 0) {
@@ -1346,10 +1374,12 @@ const scratch = defineCommand({
 // filesystem op — no running server needed. Resolves the workspace root the
 // same way `moi bundle` does, so it works from `.moi/` or any subdirectory.
 async function runSkillUpdate(cwd: string): Promise<void> {
-  const root = await resolveWorkspaceRoot(cwd)
-  const before = await skillStatuses(root)
-  await installBundledSkills(join(root, '.claude', 'skills'))
-  const after = await skillStatuses(root)
+  // Type-aware: an OpenClaw workspace keeps its skills in `skills/`, so the
+  // update must target the same dir the agent actually loads from.
+  const { root, type } = await resolveWorkspace(cwd)
+  const before = await skillStatuses(root, type)
+  await installBundledSkills(skillsDirFor(root, type))
+  const after = await skillStatuses(root, type)
 
   console.log('\n' + pc.green('✓') + ' Skills updated in ' + pc.bold(root) + '\n')
   console.log(
@@ -1414,8 +1444,8 @@ const skill = defineCommand({
     const sub = rawArgs.find(a => !a.startsWith('-'))
     if (sub && sub in skillSubCommands) return
 
-    const root = await resolveWorkspaceRoot(resolve(args.dir))
-    const statuses = await skillStatuses(root)
+    const { root, type } = await resolveWorkspace(resolve(args.dir))
+    const statuses = await skillStatuses(root, type)
 
     console.log('\n' + pc.bold('moi skill') + pc.dim(' — workspace skills') + '\n')
     console.log(

--- a/server/registry.ts
+++ b/server/registry.ts
@@ -9,7 +9,7 @@ import { type OpenClawAgent, discoverOpenClawAgents } from './openclaw'
 
 // Replace the home-dir prefix with `~` for display. Keeps the original
 // absolute path in place; callers should put the result in `displayPath`.
-function tildify(absPath: string): string {
+export function tildify(absPath: string): string {
   const home = homedir()
   if (!home) return absPath
   if (absPath === home) return '~'

--- a/server/skill-version.ts
+++ b/server/skill-version.ts
@@ -7,8 +7,11 @@
 import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import type { WorkspaceType } from '@/lib/types'
+
 import { findWorkspaceForPath, liftToWorkspaceRoot, listWorkspaces } from './registry'
 import { BUNDLED_SKILLS_DIR } from './skills-template'
+import { skillsDirFor } from './workspace-init'
 
 export type SkillStatus = {
   name: string
@@ -90,25 +93,38 @@ export async function bundledSkillNames(): Promise<string[]> {
   }
 }
 
-// Per-skill installed-vs-bundled versions for a workspace root.
-export async function skillStatuses(workspaceRoot: string): Promise<SkillStatus[]> {
+// Per-skill installed-vs-bundled versions for a workspace root. `type` picks
+// the installed-skills location (OpenClaw keeps them in `skills/`, not
+// `.claude/skills/`) — pass the registry entry's type when known.
+export async function skillStatuses(
+  workspaceRoot: string,
+  type?: WorkspaceType
+): Promise<SkillStatus[]> {
   const names = await bundledSkillNames()
+  const skillsDir = skillsDirFor(workspaceRoot, type)
   return Promise.all(
     names.map(async name => ({
       name,
       bundled: await readSkillVersion(join(BUNDLED_SKILLS_DIR, name, 'SKILL.md')),
-      installed: await readSkillVersion(join(workspaceRoot, '.claude', 'skills', name, 'SKILL.md'))
+      installed: await readSkillVersion(join(skillsDir, name, 'SKILL.md'))
     }))
   )
 }
 
-// Resolve a path to its workspace root: the registered workspace that owns it,
-// else lifted out of any `.moi/`, else the path itself. Mirrors how `moi
-// bundle` resolves a target so `moi skill` works from the same places.
-export async function resolveWorkspaceRoot(cwd: string): Promise<string> {
+export type ResolvedWorkspace = { root: string; type?: WorkspaceType }
+
+// Resolve a path to its workspace root: the registered workspace that owns it
+// (carrying its backend type), else lifted out of any `.moi/`, else the path
+// itself. Mirrors how `moi bundle` resolves a target so `moi skill` works from
+// the same places.
+export async function resolveWorkspace(cwd: string): Promise<ResolvedWorkspace> {
   const ws = findWorkspaceForPath(await listWorkspaces(), cwd)
-  if (ws) return ws.path
-  return liftToWorkspaceRoot(cwd)
+  if (ws) return { root: ws.path, type: ws.type }
+  return { root: liftToWorkspaceRoot(cwd) }
+}
+
+export async function resolveWorkspaceRoot(cwd: string): Promise<string> {
+  return (await resolveWorkspace(cwd)).root
 }
 
 // One-line, agent-facing notice when any installed skill is a minor+ behind the
@@ -117,8 +133,10 @@ export async function resolveWorkspaceRoot(cwd: string): Promise<string> {
 // version checks must not break the command they ride on.
 export async function staleSkillNotice(cwd: string): Promise<string | null> {
   try {
-    const root = await resolveWorkspaceRoot(cwd)
-    const stale = (await skillStatuses(root)).filter(s => isMinorBehind(s.installed, s.bundled))
+    const { root, type } = await resolveWorkspace(cwd)
+    const stale = (await skillStatuses(root, type)).filter(s =>
+      isMinorBehind(s.installed, s.bundled)
+    )
     if (stale.length === 0) return null
     const parts = stale.map(s => `${s.name} (${s.installed ?? 'none'} → ${s.bundled})`)
     return `⚠ moi skill outdated: ${parts.join(', ')} — run \`moi skill update\` to refresh.`

--- a/server/test/workspace-init.test.ts
+++ b/server/test/workspace-init.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import { join } from 'path'
+
+import { skillsDirFor, validateWorkspaceFolderName } from '../workspace-init'
+
+// Pure helpers only — `provisionWorkspace` composes `installBundledSkills` and
+// `scaffoldMoiDir` (covered by their own tests) and would hit the network via
+// `bun install`.
+
+describe('skillsDirFor', () => {
+  test('claude-code (and untyped) workspaces load skills from .claude/skills', () => {
+    expect(skillsDirFor('/ws', 'claude-code')).toBe(join('/ws', '.claude', 'skills'))
+    expect(skillsDirFor('/ws')).toBe(join('/ws', '.claude', 'skills'))
+    expect(skillsDirFor('/ws', 'hermes')).toBe(join('/ws', '.claude', 'skills'))
+  })
+
+  test('openclaw agents load skills from <workspace>/skills', () => {
+    expect(skillsDirFor('/agent', 'openclaw')).toBe(join('/agent', 'skills'))
+  })
+})
+
+describe('validateWorkspaceFolderName', () => {
+  test('accepts plain folder names', () => {
+    expect(validateWorkspaceFolderName('my-workspace')).toBeNull()
+    expect(validateWorkspaceFolderName('Notes 2026')).toBeNull()
+    expect(validateWorkspaceFolderName('a')).toBeNull()
+    expect(validateWorkspaceFolderName('v1.2_final')).toBeNull()
+  })
+
+  test('rejects empty and oversized names', () => {
+    expect(validateWorkspaceFolderName('')).not.toBeNull()
+    expect(validateWorkspaceFolderName('x'.repeat(65))).not.toBeNull()
+  })
+
+  test('rejects path separators and traversal', () => {
+    expect(validateWorkspaceFolderName('a/b')).not.toBeNull()
+    expect(validateWorkspaceFolderName('a\\b')).not.toBeNull()
+    expect(validateWorkspaceFolderName('..')).not.toBeNull()
+    expect(validateWorkspaceFolderName('../escape')).not.toBeNull()
+  })
+
+  test('rejects hidden names so `.moi`/`.claude` can never collide', () => {
+    expect(validateWorkspaceFolderName('.moi')).not.toBeNull()
+    expect(validateWorkspaceFolderName('.claude')).not.toBeNull()
+    expect(validateWorkspaceFolderName('.hidden')).not.toBeNull()
+  })
+
+  test('rejects trailing dots and spaces', () => {
+    expect(validateWorkspaceFolderName('name.')).not.toBeNull()
+    expect(validateWorkspaceFolderName('name ')).not.toBeNull()
+  })
+})

--- a/server/workspace-init.ts
+++ b/server/workspace-init.ts
@@ -1,0 +1,66 @@
+// The one place that knows how to turn a directory into a moi workspace:
+// bundled skills + the `.moi/` scaffold, with the skills location keyed on the
+// agent backend. `moi init`, `moi openclaw init`, and the HTTP API (UI import /
+// create) all provision through here, so a workspace set up from the UI is
+// indistinguishable from one set up via the CLI.
+import { mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import type { WorkspaceType } from '@/lib/types'
+
+import { scaffoldMoiDir } from './moi-scaffold'
+import { installBundledSkills } from './skills-template'
+
+// Where each backend loads skills from. Claude Code reads `.claude/skills/`;
+// OpenClaw resolves `<workspace>/skills/` with the highest precedence (it wins
+// over same-named bundled or per-user skills). An untyped entry is Claude Code.
+export function skillsDirFor(workspaceRoot: string, type?: WorkspaceType): string {
+  return type === 'openclaw'
+    ? join(workspaceRoot, 'skills')
+    : join(workspaceRoot, '.claude', 'skills')
+}
+
+// Folder that holds workspaces created from the UI (`/workspace/create`) — a
+// visible home-dir folder, mirroring how Cowork keeps its session folders under
+// the user's home rather than an app-data dir.
+export const CREATED_WORKSPACES_ROOT = join(homedir(), 'moi')
+
+export type ProvisionResult = {
+  // Where the skills were installed (backend-dependent, see skillsDirFor).
+  skillsDir: string
+  // 'exists' when `.moi/` was already bootstrapped, else the bun install exit
+  // code (non-zero means deps must be installed manually — not fatal).
+  scaffold: 'exists' | number
+}
+
+// Lay down everything a workspace needs: create the folder, copy the bundled
+// skills into the backend's skills dir, and bootstrap `.moi/`. Idempotent —
+// re-running refreshes skills and leaves an existing `.moi/` untouched.
+// Registration in the workspace registry is a separate, caller-owned step.
+export async function provisionWorkspace(
+  workspaceRoot: string,
+  type?: WorkspaceType
+): Promise<ProvisionResult> {
+  const skillsDir = skillsDirFor(workspaceRoot, type)
+  await mkdir(workspaceRoot, { recursive: true })
+  await installBundledSkills(skillsDir)
+  const scaffold = await scaffoldMoiDir(workspaceRoot)
+  return { skillsDir, scaffold }
+}
+
+// Validate a folder name typed in the create-workspace form. Returns a
+// user-facing error, or null when the name is usable as a single path segment
+// under CREATED_WORKSPACES_ROOT. Leading dots are rejected so a name can never
+// be hidden or collide with `.moi` / `.claude`.
+export function validateWorkspaceFolderName(name: string): string | null {
+  if (!name) return 'Folder name is required'
+  if (name.length > 64) return 'Folder name is too long (max 64 characters)'
+  if (!/^[A-Za-z0-9][A-Za-z0-9._ -]*$/.test(name)) {
+    return 'Use letters, numbers, dots, dashes, underscores and spaces, starting with a letter or number'
+  }
+  if (name.endsWith('.') || name.endsWith(' ')) {
+    return 'Folder name cannot end with a dot or space'
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Adds a `/workspace/create` route and UI for creating new Claude Code workspaces from the browser, while consolidating workspace provisioning logic into a single reusable path. Both CLI (`moi init`, `moi openclaw init`) and the HTTP API now provision workspaces identically—skills + `.moi/` scaffold—ensuring workspaces created via the UI are indistinguishable from those created via CLI.

## Key Changes

- **New workspace creation UI** (`client/components/routes/workspace/create.tsx`):
  - Form to name a new workspace and select agent type (Claude Code only for now)
  - Client-side validation mirroring server rules
  - Real-time path preview showing where the folder will be created
  - Loading state and error handling

- **Unified provisioning** (`server/workspace-init.ts`):
  - Extracted `provisionWorkspace()` function that handles skills installation and `.moi/` bootstrap
  - `skillsDirFor()` helper that routes skills to the correct location based on workspace type (`.claude/skills/` for Claude Code, `skills/` for OpenClaw)
  - `validateWorkspaceFolderName()` for consistent validation across CLI and API
  - `CREATED_WORKSPACES_ROOT` constant (`~/moi`) for UI-created workspaces

- **HTTP API endpoints** (`server/api.ts`):
  - `GET /api/workspaces/create` — returns the root folder and display path for new workspaces
  - `POST /api/workspaces/create` — creates a new Claude Code workspace (validates name, provisions, registers)
  - Updated `POST /api/workspaces/` to provision imported workspaces before registration

- **CLI refactoring** (`server/cli.ts`):
  - `moi init` and `moi openclaw init` now use `provisionWorkspace()` instead of inline logic
  - `moi init` detects OpenClaw agent workspaces and initializes them appropriately
  - `moi skill update` and `moi skill` commands now type-aware (use correct skills dir per backend)

- **Type-aware skill resolution** (`server/skill-version.ts`):
  - `resolveWorkspace()` returns both root path and workspace type
  - `skillStatuses()` accepts optional type parameter to check skills in the correct location
  - Maintains backward compatibility with `resolveWorkspaceRoot()`

- **Exports and UI components**:
  - Exported `TypeIcon` and `typeLabel` from `WorkspacesPage` for reuse in create form
  - Added `CreateWorkspacePage` route to `App.tsx`
  - Updated sidebar to include "New workspace" button

- **Tests** (`server/test/workspace-init.test.ts`):
  - Validation tests for folder names (length, characters, hidden names, trailing dots/spaces)
  - Skills directory resolution tests for both workspace types

## Implementation Details

- Validation is mirrored client-side (instant feedback) and server-side (authority)
- Workspace provisioning is idempotent—re-running refreshes skills and leaves existing `.moi/` untouched
- OpenClaw agent detection in `moi init` uses the same discovery mechanism as the UI, so CLI and browser paths converge
- The `CREATED_WORKSPACES_ROOT` folder is user-visible (`~/moi`), matching Cowork's session folder pattern
- All workspace creation flows (CLI, OpenClaw discovery, HTTP import, HTTP create) now go through the same provisioning path

https://claude.ai/code/session_01VeGanidvzCaRNbjAvii5zM