### PR TITLE
Add disclaimer about unauthorized moi tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,13 @@ moi also works with OpenClaw agents — `moi openclaw init` installs the moi
 skills into an OpenClaw agent workspace. Integration notes live in
 [docs/OPENCLAW.md](docs/OPENCLAW.md).
 
+## No crypto token
+
+moi has **no** cryptocurrency, token, coin, or NFT — official or otherwise —
+on any chain, and never will. Any token using the moi name, logo, or the
+maintainer's name (on pump.fun, Solana, or anywhere else) is an unauthorized
+scam with no affiliation to, endorsement from, or benefit to this project.
+The maintainer will never announce, endorse, or accept proceeds from a token.
+Don't buy it, and report it to the platform where it's listed.
+
 License: [Elastic 2.0](LICENSE).


### PR DESCRIPTION
## Summary

Added a "No crypto token" section to the README clarifying that moi has no official cryptocurrency, token, coin, or NFT on any blockchain, and warning users against scams using the moi name or maintainer's identity.

## Changes

- Added a new section in README.md warning users that any tokens claiming to be "moi" on pump.fun, Solana, or other platforms are unauthorized scams with no affiliation to the project
- Clarified that the maintainer will never announce, endorse, or accept proceeds from any token
- Included guidance for users to report fraudulent tokens to the platforms where they're listed

## Context

This is a proactive measure to protect users from cryptocurrency scams that may attempt to capitalize on the moi project's name or the maintainer's reputation.

https://claude.ai/code/session_01Lxi2kps9cvUqjn52JujZed