### PR TITLE
Show function workers on /status

### DIFF
--- a/server/functions-worker.ts
+++ b/server/functions-worker.ts
@@ -45,6 +45,8 @@ async function loadModule(name: string): Promise<Record<string, unknown>> {
 
   const mod = (await import(filePath + `?t=${file.lastModified}`)) as Record<string, unknown>
   moduleCache.set(name, mod)
+  // Tell the parent what's cached here — introspection only, shown in /status.
+  send({ type: 'loaded', module: name })
   return mod
 }
 

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -16,6 +16,7 @@
 // are paths relative to it (`"widgets/hello"` → `.moi/widgets/hello.server.ts`).
 // This is the contract documented in the widgets SKILL.
 import { LRUCache } from 'lru-cache'
+import { readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'path'
 
@@ -38,6 +39,16 @@ type Slot = {
   readyPromise: Promise<void>
   pending: Map<string, Pending>
   killed: boolean
+  // Introspection only (surfaced by /status) — not load-bearing.
+  ready: boolean
+  spawnedAt: number
+  lastCallAt: number | null
+  calls: number
+  errors: number
+  timeouts: number
+  // Module keys the worker has loaded and cached (reported via 'loaded' IPC,
+  // pruned when reloadModules evicts them).
+  modules: Set<string>
 }
 
 function rejectAndClearPending(slot: Slot, reason: string) {
@@ -76,7 +87,14 @@ function spawnSlot(workspacePath: string, workspaceEnv: Record<string, string>):
     worker: undefined as never,
     readyPromise,
     pending: new Map(),
-    killed: false
+    killed: false,
+    ready: false,
+    spawnedAt: Date.now(),
+    lastCallAt: null,
+    calls: 0,
+    errors: 0,
+    timeouts: 0,
+    modules: new Set()
   }
 
   slot.worker = Bun.spawn([process.execPath, WORKER_PATH], {
@@ -106,10 +124,22 @@ function spawnSlot(workspacePath: string, workspaceEnv: Record<string, string>):
       if (slots.peek(workspacePath) === slot) slots.delete(workspacePath)
     },
     ipc(message) {
-      const msg = message as { type: string; id?: string; data?: string; message?: string }
+      const msg = message as {
+        type: string
+        id?: string
+        data?: string
+        message?: string
+        module?: string
+      }
 
       if (msg.type === 'ready') {
+        slot.ready = true
         readyResolve()
+        return
+      }
+
+      if (msg.type === 'loaded' && msg.module) {
+        slot.modules.add(msg.module)
         return
       }
 
@@ -122,6 +152,7 @@ function spawnSlot(workspacePath: string, workspaceEnv: Record<string, string>):
         if (msg.type === 'result') {
           p.resolve(msg.data!)
         } else if (msg.type === 'error') {
+          slot.errors++
           p.reject(new Error(msg.message ?? 'Unknown error'))
         }
       }
@@ -169,10 +200,14 @@ export async function callFunction(
   const slot = getOrSpawn(workspacePath, workspaceEnv)
   await slot.readyPromise
 
+  slot.calls++
+  slot.lastCallAt = Date.now()
+
   const id = crypto.randomUUID()
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       slot.pending.delete(id)
+      slot.timeouts++
       reject(new Error(`Function call timed out: ${module}/${name}`))
     }, CALL_TIMEOUT_MS)
 
@@ -206,6 +241,66 @@ export function restartWorker(workspacePath: string) {
   slots.delete(workspacePath)
 }
 
+// Caps surfaced in /status so the numbers there are self-explanatory.
+export const WORKER_LIMITS = {
+  maxWorkers: MAX_WORKERS,
+  idleTtlMs: WORKER_IDLE_TTL_MS,
+  callTimeoutMs: CALL_TIMEOUT_MS
+} as const
+
+export type WorkerDebugInfo = {
+  workspacePath: string
+  pid: number | undefined
+  ready: boolean
+  spawnedAt: number
+  lastCallAt: number | null
+  calls: number
+  errors: number
+  timeouts: number
+  pending: number
+  // ms until the LRU idle TTL reaps this worker (refreshed on every call)
+  ttlRemainingMs: number
+  // Resident memory of the worker process; null when /proc isn't available (macOS)
+  rssBytes: number | null
+  modules: string[]
+}
+
+// Best-effort RSS from /proc — Linux only, returns null elsewhere. VmRSS is in
+// kB, so no page-size assumptions. Sync read of a tiny procfs file is cheap.
+function readRss(pid: number | undefined): number | null {
+  if (!pid || process.platform !== 'linux') return null
+  try {
+    const m = readFileSync(`/proc/${pid}/status`, 'utf8').match(/^VmRSS:\s+(\d+)\s+kB/m)
+    return m ? Number(m[1]) * 1024 : null
+  } catch {
+    return null
+  }
+}
+
+// A snapshot of the live worker pool, for the /status page. Iteration and
+// getRemainingTTL don't refresh LRU recency, so peeking is side-effect free.
+export function getWorkersDebugSnapshot(): WorkerDebugInfo[] {
+  const out: WorkerDebugInfo[] = []
+  for (const [workspacePath, slot] of slots.entries()) {
+    if (slot.killed) continue
+    out.push({
+      workspacePath,
+      pid: slot.worker.pid,
+      ready: slot.ready,
+      spawnedAt: slot.spawnedAt,
+      lastCallAt: slot.lastCallAt,
+      calls: slot.calls,
+      errors: slot.errors,
+      timeouts: slot.timeouts,
+      pending: slot.pending.size,
+      ttlRemainingMs: slots.getRemainingTTL(workspacePath),
+      rssBytes: readRss(slot.worker.pid),
+      modules: [...slot.modules].sort()
+    })
+  }
+  return out
+}
+
 export function reloadModules(modules: string[], workspacePath: string) {
   if (modules.length === 0) return
   // peek: don't refresh TTL just because files changed. If the worker was
@@ -214,5 +309,8 @@ export function reloadModules(modules: string[], workspacePath: string) {
   if (!slot || slot.killed) return
   try {
     slot.worker.send({ type: 'reload', modules })
+    // The worker evicts these from its module cache; it re-reports 'loaded'
+    // on the next call, so drop them from the introspection set too.
+    for (const m of modules) slot.modules.delete(m)
   } catch {}
 }

--- a/server/status.ts
+++ b/server/status.ts
@@ -1,12 +1,16 @@
 // Plain-text introspection of the running server, served at GET /status.
 // A quick "peek into the process": connected tabs, the in-memory live-session
-// registry (CC + OpenClaw), and each session's busy/idle state + last message —
-// handy when a chat appears stuck (loader spinning) and you want to know whether
-// the server still holds a live session for that thread and what it's doing.
+// registry (CC + OpenClaw), each session's busy/idle state + last message, and
+// the functions-worker pool (one child process per workspace) — handy when a
+// chat appears stuck (loader spinning) and you want to know whether the server
+// still holds a live session for that thread, or when a widget's server call
+// hangs and you want to see whether its worker is alive and what it has loaded.
 import { type CCDebugSession, SESSION_LIMITS, getCCDebugSnapshot } from './cc-session'
 import { CONTROL_PORT, PORT } from './constants'
 import { debugEnabled } from './debug'
+import { WORKER_LIMITS, type WorkerDebugInfo, getWorkersDebugSnapshot } from './functions'
 import { getOpenClawRunningSessions } from './openclaw-session'
+import { tildify } from './registry'
 import { getClientCount } from './state'
 
 const STARTED_AT = Date.now()
@@ -28,6 +32,36 @@ function fmtAgo(ts: number, now: number): string {
   const m = Math.floor(s / 60)
   if (m < 60) return `${m}m ${s % 60}s ago`
   return `${Math.floor(m / 60)}h ${m % 60}m ago`
+}
+
+function fmtMb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)}mb`
+}
+
+function workerLine(w: WorkerDebugInfo, now: number): string {
+  // A worker with in-flight calls is busy; one still booting is spawning;
+  // otherwise it's warm and waiting for its idle TTL.
+  const mark = w.pending > 0 ? '▶ busy' : w.ready ? '○ warm' : '… spawning'
+  let callsBit = `calls=${w.calls}`
+  const problems: string[] = []
+  if (w.errors > 0) problems.push(`${w.errors} error${w.errors === 1 ? '' : 's'}`)
+  if (w.timeouts > 0) problems.push(`${w.timeouts} timeout${w.timeouts === 1 ? '' : 's'}`)
+  if (problems.length > 0) callsBit += ` (${problems.join(', ')})`
+
+  const bits = [
+    mark.padEnd(10),
+    `ws=${tildify(w.workspacePath)}`,
+    `pid=${w.pid ?? '?'}`,
+    callsBit,
+    `pending=${w.pending}`,
+    `age=${fmtDuration(now - w.spawnedAt)}`,
+    `lastCall=${w.lastCallAt === null ? 'never' : fmtAgo(w.lastCallAt, now)}`,
+    `reap=${w.ttlRemainingMs > 0 ? 'in ' + fmtDuration(w.ttlRemainingMs) : 'imminent'}`
+  ]
+  if (w.rssBytes !== null) bits.push(`rss=${fmtMb(w.rssBytes)}`)
+  let line = '  ' + bits.join('  ')
+  line += `\n      modules: ${w.modules.length > 0 ? w.modules.join(', ') : '(none loaded)'}`
+  return line
 }
 
 function sessionLine(s: CCDebugSession, now: number): string {
@@ -87,6 +121,23 @@ export function renderStatus(): string {
   lines.push(`live OpenClaw runs  ${openclawRunning.length}`)
   for (const r of openclawRunning) {
     lines.push(`  ▶ busy  ws=${r.workspaceId}  session=${r.sessionId}`)
+  }
+  lines.push('')
+
+  const workers = getWorkersDebugSnapshot()
+  lines.push(
+    `function workers  ${workers.length}/${WORKER_LIMITS.maxWorkers}  ` +
+      `(one per workspace, idle TTL ${fmtDuration(WORKER_LIMITS.idleTtlMs)}, ` +
+      `call timeout ${fmtDuration(WORKER_LIMITS.callTimeoutMs)})`
+  )
+  if (workers.length === 0) {
+    lines.push('  (none running — spawned lazily on the first server-function call)')
+  } else {
+    // Busiest / most-recently-called first.
+    const sorted = [...workers].sort(
+      (a, b) => b.pending - a.pending || (b.lastCallAt ?? 0) - (a.lastCallAt ?? 0)
+    )
+    for (const w of sorted) lines.push(workerLine(w, now))
   }
   lines.push('')
 


### PR DESCRIPTION
Each workspace's functions-worker subprocess now appears in the /status
introspection page: busy/warm/spawning state, pid, calls served (with
error and timeout counts), in-flight calls, age, last call time, idle-reap
countdown, RSS (Linux best-effort via /proc), and which .server.ts modules
the worker has loaded. The worker reports module loads over IPC ('loaded'
messages, introspection-only); reloadModules prunes them so a hot-reload
eviction is visible. Pool caps (max workers, idle TTL, call timeout) are
printed in the section header so the numbers are self-explanatory.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0165RJ9ky5bZt7i6Dat5GZSY