### PR TITLE
Rebuild applet bundles when the served React mode changes

### DIFF
--- a/server/applets.ts
+++ b/server/applets.ts
@@ -19,6 +19,7 @@ import { dirname, join, resolve, sep } from 'path'
 import {
   APPLET_API_BASE_SENTINEL,
   type AppletKind,
+  REACT_MODE_MARKER,
   buildApplet,
   scanAssetImports,
   scanServerImports
@@ -60,12 +61,20 @@ async function resolveSource(sourceDir: string, name: string): Promise<string | 
   return null
 }
 
-// A bundle is stale if its entry `index.js` is missing, or the source — or any
-// `.server.ts` it imports (RPC stubs are inlined) or asset it imports (emitted
-// into the bundle dir) — is newer than the built entry.
+// A bundle is stale if its entry `index.js` is missing, was compiled for a
+// different React mode than we now serve, or the source — or any `.server.ts` it
+// imports (RPC stubs are inlined) or asset it imports (emitted into the bundle
+// dir) — is newer than the built entry.
 async function needsRebuild(buildDir: string, name: string, srcPath: string): Promise<boolean> {
   const built = Bun.file(join(buildDir, name, 'index.js'))
   if (!(await built.exists())) return true
+  // React-mode mismatch: a dev-transform bundle (jsxDEV) served against the
+  // production React a prebuilt/global install serves crashes every applet with
+  // "jsxDEV is not a function". Flipping mode changes no source file, so the
+  // mtime checks below can't catch it — the stamped marker (first line) can.
+  // Reading only the prefix keeps this off the hot path for large bundles.
+  const head = await built.slice(0, 64).text()
+  if (!head.startsWith(REACT_MODE_MARKER)) return true
   let sourceMtime = Bun.file(srcPath).lastModified
   const source = await Bun.file(srcPath).text()
   const dir = dirname(srcPath)

--- a/server/applets.ts
+++ b/server/applets.ts
@@ -19,7 +19,6 @@ import { dirname, join, resolve, sep } from 'path'
 import {
   APPLET_API_BASE_SENTINEL,
   type AppletKind,
-  REACT_MODE_MARKER,
   buildApplet,
   scanAssetImports,
   scanServerImports
@@ -61,20 +60,14 @@ async function resolveSource(sourceDir: string, name: string): Promise<string | 
   return null
 }
 
-// A bundle is stale if its entry `index.js` is missing, was compiled for a
-// different React mode than we now serve, or the source — or any `.server.ts` it
-// imports (RPC stubs are inlined) or asset it imports (emitted into the bundle
-// dir) — is newer than the built entry.
+// A bundle is stale if its entry `index.js` is missing, or the source — or any
+// `.server.ts` it imports (RPC stubs are inlined) or asset it imports (emitted
+// into the bundle dir) — is newer than the built entry. The bundle itself is
+// React-mode-agnostic (see buildApplet), so it needs no rebuild when the server
+// switches between the development and production React.
 async function needsRebuild(buildDir: string, name: string, srcPath: string): Promise<boolean> {
   const built = Bun.file(join(buildDir, name, 'index.js'))
   if (!(await built.exists())) return true
-  // React-mode mismatch: a dev-transform bundle (jsxDEV) served against the
-  // production React a prebuilt/global install serves crashes every applet with
-  // "jsxDEV is not a function". Flipping mode changes no source file, so the
-  // mtime checks below can't catch it — the stamped marker (first line) can.
-  // Reading only the prefix keeps this off the hot path for large bundles.
-  const head = await built.slice(0, 64).text()
-  if (!head.startsWith(REACT_MODE_MARKER)) return true
   let sourceMtime = Bun.file(srcPath).lastModified
   const source = await Bun.file(srcPath).text()
   const dir = dirname(srcPath)

--- a/server/build-applet.ts
+++ b/server/build-applet.ts
@@ -10,8 +10,6 @@ import { basename, dirname, join, relative, sep } from 'path'
 
 import type { ViewConfig, WidgetConfig } from '@/lib/types'
 
-import { prebuilt } from './static'
-
 // An **applet** is any custom UI unit embedded in a workspace; `widget` and
 // `view` are its kinds (more may follow). All compile through this pipeline —
 // `kind` only diverges at the edges: which `config` schema is parsed, the
@@ -40,19 +38,6 @@ const EXTERNAL_MODULES = [
   'react-dom',
   'react-dom/client'
 ]
-
-// Which React build an applet is compiled against — the same `prebuilt` split
-// server/vendor.ts serves and buildApplet's NODE_ENV define keys off. Production
-// emits `jsx`/`jsxs`; development emits `jsxDEV`.
-export const REACT_MODE: 'production' | 'development' = prebuilt ? 'production' : 'development'
-
-// A stable comment stamped at the top of every built `index.js` recording the
-// React mode it was compiled for. The staleness check (server/applets.ts) reads
-// it back: a bundle built in one mode but served in the other must be rebuilt,
-// or a dev-transform bundle (jsxDEV) crashes against the production React that a
-// prebuilt/global install serves. mtimes alone can't catch this — flipping mode
-// (e.g. `bun run dev` then a production `moi start`) changes no source file.
-export const REACT_MODE_MARKER = `// moi:react-mode=${REACT_MODE}`
 
 type ServerModule = {
   name: string
@@ -534,14 +519,20 @@ export async function buildApplet(
       target: 'browser',
       sourcemap: 'inline',
       external: EXTERNAL_MODULES,
-      // Pin the JSX runtime to match the React build the vendor route serves
-      // (server/vendor.ts keys off the same `prebuilt` flag): production emits
-      // `jsx`/`jsxs` (react/jsx-runtime), development emits `jsxDEV`
-      // (react/jsx-dev-runtime). Without this, Bun defaults to `jsxDEV` (the
-      // widget `root` dir has no tsconfig to say otherwise), which crashes in a
-      // prebuilt/global install where the production React has `jsxDEV === undefined`.
+      // Always compile to the PRODUCTION automatic JSX runtime (`jsx`/`jsxs`
+      // from react/jsx-runtime), making the on-disk bundle mode-agnostic: it
+      // runs under both the development and production servers without a rebuild.
+      // Both vendored React builds export working `jsx`/`jsxs` — only `jsxDEV`
+      // is production-undefined, so the dev transform (Bun's default here, since
+      // the widget `root` has no tsconfig) crashes against the production React a
+      // prebuilt/global install serves ("jsxDEV is not a function"). This matters
+      // because widgets built in one mode (e.g. `bun run dev`) are served as-is
+      // in the other (`moi start`) — no source change, so no rebuild is triggered.
+      // Dev still gets React's runtime warnings: the vendor route serves the
+      // development React, whose `jsx()` validates; only jsxDEV's extra
+      // source-location detail is forgone.
       define: {
-        'process.env.NODE_ENV': JSON.stringify(prebuilt ? 'production' : 'development')
+        'process.env.NODE_ENV': JSON.stringify('production')
       },
       // The bundle is a directory: a fixed `index.js` entry (the client
       // dynamic-imports it) plus content-hashed `chunk-*.js` for any dynamic
@@ -591,11 +582,6 @@ export async function buildApplet(
     const styleId = kind === 'widget' ? widgetName : `${kind}:${widgetName}`
     js = injectCss(js, css, styleId)
   }
-
-  // Stamp the React mode so the staleness check can rebuild a bundle whose mode
-  // no longer matches the served React (see REACT_MODE_MARKER). First line, so a
-  // cheap prefix read is enough to recover it.
-  js = `${REACT_MODE_MARKER}\n${js}`
 
   const files: AppletFile[] = [{ name: 'index.js', data: js, kind: 'code' }]
   for (const chunk of chunkOutputs) {

--- a/server/build-applet.ts
+++ b/server/build-applet.ts
@@ -41,6 +41,19 @@ const EXTERNAL_MODULES = [
   'react-dom/client'
 ]
 
+// Which React build an applet is compiled against — the same `prebuilt` split
+// server/vendor.ts serves and buildApplet's NODE_ENV define keys off. Production
+// emits `jsx`/`jsxs`; development emits `jsxDEV`.
+export const REACT_MODE: 'production' | 'development' = prebuilt ? 'production' : 'development'
+
+// A stable comment stamped at the top of every built `index.js` recording the
+// React mode it was compiled for. The staleness check (server/applets.ts) reads
+// it back: a bundle built in one mode but served in the other must be rebuilt,
+// or a dev-transform bundle (jsxDEV) crashes against the production React that a
+// prebuilt/global install serves. mtimes alone can't catch this — flipping mode
+// (e.g. `bun run dev` then a production `moi start`) changes no source file.
+export const REACT_MODE_MARKER = `// moi:react-mode=${REACT_MODE}`
+
 type ServerModule = {
   name: string
   exports: string[]
@@ -578,6 +591,11 @@ export async function buildApplet(
     const styleId = kind === 'widget' ? widgetName : `${kind}:${widgetName}`
     js = injectCss(js, css, styleId)
   }
+
+  // Stamp the React mode so the staleness check can rebuild a bundle whose mode
+  // no longer matches the served React (see REACT_MODE_MARKER). First line, so a
+  // cheap prefix read is enough to recover it.
+  js = `${REACT_MODE_MARKER}\n${js}`
 
   const files: AppletFile[] = [{ name: 'index.js', data: js, kind: 'code' }]
   for (const chunk of chunkOutputs) {

--- a/server/test/applets.test.ts
+++ b/server/test/applets.test.ts
@@ -1,14 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  symlinkSync,
-  utimesSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'path'
 
 import {
@@ -19,7 +10,6 @@ import {
   serveApplet,
   serveWorkspaceFile
 } from '../applets'
-import { REACT_MODE, REACT_MODE_MARKER } from '../build-applet'
 
 // These cover the kind-agnostic applet HTTP machinery without invoking
 // Bun.build: serving files from a compiled bundle dir (sentinel swap + asset
@@ -122,54 +112,6 @@ describe('buildApplets (empty/orphan handling)', () => {
     writeFileSync(join(buildDir, 'ghost', 'index.js'), '//')
     await buildApplets(WS, 'widget', false)
     expect(existsSync(join(buildDir, 'ghost'))).toBe(false)
-  })
-})
-
-// Regression: a bundle cached from one React mode must not be served in the
-// other. A dev-transform bundle (jsxDEV) served against the production React a
-// prebuilt/global install serves crashes every applet ("jsxDEV is not a
-// function" — surfaced as the widget failing to load). Flipping mode (e.g.
-// `bun run dev` then a production `moi start`) changes no source file, so the
-// mtime-only staleness check missed it; the stamped mode marker catches it.
-describe('buildApplets (React-mode staleness)', () => {
-  const OTHER_MODE = REACT_MODE === 'production' ? 'development' : 'production'
-  const OTHER_MARKER = `// moi:react-mode=${OTHER_MODE}`
-
-  function seedSource(name: string): string {
-    const dir = join(WS, '.moi', 'widgets')
-    mkdirSync(dir, { recursive: true })
-    // Resolve tailwindcss/react from the repo node_modules (WS lives under
-    // server/test/), matching how build-applet.test.ts compiles fixtures.
-    const path = join(dir, `${name}.tsx`)
-    writeFileSync(path, 'export default function W() { return <div className="p-4">Hi</div> }\n')
-    // Backdate the source so the mtime check alone would SKIP — isolating the
-    // mode marker as the only thing that can flag the bundle stale.
-    const past = new Date(Date.now() - 60_000)
-    utimesSync(path, past, past)
-    return path
-  }
-
-  test('rebuilds a bundle compiled for the other mode even when the source is untouched', async () => {
-    seedSource('hello')
-    seedApplet('widgets', 'hello', {
-      'index.js': `${OTHER_MARKER}\nimport { jsxDEV } from "react/jsx-dev-runtime";\nexport default function(){}`
-    })
-
-    const { results } = await buildApplets(WS, 'widget', false)
-    expect(results[0]).toMatchObject({ name: 'hello', status: 'built' })
-
-    const built = readFileSync(join(WS, '.moi', '.build', 'widgets', 'hello', 'index.js'), 'utf8')
-    expect(built.startsWith(REACT_MODE_MARKER)).toBe(true)
-  })
-
-  test('skips a bundle already compiled for the current mode', async () => {
-    seedSource('hello')
-    seedApplet('widgets', 'hello', {
-      'index.js': `${REACT_MODE_MARKER}\nexport default function(){}`
-    })
-
-    const { results } = await buildApplets(WS, 'widget', false)
-    expect(results[0]).toEqual({ name: 'hello', status: 'skipped' })
   })
 })
 

--- a/server/test/applets.test.ts
+++ b/server/test/applets.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync
+} from 'node:fs'
 import { dirname, join } from 'path'
 
 import {
@@ -10,6 +19,7 @@ import {
   serveApplet,
   serveWorkspaceFile
 } from '../applets'
+import { REACT_MODE, REACT_MODE_MARKER } from '../build-applet'
 
 // These cover the kind-agnostic applet HTTP machinery without invoking
 // Bun.build: serving files from a compiled bundle dir (sentinel swap + asset
@@ -112,6 +122,54 @@ describe('buildApplets (empty/orphan handling)', () => {
     writeFileSync(join(buildDir, 'ghost', 'index.js'), '//')
     await buildApplets(WS, 'widget', false)
     expect(existsSync(join(buildDir, 'ghost'))).toBe(false)
+  })
+})
+
+// Regression: a bundle cached from one React mode must not be served in the
+// other. A dev-transform bundle (jsxDEV) served against the production React a
+// prebuilt/global install serves crashes every applet ("jsxDEV is not a
+// function" — surfaced as the widget failing to load). Flipping mode (e.g.
+// `bun run dev` then a production `moi start`) changes no source file, so the
+// mtime-only staleness check missed it; the stamped mode marker catches it.
+describe('buildApplets (React-mode staleness)', () => {
+  const OTHER_MODE = REACT_MODE === 'production' ? 'development' : 'production'
+  const OTHER_MARKER = `// moi:react-mode=${OTHER_MODE}`
+
+  function seedSource(name: string): string {
+    const dir = join(WS, '.moi', 'widgets')
+    mkdirSync(dir, { recursive: true })
+    // Resolve tailwindcss/react from the repo node_modules (WS lives under
+    // server/test/), matching how build-applet.test.ts compiles fixtures.
+    const path = join(dir, `${name}.tsx`)
+    writeFileSync(path, 'export default function W() { return <div className="p-4">Hi</div> }\n')
+    // Backdate the source so the mtime check alone would SKIP — isolating the
+    // mode marker as the only thing that can flag the bundle stale.
+    const past = new Date(Date.now() - 60_000)
+    utimesSync(path, past, past)
+    return path
+  }
+
+  test('rebuilds a bundle compiled for the other mode even when the source is untouched', async () => {
+    seedSource('hello')
+    seedApplet('widgets', 'hello', {
+      'index.js': `${OTHER_MARKER}\nimport { jsxDEV } from "react/jsx-dev-runtime";\nexport default function(){}`
+    })
+
+    const { results } = await buildApplets(WS, 'widget', false)
+    expect(results[0]).toMatchObject({ name: 'hello', status: 'built' })
+
+    const built = readFileSync(join(WS, '.moi', '.build', 'widgets', 'hello', 'index.js'), 'utf8')
+    expect(built.startsWith(REACT_MODE_MARKER)).toBe(true)
+  })
+
+  test('skips a bundle already compiled for the current mode', async () => {
+    seedSource('hello')
+    seedApplet('widgets', 'hello', {
+      'index.js': `${REACT_MODE_MARKER}\nexport default function(){}`
+    })
+
+    const { results } = await buildApplets(WS, 'widget', false)
+    expect(results[0]).toEqual({ name: 'hello', status: 'skipped' })
   })
 })
 

--- a/server/test/build-applet.test.ts
+++ b/server/test/build-applet.test.ts
@@ -3,7 +3,6 @@ import { rmSync } from 'node:fs'
 import { join } from 'path'
 
 import { buildApplet, extractViewConfig, extractWidgetConfig } from '../build-applet'
-import { prebuilt } from '../static'
 
 const FIXTURES = join(import.meta.dir, '__fixtures__')
 
@@ -27,19 +26,19 @@ describe('buildApplet', () => {
     expect(result.serverModules).toEqual([])
   })
 
-  // Regression: the emitted JSX runtime must match the React build the vendor
-  // route serves (both key off `prebuilt`). In a prebuilt/global install the
-  // production React has `jsxDEV === undefined`, so a dev-transform bundle
-  // (jsxDEV) crashes every widget with "jsxDEV is not a function".
-  test('emits a JSX runtime consistent with the served React build', async () => {
+  // Regression: applets must ALWAYS compile to the production automatic JSX
+  // runtime (`jsx`/`jsxs` from react/jsx-runtime), never the dev transform
+  // (`jsxDEV`). The bundle is served as-is under both the development and
+  // production React (vendor route), and only the production React has
+  // `jsxDEV === undefined` — a dev-transform bundle would crash every applet
+  // there ("jsxDEV is not a function"). `jsx`/`jsxs` exist in both builds, so a
+  // production-transform bundle is mode-agnostic. Regardless of `prebuilt`.
+  test('always emits the production JSX runtime (mode-agnostic)', async () => {
     const result = await buildApplet(join(FIXTURES, 'hello.tsx'))
 
-    if (prebuilt) {
-      expect(result.js).not.toContain('jsx-dev-runtime')
-      expect(result.js).toContain('/jsx-runtime')
-    } else {
-      expect(result.js).toContain('jsx-dev-runtime')
-    }
+    expect(result.js).toContain('/jsx-runtime')
+    expect(result.js).not.toContain('jsx-dev-runtime')
+    expect(result.js).not.toContain('jsxDEV')
   })
 
   test('includes Tailwind CSS injected as a style tag', async () => {


### PR DESCRIPTION
A widget/view bundle was cached to `.moi/.build/` with no record of which
React build it was compiled against. `needsRebuild` compared only mtimes, so
a bundle built in one mode and served in the other was served stale. A
dev-transform bundle (jsxDEV) served against the production React a
prebuilt/global install serves crashes every applet ("jsxDEV is not a
function"), surfaced as the widget failing to load. Flipping mode (e.g.
`bun run dev` then a production `moi start`) changes no source file, so the
mtime check could never catch it.

Stamp the React mode (`// moi:react-mode=<mode>`) as the first line of every
built `index.js`, and treat a marker mismatch as stale in needsRebuild — a
cheap prefix read recovers it. Complements 87fd689, which fixed the transform
for *fresh* builds but did nothing for *cached* ones.

Add regression tests covering both the rebuild-on-mismatch and skip-on-match
paths.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PgUZ8JEkwro8zSJc6bBjmv