### PR TITLE
Handle tldraw version skew in Scratchpad snapshots

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "sugar-high": "^1.2.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.1.11",
-        "tldraw": "^5.1.1",
+        "tldraw": "5.2.3",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
         "wouter": "^3.9.0",
@@ -829,21 +829,21 @@
 
     "@tiptap/starter-kit": ["@tiptap/starter-kit@3.27.1", "", { "dependencies": { "@tiptap/core": "^3.27.1", "@tiptap/extension-blockquote": "^3.27.1", "@tiptap/extension-bold": "^3.27.1", "@tiptap/extension-bullet-list": "^3.27.1", "@tiptap/extension-code": "^3.27.1", "@tiptap/extension-code-block": "^3.27.1", "@tiptap/extension-document": "^3.27.1", "@tiptap/extension-dropcursor": "^3.27.1", "@tiptap/extension-gapcursor": "^3.27.1", "@tiptap/extension-hard-break": "^3.27.1", "@tiptap/extension-heading": "^3.27.1", "@tiptap/extension-horizontal-rule": "^3.27.1", "@tiptap/extension-italic": "^3.27.1", "@tiptap/extension-link": "^3.27.1", "@tiptap/extension-list": "^3.27.1", "@tiptap/extension-list-item": "^3.27.1", "@tiptap/extension-list-keymap": "^3.27.1", "@tiptap/extension-ordered-list": "^3.27.1", "@tiptap/extension-paragraph": "^3.27.1", "@tiptap/extension-strike": "^3.27.1", "@tiptap/extension-text": "^3.27.1", "@tiptap/extension-underline": "^3.27.1", "@tiptap/extensions": "^3.27.1", "@tiptap/pm": "^3.27.1" } }, "sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow=="],
 
-    "@tldraw/driver": ["@tldraw/driver@5.1.1", "", { "dependencies": { "@tldraw/editor": "5.1.1", "@tldraw/utils": "5.1.1" } }, "sha512-toOxjedSIawOzx1/DbdA2MgYEFPTXMqbYhdVm8J8AWfvATQOBC5TBlOfUs7dxzRnxwF4N0dZ6AKaJqlN4Fzhfg=="],
+    "@tldraw/driver": ["@tldraw/driver@5.2.3", "", { "dependencies": { "@tldraw/editor": "5.2.3", "@tldraw/utils": "5.2.3" } }, "sha512-DU+JPu5YD2KBkRm4kCeCDfSGQEciUG8FXvOuyx/EOZuDGnQnDVA4CbfFT5pGgZMH502bINXitGakRLiHG+U2Og=="],
 
-    "@tldraw/editor": ["@tldraw/editor@5.1.1", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tldraw/state": "5.1.1", "@tldraw/state-react": "5.1.1", "@tldraw/store": "5.1.1", "@tldraw/tlschema": "5.1.1", "@tldraw/utils": "5.1.1", "@tldraw/validate": "5.1.1", "classnames": "^2.5.1", "eventemitter3": "^4.0.7", "idb": "^7.1.1", "is-plain-object": "^5.0.0", "rbush": "^3.0.1" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-TyIpxJBWHPkOvaviy05Yjnf9pYbBLFib000IxJkeLVv8fkBhFBaQNYyIc93uJwsPxaAdNYhNUye3XxBDSj8fYQ=="],
+    "@tldraw/editor": ["@tldraw/editor@5.2.3", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tldraw/state": "5.2.3", "@tldraw/state-react": "5.2.3", "@tldraw/store": "5.2.3", "@tldraw/tlschema": "5.2.3", "@tldraw/utils": "5.2.3", "@tldraw/validate": "5.2.3", "classnames": "^2.5.1", "eventemitter3": "^4.0.7", "idb": "^7.1.1", "is-plain-object": "^5.0.0", "rbush": "^3.0.1" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-DTdFANx9Kr/rfiBWCfa141MOnzdDCOpRBiAbiv23Cztz3dyN5Y8deaDxh1EvC4PTB7wBO+oVIq1nxCVrIwEKkg=="],
 
-    "@tldraw/state": ["@tldraw/state@5.1.1", "", { "dependencies": { "@tldraw/utils": "5.1.1" } }, "sha512-Niu5UaUMbNRFarZlHWfJYYZyquVSg9v+zBV+N1k/3i9ykXcO41Q7G2zfMa86FmxxBOEIVkAo5L/kYhstO1QHMg=="],
+    "@tldraw/state": ["@tldraw/state@5.2.3", "", { "dependencies": { "@tldraw/utils": "5.2.3" } }, "sha512-hnK6uUpjydiD9GmkhYzgmq3VNmjLuC+jMCbfR67NOC0kl4f0Cs36Het+Pb2sju/KnK+6OsdthNwLHm442YCDfQ=="],
 
-    "@tldraw/state-react": ["@tldraw/state-react@5.1.1", "", { "dependencies": { "@tldraw/state": "5.1.1", "@tldraw/utils": "5.1.1" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-JSINp7qvHF0oZopKD9RRTgMYWlFmEeEj4R8xF15Mc/D4r1Cxc6iLmLWOOlEiHLxIyjmTgZVxqOlmjnJr/YMCCQ=="],
+    "@tldraw/state-react": ["@tldraw/state-react@5.2.3", "", { "dependencies": { "@tldraw/state": "5.2.3", "@tldraw/utils": "5.2.3" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-Z2pQ/rl+LG3U0vYMTRBrohnKMKIbBlXjvSbyJKkghGN75xmc69ciRtb9pLoaUTbIB/eHA2fvnbB1HFxnWm3vgQ=="],
 
-    "@tldraw/store": ["@tldraw/store@5.1.1", "", { "dependencies": { "@tldraw/state": "5.1.1", "@tldraw/utils": "5.1.1" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1" } }, "sha512-J2hLsLaExSFPyyeYWH8qzOcrPd7evWAba07ud5OqmSx2WQiue68OXhClOfUo3/hXQDXJW5ofqNyz8dia/MzFIA=="],
+    "@tldraw/store": ["@tldraw/store@5.2.3", "", { "dependencies": { "@tldraw/state": "5.2.3", "@tldraw/utils": "5.2.3" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1" } }, "sha512-KbX3q5b+fTFqZohh4o/p5dm2nAh/LD8G3+wKcMButqhWyWn5D1vbpNZO6EuyTpLiDAfXmHs2ilZSd9+puNGFpA=="],
 
-    "@tldraw/tlschema": ["@tldraw/tlschema@5.1.1", "", { "dependencies": { "@tldraw/state": "5.1.1", "@tldraw/store": "5.1.1", "@tldraw/utils": "5.1.1", "@tldraw/validate": "5.1.1" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-CG6/gvQd0Ejeqdg3Uom016++fmzBB4JzHMbTdtbwDk4IaN2lbNDR6HHWl8ekhs9MGqVf1EdYyxmAA+BxxqOZWA=="],
+    "@tldraw/tlschema": ["@tldraw/tlschema@5.2.3", "", { "dependencies": { "@tldraw/state": "5.2.3", "@tldraw/store": "5.2.3", "@tldraw/utils": "5.2.3", "@tldraw/validate": "5.2.3" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-VNzEzPuk4xLjGU873y6REMqkUKISRsmqy+p+zqgRg0693C6X9efjcEGteIMXkZ37VNpMAEaa+VPYcbcnCrcbdg=="],
 
-    "@tldraw/utils": ["@tldraw/utils@5.1.1", "", { "dependencies": { "jittered-fractional-indexing": "^1.0.0", "lodash.isequal": "^4.5.0", "lodash.isequalwith": "^4.4.0", "lodash.throttle": "^4.1.1", "lodash.uniq": "^4.5.0" } }, "sha512-km+Q/i3mbfN52O76rrfMm7qhbF+IOjk8nZ7BG9Pk7hSUMM+i81CGm6FYrk2MQUU3oXue4iF1av9y/M5hDHEbMg=="],
+    "@tldraw/utils": ["@tldraw/utils@5.2.3", "", { "dependencies": { "lodash.isequal": "^4.5.0", "lodash.isequalwith": "^4.4.0", "lodash.throttle": "^4.1.1", "lodash.uniq": "^4.5.0" } }, "sha512-n/+ovXkPogDbfYwoX3WhtN5n6iszwjvXxgUk2MHolC6ib7cefAbv5LlSIQ/KAGWMjlR7qJkQiShg0BdVbAr+2A=="],
 
-    "@tldraw/validate": ["@tldraw/validate@5.1.1", "", { "dependencies": { "@tldraw/utils": "5.1.1" } }, "sha512-tf1tYCwBLNDrWrtscTY+jjEmVWXTtaFbiJMIKGq+Tc2JIsCveGyLVMmdif0KtQwbvvab0/4dXbV+l6ZgfZ8oJA=="],
+    "@tldraw/validate": ["@tldraw/validate@5.2.3", "", { "dependencies": { "@tldraw/utils": "5.2.3" } }, "sha512-+c47vL9VNuwdh8+xIePSkbngF5HsNa2cpQTjp+MJhBiuGqgoHXMft5ifcMRfYAkqot7aPcZLqEMha9WxkfrOEA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -1193,8 +1193,6 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
-    "fractional-indexing": ["fractional-indexing@3.2.0", "", {}, "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ=="],
-
     "framer-motion": ["framer-motion@12.35.1", "", { "dependencies": { "motion-dom": "^12.35.1", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rL8cLrjYZNShZqKV3U0Qj6Y5WDiZXYEM5giiTLfEqsIZxtspzMDCkKmrO5po76jWfvOg04+Vk+sfBvTD0iMmLw=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -1354,8 +1352,6 @@
     "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
-
-    "jittered-fractional-indexing": ["jittered-fractional-indexing@1.0.1", "", { "dependencies": { "fractional-indexing": "^3.2.0" } }, "sha512-OpKFkVr4hU5ivd1ZCjZfHvVpWekraJvcePcMusBmgBmCVQK5JiRCA+4TT1vAUTLqGD9MkhqFwO0l3QspvlZgzw=="],
 
     "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
 
@@ -1913,7 +1909,7 @@
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
-    "tldraw": ["tldraw@5.1.1", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/extension-code": "^3.12.1", "@tiptap/extension-highlight": "^3.12.1", "@tiptap/extension-list": "^3.12.1", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tiptap/starter-kit": "^3.12.1", "@tldraw/driver": "5.1.1", "@tldraw/editor": "5.1.1", "@tldraw/store": "5.1.1", "classnames": "^2.5.1", "idb": "^7.1.1", "lz-string": "^1.5.0", "radix-ui": "^1.4.2" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-wC6AwtjlDvV1gFZjIm9vSmG6LHeg8v99HTGpzGT9S0Wg0iSIZduEoQgx6Lp6vRkTYfVrGQV//qBDjwhKq3dIJQ=="],
+    "tldraw": ["tldraw@5.2.3", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/extension-code": "^3.12.1", "@tiptap/extension-highlight": "^3.12.1", "@tiptap/extension-list": "^3.12.1", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tiptap/starter-kit": "^3.12.1", "@tldraw/driver": "5.2.3", "@tldraw/editor": "5.2.3", "@tldraw/store": "5.2.3", "classnames": "^2.5.1", "idb": "^7.1.1", "lz-string": "^1.5.0", "radix-ui": "^1.4.2" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-4MS3HijuFcRMUS4kk6/DPiMsdXirqrS8aYNK9F2VjKZi1izXjURDojG5smNK7a2VgsD9UE6Le1atytjgGIMlVA=="],
 
     "tldts": ["tldts@7.0.25", "", { "dependencies": { "tldts-core": "^7.0.25" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w=="],
 

--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -9,6 +9,7 @@ import {
   type TLDefaultFillStyle,
   type TLDefaultSizeStyle,
   type TLEditorSnapshot,
+  type TLStore,
   type TLUiOverrides,
   DefaultColorStyle,
   DefaultDashStyle,
@@ -19,11 +20,15 @@ import {
   DefaultVerticalAlignStyle,
   GeoShapeGeoStyle,
   Tldraw,
+  createTLStore,
+  defaultBindingUtils,
+  defaultShapeUtils,
   getSnapshot,
   loadSnapshot,
   react
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import tldrawPkg from 'tldraw/package.json'
 import { motion } from 'motion/react'
 import {
   IconArrowUpRight,
@@ -35,14 +40,16 @@ import {
   IconSketching,
   IconSquare,
   IconSticker2,
-  IconTypography
+  IconTypography,
+  IconVersions
 } from '@tabler/icons-react'
 
 import { cn } from '@/client/lib/cn'
 import { useWorkspaceId } from '@/client/lib/WorkspaceContext'
 import { setScratchExecutor } from '@/client/lib/scratch-executor'
 import { type MeiEvent, useMeiEvent } from '@/client/hooks/useMeiEvents'
-import type { ScratchOp, ScratchOpResult } from '@/lib/types'
+import { describeNewerWriter, sequencesAhead } from '@/lib/scratchpad-skew'
+import type { ScratchOp, ScratchOpResult, ScratchpadWriter } from '@/lib/types'
 
 // Identifies this tab's writes so it can ignore the `scratchpad:updated` echo of
 // its own save (see the MEI reload below). Per page load.
@@ -595,28 +602,86 @@ function ScratchStyleBar({ editor }: ScratchStyleBarProps) {
   )
 }
 
+// --- Version-skew pre-flight ------------------------------------------------
+// tldraw snapshots migrate forward only: a canvas saved by a newer tldraw can
+// never load here, and handing it to <Tldraw> anyway lands on tldraw's crash
+// screen — whose main button is a destructive "Reset data". So every fetched
+// document is pre-flighted against this bundle's schema first; on failure we
+// render a friendly read-only notice and never mount the editor, which is what
+// guarantees this stale client can't autosave over the newer file. See
+// lib/scratchpad-skew.ts and docs/moi-scratchpad.md § Version skew.
+
+// What GET /api/workspaces/:id/scratchpad returns (see server/scratchpad.ts).
+type ScratchpadFetch = {
+  document: TLEditorSnapshot['document'] | null
+  writer?: ScratchpadWriter
+}
+
+// Why the canvas can't be shown: a newer writer (version skew) or a snapshot
+// that fails to load for some other reason. Either way the file is left alone.
+type ScratchpadSkew = { newer: boolean; writer?: ScratchpadWriter; detail: string }
+
+// This bundle's schema, built once and lazily — the same store config the
+// editor and the server executor use, so the pre-flight verdict matches what
+// <Tldraw> would do.
+let runtimeSchemaCache: TLStore['schema'] | null = null
+function runtimeSchema(): TLStore['schema'] {
+  if (!runtimeSchemaCache) {
+    runtimeSchemaCache = createTLStore({
+      shapeUtils: defaultShapeUtils,
+      bindingUtils: defaultBindingUtils
+    }).schema
+  }
+  return runtimeSchemaCache
+}
+
+// Dry-run the migration <Tldraw>/`loadSnapshot` would perform. Returns null when
+// the document is safe to mount, else the skew to display.
+function detectSkew(
+  document: NonNullable<TLEditorSnapshot['document']>,
+  writer: ScratchpadWriter | undefined
+): ScratchpadSkew | null {
+  const schema = runtimeSchema()
+  try {
+    if (schema.migrateStoreSnapshot(document).type === 'success') return null
+  } catch {}
+  const ahead = sequencesAhead(document.schema, schema.serialize().sequences)
+  if (ahead.length > 0) return { newer: true, writer, detail: describeNewerWriter(writer, ahead) }
+  return { newer: false, writer, detail: 'The saved snapshot failed to load.' }
+}
+
 // Hydrate the saved canvas once per workspace from the REST snapshot endpoint.
 // Returns a STABLE snapshot reference (held in a ref, never a fresh object per
 // render): tldraw rebuilds its entire store whenever the `snapshot` prop identity
 // changes, so handing it a new object each render loops it forever — remounting the
 // store and re-fetching fonts/translations endlessly. `document: null` → empty
-// canvas; `loaded` gates the placeholder until the fetch settles.
+// canvas; `loaded` gates the placeholder until the fetch settles. A document that
+// fails the pre-flight sets `skew` instead of the snapshot; `flagSkew` lets the
+// remote-reload path flip the same state mid-session.
 function useScratchpadSnapshot(workspaceId: string): {
   loaded: boolean
   snapshot: Partial<TLEditorSnapshot> | undefined
+  skew: ScratchpadSkew | null
+  flagSkew: (skew: ScratchpadSkew) => void
 } {
   const [loaded, setLoaded] = useState(false)
+  const [skew, setSkew] = useState<ScratchpadSkew | null>(null)
   const snapshot = useRef<Partial<TLEditorSnapshot> | undefined>(undefined)
 
   useEffect(() => {
     let cancelled = false
     setLoaded(false)
+    setSkew(null)
     snapshot.current = undefined
     fetch(`/api/workspaces/${workspaceId}/scratchpad`)
       .then(r => r.json())
-      .then((d: { document: TLEditorSnapshot['document'] | null }) => {
+      .then((d: ScratchpadFetch) => {
         if (cancelled) return
-        if (d?.document) snapshot.current = { document: d.document }
+        if (d?.document) {
+          const found = detectSkew(d.document, d.writer)
+          if (found) setSkew(found)
+          else snapshot.current = { document: d.document }
+        }
         setLoaded(true)
       })
       .catch(() => {
@@ -627,7 +692,47 @@ function useScratchpadSnapshot(workspaceId: string): {
     }
   }, [workspaceId])
 
-  return { loaded, snapshot: snapshot.current }
+  return { loaded, snapshot: snapshot.current, skew, flagSkew: setSkew }
+}
+
+type ScratchpadSkewNoticeProps = { skew: ScratchpadSkew }
+
+// The read-only stand-in for an unloadable canvas. Deliberately mounts no
+// editor and offers no "load anyway": with no store there is nothing to
+// autosave, so the newer file on disk stays byte-for-byte intact.
+function ScratchpadSkewNotice({ skew }: ScratchpadSkewNoticeProps) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center bg-muted/40 p-6">
+      <div className="flex max-w-md animate-in flex-col gap-3 rounded-xl border bg-background p-6 shadow-sm duration-200 fade-in-0 zoom-in-95">
+        <div className="flex items-center gap-2">
+          <IconVersions size={20} stroke={1.5} className="shrink-0 text-amber-600" />
+          <h2 className="font-semibold text-foreground">
+            {skew.newer ? 'This canvas needs a newer moi' : 'This canvas couldn’t be loaded'}
+          </h2>
+        </div>
+        {skew.newer ? (
+          <>
+            <p className="text-sm text-muted-foreground">
+              It was last saved by a newer version of moi ({skew.detail}), and this moi (tldraw{' '}
+              {tldrawPkg.version}) can’t open canvases from the future.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Restart the newer moi server, or update this one:
+            </p>
+            <code className="self-start rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
+              bun install -g moi-computer@latest
+            </code>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">{skew.detail}</p>
+        )}
+        <p className="text-sm text-muted-foreground">
+          Nothing was lost — the canvas file is untouched and stays that way while this notice is
+          shown.
+        </p>
+      </div>
+    </div>
+  )
 }
 
 // The Scratchpad surface: a real tldraw editor, hydrated from and autosaved to
@@ -649,7 +754,7 @@ export function Scratchpad() {
   const applyingRemote = useRef(false)
   // Reactive handle to the mounted editor, used to render the custom tool bar.
   const [editor, setEditor] = useState<Editor | null>(null)
-  const { loaded, snapshot } = useScratchpadSnapshot(workspaceId)
+  const { loaded, snapshot, skew, flagSkew } = useScratchpadSnapshot(workspaceId)
 
   const save = useCallback(() => {
     const editor = editorRef.current
@@ -668,16 +773,26 @@ export function Scratchpad() {
   }, [workspaceId])
 
   // A remote save (another tab, or an agent draw landing in another tab) — pull
-  // the new snapshot and load it into the live store. Skip our own echo.
+  // the new snapshot and load it into the live store. Skip our own echo. The
+  // fetched document is pre-flighted like the initial load: if the server was
+  // swapped for a newer moi mid-session, `loadSnapshot` here would throw — flip
+  // the skew notice instead (unmounting the editor, which also stops the
+  // autosave timer) so this stale tab can't save over the newer file.
   useMeiEvent((e: MeiEvent) => {
     if (e.type !== 'scratchpad:updated' || e.workspaceId !== workspaceId) return
     if (e.origin && e.origin === ORIGIN_ID) return
     if (!editorRef.current) return
     fetch(`/api/workspaces/${workspaceId}/scratchpad`)
       .then(r => r.json())
-      .then((d: { document: TLEditorSnapshot['document'] | null }) => {
+      .then((d: ScratchpadFetch) => {
         const editor = editorRef.current
         if (!editor || !d?.document) return
+        const found = detectSkew(d.document, d.writer)
+        if (found) {
+          if (saveTimer.current) clearTimeout(saveTimer.current)
+          flagSkew(found)
+          return
+        }
         applyingRemote.current = true
         loadSnapshot(editor.store, { document: d.document })
       })
@@ -750,6 +865,7 @@ export function Scratchpad() {
   )
 
   if (!loaded) return <div className="min-h-0 flex-1 bg-muted/40" />
+  if (skew) return <ScratchpadSkewNotice skew={skew} />
 
   return (
     <div ref={rootRef} className="relative min-h-0 flex-1 overflow-hidden">

--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -28,7 +28,6 @@ import {
   react
 } from 'tldraw'
 import 'tldraw/tldraw.css'
-import tldrawPkg from 'tldraw/package.json'
 import { motion } from 'motion/react'
 import {
   IconArrowUpRight,
@@ -713,11 +712,9 @@ function ScratchpadSkewNotice({ skew }: ScratchpadSkewNoticeProps) {
         {skew.newer ? (
           <>
             <p className="text-sm text-muted-foreground">
-              It was last saved by a newer version of moi ({skew.detail}), and this moi (tldraw{' '}
-              {tldrawPkg.version}) can’t open canvases from the future.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Restart the newer moi server, or update this one:
+              This scratchpad was saved by a newer version of moi
+              {skew.writer ? ` (v${skew.writer.moi})` : ''} — please update moi and restart the
+              server:
             </p>
             <code className="self-start rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
               bun install -g moi-computer@latest
@@ -726,10 +723,6 @@ function ScratchpadSkewNotice({ skew }: ScratchpadSkewNoticeProps) {
         ) : (
           <p className="text-sm text-muted-foreground">{skew.detail}</p>
         )}
-        <p className="text-sm text-muted-foreground">
-          Nothing was lost — the canvas file is untouched and stays that way while this notice is
-          shown.
-        </p>
       </div>
     </div>
   )

--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -701,19 +701,19 @@ type ScratchpadSkewNoticeProps = { skew: ScratchpadSkew }
 // autosave, so the newer file on disk stays byte-for-byte intact.
 function ScratchpadSkewNotice({ skew }: ScratchpadSkewNoticeProps) {
   return (
-    <div className="flex min-h-0 flex-1 items-center justify-center bg-muted/40 p-6">
-      <div className="flex max-w-md animate-in flex-col gap-3 rounded-xl border bg-background p-6 shadow-sm duration-200 fade-in-0 zoom-in-95">
+    <div className="flex min-h-0 flex-1 items-center justify-center bg-muted/40 bg-[radial-gradient(var(--color-border)_1px,transparent_1px)] [background-size:16px_16px] p-6">
+      <div className="flex max-w-md animate-in flex-col gap-3 rounded-md bg-background p-6 shadow-xs duration-200 fade-in-0 zoom-in-95">
         <div className="flex items-center gap-2">
           <IconVersions size={20} stroke={1.5} className="shrink-0 text-amber-600" />
-          <h2 className="font-semibold text-foreground">
+          <h2 className="font-medium text-foreground">
             {skew.newer ? 'This canvas needs a newer moi' : 'This canvas couldn’t be loaded'}
           </h2>
         </div>
         {skew.newer ? (
           <>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-pretty text-muted-foreground">
               This scratchpad was saved by a newer version of moi
-              {skew.writer ? ` (v${skew.writer.moi})` : ''} — please update moi and restart the
+              {skew.writer ? ` (v${skew.writer.moi})` : ''}.<br /> Please update moi and restart the
               server:
             </p>
             <code className="self-start rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -120,6 +120,34 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
 > couldn't draw to a closed canvas. The write path moved server-side so drawing no longer
 > depends on the user keeping the Scratchpad open.
 
+## Version skew
+
+The snapshot embeds the serialized tldraw schema of whatever process last **wrote** it, and
+tldraw migrates **forward only** — there are no down-migrations. So `.moi/.scratchpad.json`
+is readable only by tldraw versions ≥ the writer's; a canvas touched by a newer moi will not
+open in an older one. That's the invariant everything below defends.
+
+- **tldraw is pinned exactly** in `package.json` (no `^`/`~` range), and a test
+  (`server/test/tldraw-pin.test.ts`) keeps it that way. The client is prebuilt into `dist/`
+  at publish time with the publisher's `node_modules`, but with a range the server's tldraw
+  would resolve at **install** time — one published version could then ship a client older
+  than its own server, which writes snapshots that client can't read. The pin also keeps
+  side-by-side installs (global package vs repo checkout) on the same schema as long as
+  they're the same moi version.
+- **Bumping tldraw is a deliberate act**: change the pin, `bun install`, test, and
+  release-note that canvases touched by the new version won't open in older moi.
+- **Every save is stamped** with the writer (`{ writer: { moi, tldraw } }` next to
+  `document`), so when an older moi does hit a newer file, the error can name the version
+  it needs. Deliberate downgrades and branch-hopping can't be prevented — only made loud,
+  actionable, and non-destructive: the server's headless ops fail with a message saying
+  which moi wrote the file and how to update (instead of tldraw's bare `migration-error`),
+  and the browser shows a read-only notice _without mounting the editor_ — never tldraw's
+  crash screen with its destructive "Reset data" button, and with no editor mounted the
+  stale tab can't autosave over the newer file. `moi scratch read`/`read-image` parse the
+  raw JSON without migration, so the agent can still see the canvas under skew. The first
+  save after a schema change also keeps the previous file as `.scratchpad.json.bak` — the
+  manual escape hatch after a downgrade. Detection lives in `lib/scratchpad-skew.ts`.
+
 ## Building it
 
 Lean on what's already here rather than inventing plumbing. The canvas is a `<Tldraw>` mounted

--- a/lib/scratchpad-skew.ts
+++ b/lib/scratchpad-skew.ts
@@ -1,0 +1,64 @@
+import type { ScratchpadWriter } from './types'
+
+// Version-skew detection for Scratchpad snapshots. A tldraw snapshot embeds the
+// serialized schema of whatever tldraw *wrote* it, and tldraw has no
+// down-migrations — a snapshot written by a newer schema can never be loaded by
+// an older one. When `loadSnapshot`/`migrateStoreSnapshot` fails, these helpers
+// tell "the file is from a newer tldraw" apart from genuine corruption, so both
+// the server error (scratchpad-executor.ts) and the client notice
+// (client/components/Scratchpad.tsx) can say something actionable instead of
+// tldraw's bare `migration-error`. See docs/moi-scratchpad.md § Version skew.
+
+// A serialized tldraw schema's migration sequences: sequence id → version, e.g.
+// `{ "com.tldraw.shape.note": 9 }`.
+export type SchemaSequences = Record<string, number>
+
+// One sequence in the file that the runtime can't load: the file's version is
+// ahead of the runtime's, or the runtime doesn't know the sequence at all
+// (which also means a newer writer).
+export type SequenceAhead = { id: string; fileVersion: number; runtimeVersion?: number }
+
+// Pull the `sequences` map out of an unknown `document.schema` value —
+// best-effort, since the file is disk JSON. Returns null when the shape isn't a
+// v2 serialized schema.
+export function schemaSequences(schema: unknown): SchemaSequences | null {
+  if (!schema || typeof schema !== 'object') return null
+  const sequences = (schema as { sequences?: unknown }).sequences
+  if (!sequences || typeof sequences !== 'object') return null
+  const out: SchemaSequences = {}
+  for (const [id, version] of Object.entries(sequences)) {
+    if (typeof version === 'number') out[id] = version
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+// The file sequences the runtime is behind on. Non-empty means the snapshot was
+// written by a newer tldraw than the runtime — the load failure is skew, not
+// corruption.
+export function sequencesAhead(fileSchema: unknown, runtime: SchemaSequences): SequenceAhead[] {
+  const file = schemaSequences(fileSchema)
+  if (!file) return []
+  const ahead: SequenceAhead[] = []
+  for (const [id, fileVersion] of Object.entries(file)) {
+    const runtimeVersion = runtime[id]
+    if (runtimeVersion === undefined) ahead.push({ id, fileVersion })
+    else if (fileVersion > runtimeVersion) ahead.push({ id, fileVersion, runtimeVersion })
+  }
+  return ahead
+}
+
+// "moi 0.1.5, tldraw 5.3.0" when the stamp is there, else the sequences that
+// are ahead — so the message can always name *what* is newer.
+export function describeNewerWriter(
+  writer: ScratchpadWriter | undefined,
+  ahead: SequenceAhead[]
+): string {
+  if (writer) return `moi ${writer.moi}, tldraw ${writer.tldraw}`
+  return ahead
+    .map(a =>
+      a.runtimeVersion === undefined
+        ? `${a.id} v${a.fileVersion} (unknown here)`
+        : `${a.id} v${a.fileVersion} > v${a.runtimeVersion}`
+    )
+    .join(', ')
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -106,6 +106,11 @@ export type ScratchOp =
 // data URL for `view`, or a bare ack for mutations.
 export type ScratchOpResult = { name: string } | { image: string } | { ok: true }
 
+// The process that last persisted `.moi/.scratchpad.json` (always the server —
+// browser saves funnel through it). Stamped on save so an older reader hitting
+// the snapshot can name the version it needs (see lib/scratchpad-skew.ts).
+export type ScratchpadWriter = { moi: string; tldraw: string }
+
 // An attachment uploaded ahead of a chat message. The bytes live server-side in
 // an in-memory upload store (see server/uploads.ts); a chat frame references it
 // by `id`. `kind` splits the two delivery paths: an `image` is inlined as a

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "sugar-high": "^1.2.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.11",
-    "tldraw": "^5.1.1",
+    "tldraw": "5.2.3",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "wouter": "^3.9.0",

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -19,10 +19,22 @@ import {
   toRichText
 } from 'tldraw'
 
-import type { ScratchImageQuality, ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
+import { describeNewerWriter, sequencesAhead } from '@/lib/scratchpad-skew'
+import type {
+  ScratchImageQuality,
+  ScratchOp,
+  ScratchOpResult,
+  ScratchStyle,
+  ScratchpadWriter
+} from '@/lib/types'
 
 import { publishEvent } from './events'
-import { type ScratchpadDoc, loadScratchpadDoc, saveScratchpadDoc } from './scratchpad'
+import {
+  SCRATCHPAD_WRITER,
+  type ScratchpadDoc,
+  loadScratchpadDoc,
+  saveScratchpadDoc
+} from './scratchpad'
 
 // Server-side Scratchpad writer. The browser is no longer required to draw: we run
 // the same ops against a *headless* tldraw store here, persist the snapshot, and
@@ -65,10 +77,31 @@ function styleProps(style: ScratchStyle): Record<string, unknown> {
 
 // A fresh headless store hydrated from the saved snapshot (or empty). The
 // snapshot shape (`{ document }`) matches what the browser PUTs and loads.
-function buildStore(doc: ScratchpadDoc | null): TLStore {
+// A failed load is inspected for version skew: tldraw has no down-migrations,
+// so a snapshot written by a newer tldraw is unreadable here — but intact.
+// That gets a loud, actionable error instead of tldraw's bare `migration-error`
+// (which surfaces verbatim through the control port to the `moi scratch` CLI).
+function buildStore(doc: ScratchpadDoc | null, writer: ScratchpadWriter | undefined): TLStore {
   const store = createTLStore({ shapeUtils: defaultShapeUtils, bindingUtils: defaultBindingUtils })
   if (doc?.store) {
-    loadSnapshot(store, { document: doc } as unknown as Parameters<typeof loadSnapshot>[1])
+    try {
+      loadSnapshot(store, { document: doc } as unknown as Parameters<typeof loadSnapshot>[1])
+    } catch (err) {
+      const ahead = sequencesAhead(doc.schema, store.schema.serialize().sequences)
+      if (ahead.length > 0) {
+        throw new Error(
+          `Scratchpad was written by a newer moi (${describeNewerWriter(writer, ahead)}); ` +
+            `this server has tldraw ${SCRATCHPAD_WRITER.tldraw}. Restart the newer server or ` +
+            `update this install (bun install -g moi-computer@latest). ` +
+            `The canvas file is intact — do not reset it.`
+        )
+      }
+      // Not skew — the snapshot itself is bad. Keep the original cause visible.
+      throw new Error(
+        `Scratchpad snapshot failed to load (not a version mismatch — the file may be ` +
+          `corrupted): ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
   }
   // Seed the document/page records a fresh (or partial) store needs to be valid.
   store.ensureStoreIsUsable()
@@ -368,8 +401,8 @@ export function executeScratchOp(
   op: ScratchOp
 ): Promise<ScratchOpResult> {
   return withLock(workspacePath, async () => {
-    const { document } = await loadScratchpadDoc(workspacePath)
-    const store = buildStore(document)
+    const { document, writer } = await loadScratchpadDoc(workspacePath)
+    const store = buildStore(document, writer)
     // add-image decodes/resizes the file first, so it's the one async op.
     const result = op.kind === 'add-image' ? await applyAddImage(store, op) : applyOp(store, op)
     const next = getSnapshot(store).document as unknown as ScratchpadDoc

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -1,5 +1,11 @@
 import { join } from 'path'
 
+import tldrawPkg from 'tldraw/package.json'
+
+import type { ScratchpadWriter } from '@/lib/types'
+
+import moiPkg from '../package.json'
+
 // The Scratchpad is a shared tldraw canvas per workspace, persisted as a tldraw
 // *document* snapshot here (the per-tab `session` is intentionally dropped). Two
 // writers: the browser autosaves on user edits, and the server writes on agent
@@ -9,7 +15,17 @@ import { join } from 'path'
 // A tldraw document snapshot: `getSnapshot(store).document`. Opaque to us apart
 // from `.store` (the record map) which `read` walks. `null` means empty canvas.
 export type ScratchpadDoc = { store?: Record<string, unknown>; schema?: unknown }
-export type ScratchpadSnapshot = { document: ScratchpadDoc | null }
+export type ScratchpadSnapshot = { document: ScratchpadDoc | null; writer?: ScratchpadWriter }
+
+// This process's identity as a snapshot writer. The tldraw version is what
+// matters for compatibility (the snapshot embeds its schema); the moi version is
+// what a user can actually act on ("update moi"). Both resolve from this
+// install's own package.json files, so they're correct in the repo-source and
+// installed layouts alike.
+export const SCRATCHPAD_WRITER: ScratchpadWriter = {
+  moi: moiPkg.version,
+  tldraw: tldrawPkg.version
+}
 
 // One shape as surfaced by `moi scratch read` — a compact, agent-friendly view.
 export type ScratchShape = {
@@ -32,12 +48,21 @@ export function getScratchpadPath(workspacePath: string): string {
   return join(workspacePath, '.moi', '.scratchpad.json')
 }
 
+// The writer stamp is trusted only off disk — we wrote it (saveScratchpadDoc
+// stamps every save); a client PUT body never carries one through.
+function parseWriter(value: unknown): ScratchpadWriter | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const w = value as { moi?: unknown; tldraw?: unknown }
+  if (typeof w.moi !== 'string' || typeof w.tldraw !== 'string') return undefined
+  return { moi: w.moi, tldraw: w.tldraw }
+}
+
 export async function loadScratchpadDoc(workspacePath: string): Promise<ScratchpadSnapshot> {
   try {
     const text = await Bun.file(getScratchpadPath(workspacePath)).text()
     const parsed = JSON.parse(text)
     if (parsed && typeof parsed === 'object' && parsed.document) {
-      return { document: parsed.document as ScratchpadDoc }
+      return { document: parsed.document as ScratchpadDoc, writer: parseWriter(parsed.writer) }
     }
   } catch {}
   return { document: null }
@@ -47,7 +72,23 @@ export async function saveScratchpadDoc(
   document: ScratchpadDoc,
   workspacePath: string
 ): Promise<void> {
-  await Bun.write(getScratchpadPath(workspacePath), JSON.stringify({ document }, null, 2))
+  const path = getScratchpadPath(workspacePath)
+  await backupOnSchemaChange(path, document)
+  await Bun.write(path, JSON.stringify({ document, writer: SCRATCHPAD_WRITER }, null, 2))
+}
+
+// When a save is about to overwrite a snapshot with a *different* schema (i.e.
+// the first write after a tldraw upgrade), keep the old file as `.bak` — the
+// manual escape hatch after a downgrade, since the new file won't open in the
+// older tldraw. One .bak, replaced on each schema change. Best-effort: a backup
+// failure must never block the save.
+async function backupOnSchemaChange(path: string, document: ScratchpadDoc): Promise<void> {
+  try {
+    const existing = JSON.parse(await Bun.file(path).text()) as { document?: ScratchpadDoc }
+    const oldSchema = existing?.document?.schema
+    if (!oldSchema || JSON.stringify(oldSchema) === JSON.stringify(document.schema)) return
+    await Bun.write(`${path}.bak`, Bun.file(path))
+  } catch {}
 }
 
 // tldraw embeds pasted/dropped images as `data:<mime>;base64,<blob>` URLs (on

--- a/server/test/scratchpad-skew.test.ts
+++ b/server/test/scratchpad-skew.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'path'
+
+import type { ScratchpadWriter } from '@/lib/types'
+
+import { executeScratchOp } from '../scratchpad-executor'
+import {
+  SCRATCHPAD_WRITER,
+  getScratchpadPath,
+  loadScratchpadDoc,
+  readScratchpadShapes
+} from '../scratchpad'
+
+// Version-skew behavior: `.moi/.scratchpad.json` embeds the writer's tldraw
+// schema and tldraw has no down-migrations, so a snapshot written by a newer
+// tldraw must fail HERE with an actionable message (not tldraw's bare
+// `migration-error`), while the raw-JSON read path keeps working. See
+// docs/moi-scratchpad.md § Version skew.
+
+let WS: string
+beforeEach(() => {
+  WS = mkdtempSync(join(import.meta.dir, 'scratch-skew-test-'))
+})
+afterEach(() => {
+  rmSync(WS, { recursive: true, force: true })
+})
+
+const run = (op: Parameters<typeof executeScratchOp>[2]) => executeScratchOp(WS, 'ws-test', op)
+
+type FileShape = {
+  document: { schema: { sequences: Record<string, number> }; store: Record<string, unknown> }
+  writer?: ScratchpadWriter
+}
+
+async function readFile(): Promise<FileShape> {
+  return JSON.parse(await Bun.file(getScratchpadPath(WS)).text())
+}
+
+// A real current-schema snapshot with one sequence bumped past this runtime —
+// exactly what a newer tldraw leaves behind.
+async function writeSkewedFixture(writer?: ScratchpadWriter): Promise<string> {
+  await run({ kind: 'add-note', name: 'n1', x: 0, y: 0, text: 'hello' })
+  const file = await readFile()
+  file.document.schema.sequences['com.tldraw.shape.note'] += 1
+  if (writer) file.writer = writer
+  else delete file.writer
+  const text = JSON.stringify(file, null, 2)
+  await Bun.write(getScratchpadPath(WS), text)
+  return text
+}
+
+describe('scratchpad version skew', () => {
+  test('saves are stamped with the writing moi + tldraw, and load surfaces it', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
+    expect((await readFile()).writer).toEqual(SCRATCHPAD_WRITER)
+    expect(SCRATCHPAD_WRITER.tldraw).toMatch(/^\d+\.\d+\.\d+/)
+    expect((await loadScratchpadDoc(WS)).writer).toEqual(SCRATCHPAD_WRITER)
+  })
+
+  test('an unstamped legacy file still loads (writer just absent)', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
+    const file = await readFile()
+    delete file.writer
+    await Bun.write(getScratchpadPath(WS), JSON.stringify(file))
+    expect((await loadScratchpadDoc(WS)).writer).toBeUndefined()
+    await run({ kind: 'add-rect', name: 'box2', x: 20, y: 0, w: 10, h: 10 })
+    expect(await readScratchpadShapes(WS)).toHaveLength(2)
+  })
+
+  test('a newer-schema snapshot fails with the actionable message, naming the stamp', async () => {
+    const before = await writeSkewedFixture({ moi: '9.9.9', tldraw: '99.0.0' })
+
+    const err = await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 }).then(
+      () => null,
+      (e: Error) => e
+    )
+    expect(err?.message).toContain('written by a newer moi')
+    expect(err?.message).toContain('moi 9.9.9, tldraw 99.0.0')
+    expect(err?.message).toContain(`this server has tldraw ${SCRATCHPAD_WRITER.tldraw}`)
+    expect(err?.message).toContain('bun install -g moi-computer@latest')
+    expect(err?.message).toContain('intact')
+    expect(err?.message).not.toContain('migration-error')
+
+    // The failed op must not have touched the file.
+    expect(await Bun.file(getScratchpadPath(WS)).text()).toBe(before)
+  })
+
+  test('an unstamped newer-schema snapshot names the sequences that are ahead', async () => {
+    await writeSkewedFixture()
+    const err = await run({ kind: 'clear' }).then(
+      () => null,
+      (e: Error) => e
+    )
+    expect(err?.message).toContain('written by a newer moi')
+    expect(err?.message).toContain('com.tldraw.shape.note')
+  })
+
+  test('moi scratch read still works under skew (raw JSON, no migration)', async () => {
+    await writeSkewedFixture({ moi: '9.9.9', tldraw: '99.0.0' })
+    const shapes = await readScratchpadShapes(WS)
+    expect(shapes).toEqual([expect.objectContaining({ id: 'n1', type: 'note', text: 'hello' })])
+  })
+
+  test('a corrupt (non-skew) snapshot fails differently, keeping the cause', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
+    const file = await readFile()
+    // Same schema, mangled record — genuine corruption, not version skew.
+    file.document.store['shape:box'] = { typeName: 'shape', id: 'shape:box', type: 'geo' }
+    await Bun.write(getScratchpadPath(WS), JSON.stringify(file))
+    const err = await run({ kind: 'clear' }).then(
+      () => null,
+      (e: Error) => e
+    )
+    expect(err?.message).toContain('not a version mismatch')
+    expect(err?.message).not.toContain('written by a newer moi')
+  })
+
+  test('the first save after a schema change backs up the old file as .bak', async () => {
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, w: 10, h: 10 })
+    const path = getScratchpadPath(WS)
+
+    // Same-schema saves: no backup. (Fresh Bun.file handles each time — a
+    // handle that has observed a missing file keeps reporting it empty.)
+    await run({ kind: 'add-rect', name: 'box2', x: 20, y: 0, w: 10, h: 10 })
+    expect(await Bun.file(`${path}.bak`).exists()).toBe(false)
+
+    // Simulate the on-disk file predating a schema bump, then save over it.
+    const file = await readFile()
+    const oldText = JSON.stringify({
+      ...file,
+      document: {
+        ...file.document,
+        schema: {
+          ...file.document.schema,
+          sequences: { ...file.document.schema.sequences, 'com.tldraw.shape.note': 0 }
+        }
+      }
+    })
+    await Bun.write(path, oldText)
+    await run({ kind: 'add-rect', name: 'box3', x: 40, y: 0, w: 10, h: 10 })
+    expect(await Bun.file(`${path}.bak`).text()).toBe(oldText)
+  })
+})

--- a/server/test/tldraw-pin.test.ts
+++ b/server/test/tldraw-pin.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test'
+
+import pkg from '../../package.json'
+
+// tldraw must be pinned EXACTLY — no ^/~ range. The client is prebuilt into
+// dist/ at publish time with the publisher's node_modules, but the server's
+// tldraw resolves from the range at *install* time. With a range, one published
+// version can ship a dist client OLDER than the server that serves it, and the
+// server then writes .moi/.scratchpad.json snapshots its own client cannot read
+// (tldraw has no down-migrations). An exact pin makes the two always agree.
+// Bumping tldraw is a deliberate act: change the pin, bun install, test,
+// release-note it. See docs/moi-scratchpad.md § Version skew.
+test('tldraw is pinned to an exact version', () => {
+  expect(pkg.dependencies.tldraw).toMatch(/^\d/)
+})


### PR DESCRIPTION
Adds comprehensive version-skew detection and handling for Scratchpad snapshots. Since tldraw has no down-migrations, a snapshot written by a newer tldraw version cannot be loaded by an older one. This change ensures that version mismatches are detected early, reported clearly, and handled non-destructively on both server and client.

## Key Changes

- **Version detection infrastructure** (`lib/scratchpad-skew.ts`): New helpers to detect when a snapshot's schema is ahead of the runtime's, distinguish version skew from genuine corruption, and generate actionable error messages naming the writer version.

- **Server-side enforcement** (`server/scratchpad-executor.ts`): When `loadSnapshot` fails, inspect the schema sequences to determine if it's version skew (newer tldraw) or corruption. Throw a clear error message with the writer's moi/tldraw versions and upgrade instructions instead of tldraw's bare `migration-error`.

- **Client-side pre-flight** (`client/components/Scratchpad.tsx`): Before mounting the editor, dry-run the migration against this bundle's schema. If skew is detected, render a read-only notice without mounting the editor—preventing autosave from overwriting the newer file. The notice explains the situation and provides upgrade instructions.

- **Snapshot stamping** (`server/scratchpad.ts`): Every save now includes a `writer` field with moi and tldraw versions, so older readers can name exactly what version wrote the file. Also backs up the previous snapshot as `.scratchpad.json.bak` when the schema changes, providing a manual escape hatch after downgrades.

- **Schema pinning** (`package.json`, `server/test/tldraw-pin.test.ts`): tldraw is now pinned to an exact version (no `^`/`~` range) to ensure the prebuilt client and server always agree on schema. A test enforces this invariant.

- **Comprehensive test coverage** (`server/test/scratchpad-skew.test.ts`): Tests for stamped saves, legacy unstamped files, newer-schema detection with actionable messages, raw-JSON read path resilience, corruption detection, and backup behavior.

## Implementation Details

- The pre-flight check uses the same store config (`defaultShapeUtils`, `defaultBindingUtils`) as the editor and server executor, so detection verdicts match what would actually happen.
- Remote reloads (another tab saving) also trigger pre-flight checks; if skew is detected mid-session, the autosave timer is cleared and the notice replaces the editor.
- `moi scratch read`/`read-image` continue to work under skew by parsing raw JSON without migration, so agents can still access the canvas.
- All error handling is best-effort; backup failures never block saves.

https://claude.ai/code/session_01T2iZZ4XUwHoNrPNxZGFkdb