### PR TITLE
Approach B: relative placement + align/distribute/autosize/tidy verbs

### DIFF
--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -45,17 +45,41 @@ that maps onto tldraw's own shape API — friendly to drive and stable against t
 internal schema:
 
 ```
-moi scratch add text   --at <x,y> --text "..."          [--id NAME] [--color C] [--font-size S]
-moi scratch add rect   --at <x,y> --size <w,h> [--text]  [--id NAME] [--color C] [--fill F] [--font-size S]
-moi scratch add note   --at <x,y> --text "..."           [--id NAME] [--color C] [--font-size S]
+moi scratch add text   <pos> --text "..."               [--id NAME] [--color C] [--font-size S]
+moi scratch add rect   <pos> [--size <w,h>] [--text]     [--id NAME] [--color C] [--fill F] [--font-size S]
+moi scratch add note   <pos> --text "..."                [--id NAME] [--color C] [--font-size S]
 moi scratch add arrow  --from <id|x,y> --to <id|x,y>     [--id NAME] [--color C] [--stroke S] [--elbow]
 moi scratch add image  <path>                            [--at <x,y>] [--id NAME] [--quality lo|hi]
 moi scratch move   <id> --to <x,y>
 moi scratch set    <id> --text "..."        # relabel / edit
+moi scratch align      <id> <id> [...] --edge left|right|top|bottom|center-x|center-y [--to <id>]
+moi scratch distribute <id> <id> <id> [...] --axis x|y [--gap N]
+moi scratch autosize   <id> [...]           # re-fit labeled rects to their labels
+moi scratch tidy [--grid N]                 # snap to grid + pull near-aligned edges together
 moi scratch delete <id>
 moi scratch clear                           # wipe the whole canvas
 ```
 
+- `<pos>` for text/rect/note is either an absolute `--at <x,y>` **or a relative placement**:
+  `--below <id>`, `--above <id>`, `--left-of <id>`, `--right-of <id>`, optionally with
+  `--gap <n>` (distance from the anchor, default 48) and `--align start|center|end`
+  (cross-axis alignment to the anchor, default `center` — e.g. `--below a --align start`
+  puts left edges flush). Exactly one of the two; the server resolves the anchor's real
+  bounds, so relative placement is exact where guessed coordinates aren't. Arrows can't
+  be anchors (their geometry lives in bindings).
+- `rect --size` is optional: omitted with `--text`, the server measures the label with the
+  actual canvas font and sizes the box to fit (so the label can never overflow); omitted
+  without text it falls back to a 160×96 node box. Give an explicit size only when the box
+  isn't label-driven (e.g. a container drawn around other shapes).
+- The arrangement verbs are the align/distribute/snap of a design tool. `align` lines the
+  listed shapes' chosen edge or center up with the anchor's (`--to`, default the first
+  listed) and moves them only on that axis. `distribute` spaces shapes along an axis in
+  their current order — with `--gap` it repacks at exactly that spacing (first shape stays
+  put); without, the first and last stay fixed and the gaps between are equalized.
+  `autosize` re-fits labeled rects to their labels in place (top-left kept). `tidy` is the
+  canvas-wide pass: snap every position (and rect size) to the grid (default 8px), then
+  pull edges and centers that are within 10px of lining up exactly together. All four skip
+  arrows — bound arrows follow their shapes on their own.
 - `--id` gives a shape a stable handle so later commands can address it; otherwise the
   command returns the generated id.
 - `arrow --from <id> --to <id>` binds endpoints to shapes, so the arrow **follows** when the
@@ -80,8 +104,24 @@ moi scratch clear                           # wipe the whole canvas
 
 The set is deliberately small — text, rect, note, arrow (with color plus each shape's
 fill/font-size/stroke), plus
-move/set/delete/clear. Enough to lay out a diagram or annotate the user's drawing; not a full
-tldraw API.
+move/set/delete/clear and the arrangement verbs. Enough to lay out a diagram or annotate the
+user's drawing; not a full tldraw API.
+
+### Laying out a diagram
+
+The failure mode to avoid is coordinate arithmetic: computing absolute positions in your head
+produces overlaps, clipped labels, and crooked rows. The workflow that works: **anchor one
+shape absolutely, place everything else relatively, let rects size themselves, and finish
+with the arrangement verbs.**
+
+1. Place the first shape with `--at` (anywhere sensible; `0,0` is fine).
+2. Every subsequent shape hangs off an existing one: `--below`, `--right-of`, etc. Don't
+   compute coordinates — name the neighbor.
+3. Omit `--size` on labeled rects; the server fits the box to the label.
+4. Connect with `add arrow --from <id> --to <id>` (bound arrows follow their shapes through
+   every later adjustment).
+5. Finish with `align` / `distribute` for rows and columns, `autosize` if a relabel outgrew
+   its box, and `tidy` to square everything up.
 
 ## How it works
 
@@ -96,14 +136,18 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
   tab reloads from disk, so all viewers converge.
 - **Reading** (`moi scratch read`, `read-image`) parses that snapshot straight off disk — the
   shape listing, or one image's bytes. No browser, no tldraw runtime.
-- **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server: it loads the snapshot
+- **Drawing** (`add`/`move`/`set`/`align`/`distribute`/`autosize`/`tidy`/`delete`/`clear`)
+  runs on the server: it loads the snapshot
   into a headless `tldraw` store (`createTLStore` + the default shape/binding utils), applies
   the op as store records — using each shape's `getDefaultProps()` so records are schema-valid —
   writes the snapshot back, and nudges open tabs to reload. **No live tab required.** The store
   validates every record on `put`, so a malformed shape throws instead of corrupting the file.
   `add image` additionally resizes the file through `sharp` (the same dep the icon pipeline uses)
   before embedding it. (We drive the store, not an `Editor`, because the Editor needs a DOM + text
-  measurement the server runtime doesn't have. See `server/scratchpad-executor.ts`.)
+  measurement the server runtime doesn't have. See `server/scratchpad-executor.ts`.) Relative
+  placement and the arrangement verbs resolve here too — only the server-side store can see an
+  anchor's bounds — with text measured in the real canvas font (`server/scratchpad-metrics.ts`)
+  and the geometry in `server/scratchpad-arrange.ts`.
 - **Viewing** (`moi scratch view`) is the one op still relayed to a connected tab: only the
   browser can rasterize the canvas (`editor.toImageDataUrl`). With no tab showing **this**
   workspace's scratchpad it returns "No live canvas" — every other op still works off disk.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -65,18 +65,53 @@ export type ScratchStyle = { color?: ScratchColor; size?: ScratchSize; fill?: Sc
 // the canvas light), 'hi' allows more pixels when detail matters.
 export type ScratchImageQuality = 'lo' | 'hi'
 
+// Relative placement for an add op — "put it below that shape" instead of raw
+// coordinates. Carried on the op and resolved by the executor, because only the
+// server-side store can see the anchor's bounds. `gap` is the distance from the
+// anchor on the placement axis; `align` sets the cross axis ('start' = leading
+// edges flush, 'end' = trailing edges flush, 'center' = midpoints match).
+export type ScratchPlacement = {
+  anchor: string
+  side: 'above' | 'below' | 'left' | 'right'
+  gap: number
+  align: 'start' | 'center' | 'end'
+}
+
+// Which edge (or center line) `align` lines shapes up on. The `-x` / `-y`
+// suffix names the axis the centers share — center-x aligns vertical center
+// lines (shapes move horizontally), center-y the horizontal ones.
+export type ScratchAlignEdge = 'left' | 'right' | 'top' | 'bottom' | 'center-x' | 'center-y'
+
+// Add ops position with absolute x/y *or* a relative `place` — exactly one.
+// A rect's w/h may be omitted too: the executor fits the box to its label
+// (or falls back to a default node size), so labels never overflow.
 export type ScratchOp =
-  | ({ kind: 'add-text'; name: string; x: number; y: number; text: string } & ScratchStyle)
+  | ({
+      kind: 'add-text'
+      name: string
+      x?: number
+      y?: number
+      place?: ScratchPlacement
+      text: string
+    } & ScratchStyle)
   | ({
       kind: 'add-rect'
       name: string
-      x: number
-      y: number
-      w: number
-      h: number
+      x?: number
+      y?: number
+      place?: ScratchPlacement
+      w?: number
+      h?: number
       text?: string
     } & ScratchStyle)
-  | ({ kind: 'add-note'; name: string; x: number; y: number; text: string } & ScratchStyle)
+  | ({
+      kind: 'add-note'
+      name: string
+      x?: number
+      y?: number
+      place?: ScratchPlacement
+      text: string
+    } & ScratchStyle)
   // Add an image from a local file `path` — the server resizes it to fit the
   // canvas and embeds it (color/stroke don't apply, so no ScratchStyle).
   // `quality` picks the resize preset: 'lo' (default, smaller) or 'hi' (sharper).
@@ -98,6 +133,18 @@ export type ScratchOp =
     } & ScratchStyle)
   | { kind: 'move'; name: string; x: number; y: number }
   | { kind: 'set'; name: string; text: string }
+  // Arrangement verbs — the align/distribute/tidy every design tool ships, so
+  // the agent nudges shapes into place instead of recomputing coordinates.
+  // Arrows are never arranged directly; bound arrows follow their shapes.
+  | { kind: 'align'; names: string[]; edge: ScratchAlignEdge; to?: string }
+  // With `gap`: repack in spatial order at exact gaps (first shape stays put).
+  // Without: keep the first and last fixed and equalize the gaps between.
+  | { kind: 'distribute'; names: string[]; axis: 'x' | 'y'; gap?: number }
+  // Re-fit labeled rects to their labels (same sizing as an auto-sized add).
+  | { kind: 'autosize'; names: string[] }
+  // Canvas-wide cleanup: snap positions (and geo sizes) to the grid, then pull
+  // nearly-aligned edges/centers exactly together.
+  | { kind: 'tidy'; grid?: number }
   | { kind: 'delete'; name: string }
   | { kind: 'clear' }
   | { kind: 'view' }

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -9,11 +9,13 @@ import pc from 'picocolors'
 import { COLOR_THEMES, FONT_THEMES } from '@/lib/themes'
 import type { ColorTheme, FontTheme } from '@/lib/themes'
 import type {
+  ScratchAlignEdge,
   ScratchArrowEnd,
   ScratchColor,
   ScratchFill,
   ScratchImageQuality,
   ScratchOp,
+  ScratchPlacement,
   ScratchSize,
   ScratchStyle
 } from '@/lib/types'
@@ -1235,6 +1237,68 @@ function styleArgs(args: {
   }
 }
 
+// Relative placement flags shared by `add text|rect|note` — position a new
+// shape off an existing one instead of computing coordinates. The anchor's
+// bounds live server-side, so the CLI only names the intent; the executor
+// resolves it (see server/scratchpad-arrange.ts).
+const placeArgs = {
+  below: { type: 'string', description: 'Place below this shape (instead of --at)' },
+  above: { type: 'string', description: 'Place above this shape (instead of --at)' },
+  leftOf: { type: 'string', description: 'Place left of this shape (instead of --at)' },
+  rightOf: { type: 'string', description: 'Place right of this shape (instead of --at)' },
+  gap: { type: 'string', description: 'Distance from the anchor in px (default: 48)' },
+  align: {
+    type: 'string',
+    description: 'Cross-axis alignment to the anchor: start|center|end (default: center)'
+  }
+} as const
+
+const PLACE_ALIGNS = ['start', 'center', 'end'] as const
+
+// Exactly one way to position a shape: absolute `--at`, or one relative side
+// flag (`--gap`/`--align` only make sense with the latter).
+function parsePosition(args: {
+  at?: string
+  below?: string
+  above?: string
+  leftOf?: string
+  rightOf?: string
+  gap?: string
+  align?: string
+}): { x: number; y: number } | { place: ScratchPlacement } {
+  const sides: [ScratchPlacement['side'], string][] = []
+  if (args.above) sides.push(['above', args.above])
+  if (args.below) sides.push(['below', args.below])
+  if (args.leftOf) sides.push(['left', args.leftOf])
+  if (args.rightOf) sides.push(['right', args.rightOf])
+  if (sides.length > 1) {
+    throw new Error('Pick one of --below/--above/--left-of/--right-of, not several')
+  }
+  if (sides.length === 0) {
+    if (args.gap || args.align) {
+      throw new Error('--gap/--align only apply with --below/--above/--left-of/--right-of')
+    }
+    if (!args.at) {
+      throw new Error(
+        'Position the shape with --at "x,y" or one of --below/--above/--left-of/--right-of'
+      )
+    }
+    return parseXY(args.at)
+  }
+  if (args.at) throw new Error('--at and --below/--above/--left-of/--right-of are exclusive')
+  const [side, anchor] = sides[0]
+  let gap = 48
+  if (args.gap !== undefined) {
+    gap = Number(args.gap)
+    if (!Number.isFinite(gap) || gap < 0) throw new Error(`Expected a gap ≥ 0, got "${args.gap}"`)
+  }
+  const alignRaw = (args.align ?? 'center').trim().toLowerCase()
+  if (!(PLACE_ALIGNS as readonly string[]).includes(alignRaw)) {
+    throw new Error(`Unknown align "${args.align}". Use one of: ${PLACE_ALIGNS.join(', ')}.`)
+  }
+  return { place: { anchor, side, gap, align: alignRaw as ScratchPlacement['align'] } }
+}
+
 type ScratchCliOp = ScratchOp | { kind: 'read' } | { kind: 'read-image'; name: string }
 
 // Round-trip one op through the control port and hand the reply to `onResult`.
@@ -1365,22 +1429,21 @@ const scratchReadImage = defineCommand({
 const scratchAddText = defineCommand({
   meta: { name: 'text', description: 'Add a text shape' },
   args: {
-    at: { type: 'string', required: true, description: 'Position "x,y"' },
+    at: { type: 'string', description: 'Position "x,y" (or use a relative flag)' },
     text: { type: 'string', required: true, description: 'Text content' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    ...placeArgs,
     color: colorArg,
     fontSize: fontSizeArg,
     dir: dirArg
   },
   run({ args }) {
-    const { x, y } = parseXY(args.at)
     sendScratch(
       resolve(args.dir),
       {
         kind: 'add-text',
         name: args.id ?? '',
-        x,
-        y,
+        ...parsePosition(args),
         text: args.text,
         ...styleArgs({ color: args.color, fontSize: args.fontSize })
       },
@@ -1392,27 +1455,29 @@ const scratchAddText = defineCommand({
 const scratchAddRect = defineCommand({
   meta: { name: 'rect', description: 'Add a rectangle' },
   args: {
-    at: { type: 'string', required: true, description: 'Top-left position "x,y"' },
-    size: { type: 'string', required: true, description: 'Size "w,h"' },
+    at: { type: 'string', description: 'Top-left position "x,y" (or use a relative flag)' },
+    size: {
+      type: 'string',
+      description: 'Size "w,h" (omit to fit the label — labels never overflow)'
+    },
     text: { type: 'string', description: 'Optional label' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    ...placeArgs,
     color: colorArg,
     fill: fillArg,
     fontSize: fontSizeArg,
     dir: dirArg
   },
   run({ args }) {
-    const { x, y } = parseXY(args.at)
-    const { x: w, y: h } = parseXY(args.size)
+    // `--size` is optional: omitted, the server fits the rect to its label.
+    const size = args.size ? parseXY(args.size) : undefined
     sendScratch(
       resolve(args.dir),
       {
         kind: 'add-rect',
         name: args.id ?? '',
-        x,
-        y,
-        w,
-        h,
+        ...parsePosition(args),
+        ...(size ? { w: size.x, h: size.y } : {}),
         ...(args.text ? { text: args.text } : {}),
         ...styleArgs({ color: args.color, fill: args.fill, fontSize: args.fontSize })
       },
@@ -1424,22 +1489,21 @@ const scratchAddRect = defineCommand({
 const scratchAddNote = defineCommand({
   meta: { name: 'note', description: 'Add a sticky note' },
   args: {
-    at: { type: 'string', required: true, description: 'Position "x,y"' },
+    at: { type: 'string', description: 'Position "x,y" (or use a relative flag)' },
     text: { type: 'string', required: true, description: 'Note content' },
     id: { type: 'string', description: 'Stable name to address this shape later' },
+    ...placeArgs,
     color: colorArg,
     fontSize: fontSizeArg,
     dir: dirArg
   },
   run({ args }) {
-    const { x, y } = parseXY(args.at)
     sendScratch(
       resolve(args.dir),
       {
         kind: 'add-note',
         name: args.id ?? '',
-        x,
-        y,
+        ...parsePosition(args),
         text: args.text,
         ...styleArgs({ color: args.color, fontSize: args.fontSize })
       },
@@ -1571,6 +1635,111 @@ const scratchClear = defineCommand({
   }
 })
 
+const ALIGN_EDGES: ScratchAlignEdge[] = ['left', 'right', 'top', 'bottom', 'center-x', 'center-y']
+
+function parseEdge(s: string): ScratchAlignEdge {
+  const edge = s.trim().toLowerCase()
+  if (!(ALIGN_EDGES as string[]).includes(edge)) {
+    throw new Error(`Unknown edge "${s}". Use one of: ${ALIGN_EDGES.join(', ')}.`)
+  }
+  return edge as ScratchAlignEdge
+}
+
+// The `id [id...]` rest-positional pattern (same as `moi env unset`): citty
+// collects every positional into `args._`.
+function parseIds(rest: string[], min: number, verb: string): string[] {
+  const ids = rest.map(s => s.trim()).filter(s => s.length > 0)
+  if (ids.length < min) throw new Error(`${verb} needs at least ${min} shape ids`)
+  return ids
+}
+
+const scratchAlign = defineCommand({
+  meta: { name: 'align', description: 'Line shapes up on an edge or center (arrows follow)' },
+  args: {
+    id: { type: 'positional', required: true, description: 'Shape names (two or more)' },
+    edge: {
+      type: 'string',
+      required: true,
+      description: `Edge to align: ${ALIGN_EDGES.join(', ')}`
+    },
+    to: { type: 'string', description: 'Anchor shape that stays put (default: first listed)' },
+    dir: dirArg
+  },
+  run({ args }) {
+    const names = parseIds(args._, 2, 'align')
+    sendScratch(
+      resolve(args.dir),
+      { kind: 'align', names, edge: parseEdge(args.edge), ...(args.to ? { to: args.to } : {}) },
+      () => console.log('\n' + pc.green('✓') + ' aligned ' + pc.bold(names.join(', ')) + '\n')
+    )
+  }
+})
+
+const scratchDistribute = defineCommand({
+  meta: { name: 'distribute', description: 'Space shapes evenly along an axis' },
+  args: {
+    id: { type: 'positional', required: true, description: 'Shape names (two or more)' },
+    axis: { type: 'string', required: true, description: 'Axis: x (a row) or y (a column)' },
+    gap: {
+      type: 'string',
+      description: 'Exact gap in px (omit to equalize between the first and last)'
+    },
+    dir: dirArg
+  },
+  run({ args }) {
+    const axis = args.axis.trim().toLowerCase()
+    if (axis !== 'x' && axis !== 'y') throw new Error(`Unknown axis "${args.axis}". Use x or y.`)
+    let gap: number | undefined
+    if (args.gap !== undefined) {
+      gap = Number(args.gap)
+      if (!Number.isFinite(gap) || gap < 0) throw new Error(`Expected a gap ≥ 0, got "${args.gap}"`)
+    }
+    const names = parseIds(args._, 2, 'distribute')
+    sendScratch(
+      resolve(args.dir),
+      { kind: 'distribute', names, axis, ...(gap !== undefined ? { gap } : {}) },
+      () => console.log('\n' + pc.green('✓') + ' distributed ' + pc.bold(names.join(', ')) + '\n')
+    )
+  }
+})
+
+const scratchAutosize = defineCommand({
+  meta: { name: 'autosize', description: 'Re-fit labeled rects to their labels' },
+  args: {
+    id: { type: 'positional', required: true, description: 'Rect names' },
+    dir: dirArg
+  },
+  run({ args }) {
+    const names = parseIds(args._, 1, 'autosize')
+    sendScratch(resolve(args.dir), { kind: 'autosize', names }, () =>
+      console.log('\n' + pc.green('✓') + ' autosized ' + pc.bold(names.join(', ')) + '\n')
+    )
+  }
+})
+
+const scratchTidy = defineCommand({
+  meta: {
+    name: 'tidy',
+    description: 'Snap every shape to the grid and pull near-aligned edges together'
+  },
+  args: {
+    grid: { type: 'string', description: 'Grid step in px (default: 8)' },
+    dir: dirArg
+  },
+  run({ args }) {
+    let grid: number | undefined
+    if (args.grid !== undefined) {
+      grid = Number(args.grid)
+      if (!Number.isFinite(grid) || grid <= 0) {
+        throw new Error(`Expected a grid step > 0, got "${args.grid}"`)
+      }
+    }
+    sendScratch(resolve(args.dir), { kind: 'tidy', ...(grid !== undefined ? { grid } : {}) }, () =>
+      console.log('\n' + pc.green('✓') + ' tidied the canvas\n')
+    )
+  }
+})
+
 const scratch = defineCommand({
   meta: {
     name: 'scratch',
@@ -1583,6 +1752,10 @@ const scratch = defineCommand({
     add: scratchAdd,
     move: scratchMove,
     set: scratchSet,
+    align: scratchAlign,
+    distribute: scratchDistribute,
+    autosize: scratchAutosize,
+    tidy: scratchTidy,
     delete: scratchDelete,
     clear: scratchClear
   }

--- a/server/scratchpad-arrange.ts
+++ b/server/scratchpad-arrange.ts
@@ -1,0 +1,357 @@
+import { type TLRecord, type TLStore, createShapeId } from 'tldraw'
+
+import type { ScratchOp, ScratchPlacement } from '@/lib/types'
+
+import { extractText } from './scratchpad'
+import { TEXT_FONT_SIZES, fitRectToLabel, textBlockSize } from './scratchpad-metrics'
+
+// Geometry for the Scratchpad's arrangement verbs: relative placement on add,
+// and align / distribute / autosize / tidy. This is where "put it below the
+// proxy box" turns into coordinates — the agent states topology, the server
+// does the arithmetic. Everything here runs against the headless store (see
+// scratchpad-executor.ts), so bounds are computed from records, not a DOM.
+//
+// Arrows are never arranged directly: a bound arrow's geometry lives in its
+// bindings and follows its shapes, so moving the arrow record would fight the
+// binding. Every verb skips arrows; an arrow can't be an anchor either.
+
+// The store's record union can't be narrowed by `typeName` alone, so verbs view
+// records through this minimal shape. `store.put` re-validates on write, which
+// is the real guarantee behind the casts below.
+type ShapeLike = {
+  id: string
+  typeName: 'shape'
+  type: string
+  x: number
+  y: number
+  props: Record<string, unknown>
+}
+
+export type Bounds = { x: number; y: number; w: number; h: number }
+
+// tldraw note shapes carry no w/h props: they're a fixed 200×200 pad that only
+// grows downward (`props.growY`) when the text overflows.
+const NOTE_SIZE = 200
+
+// Auto-sizing for rects when `--size` is omitted: fit the label at a readable
+// wrap width, or fall back to a sensible node box for an unlabeled rect.
+const RECT_TARGET_WIDTH = 260
+const DEFAULT_RECT = { w: 160, h: 96 }
+
+/** Rect size when the caller didn't give one: fitted to the label (never
+ * overflowing — the point of omitting `--size`), or the default node box. */
+export function autoRectSize(
+  text: string | undefined,
+  sizeToken: string | undefined
+): { w: number; h: number } {
+  if (!text) return { ...DEFAULT_RECT }
+  return fitRectToLabel(text, { size: sizeToken ?? 'm', targetWidth: RECT_TARGET_WIDTH })
+}
+
+/**
+ * Axis-aligned bounds of a shape record, without an editor. Geo/image shapes
+ * carry explicit w/h; notes are the fixed pad plus growY; text has no reliable
+ * stored width, so it's estimated with the canvas font metrics. Arrows have no
+ * standalone bounds (their geometry lives in bindings) → null.
+ */
+export function shapeBounds(record: TLRecord): Bounds | null {
+  const s = record as unknown as ShapeLike
+  if (s.type === 'arrow') return null
+  if (s.type === 'note') {
+    const growY = typeof s.props.growY === 'number' ? s.props.growY : 0
+    return { x: s.x, y: s.y, w: NOTE_SIZE, h: NOTE_SIZE + growY }
+  }
+  if (s.type === 'text') {
+    const token = typeof s.props.size === 'string' ? s.props.size : 'm'
+    const fontSize = TEXT_FONT_SIZES[token] ?? TEXT_FONT_SIZES.m
+    const block = textBlockSize(extractText(s.props) ?? '', fontSize)
+    return { x: s.x, y: s.y, w: block.w, h: block.h }
+  }
+  // Geo, image, and anything else with stored dimensions; unknown types (e.g.
+  // the user's freehand strokes) degrade to a point at their origin.
+  const w = typeof s.props.w === 'number' ? s.props.w : 0
+  const h = typeof s.props.h === 'number' ? s.props.h : 0
+  return { x: s.x, y: s.y, w, h }
+}
+
+function getShapeRecord(store: TLStore, name: string): TLRecord {
+  const record = store.get(createShapeId(name))
+  if (!record || record.typeName !== 'shape') throw new Error(`No shape named "${name}"`)
+  return record
+}
+
+/** Estimated size of a text shape *before* it exists, for placing it. */
+export function textAddSize(text: string, sizeToken: string | undefined): { w: number; h: number } {
+  const fontSize = TEXT_FONT_SIZES[sizeToken ?? 'm'] ?? TEXT_FONT_SIZES.m
+  const block = textBlockSize(text, fontSize)
+  return { w: block.w, h: block.h }
+}
+
+/** The fixed footprint a new note occupies, for placing it. */
+export function noteAddSize(): { w: number; h: number } {
+  return { w: NOTE_SIZE, h: NOTE_SIZE }
+}
+
+/**
+ * Turn a relative placement into the new shape's top-left: offset from the
+ * anchor by `gap` on the placement axis, aligned on the cross axis.
+ */
+export function resolvePlacement(
+  store: TLStore,
+  place: ScratchPlacement,
+  size: { w: number; h: number }
+): { x: number; y: number } {
+  const anchor = shapeBounds(getShapeRecord(store, place.anchor))
+  if (!anchor) {
+    throw new Error(
+      `Cannot place relative to arrow "${place.anchor}" — anchor a rect, note, text, or image instead`
+    )
+  }
+  // Cross-axis coordinate: leading edges flush / centered / trailing edges flush.
+  const across = (aPos: number, aLen: number, len: number) =>
+    place.align === 'start'
+      ? aPos
+      : place.align === 'end'
+        ? aPos + aLen - len
+        : aPos + (aLen - len) / 2
+  switch (place.side) {
+    case 'below':
+      return { x: across(anchor.x, anchor.w, size.w), y: anchor.y + anchor.h + place.gap }
+    case 'above':
+      return { x: across(anchor.x, anchor.w, size.w), y: anchor.y - place.gap - size.h }
+    case 'right':
+      return { x: anchor.x + anchor.w + place.gap, y: across(anchor.y, anchor.h, size.h) }
+    case 'left':
+      return { x: anchor.x - place.gap - size.w, y: across(anchor.y, anchor.h, size.h) }
+  }
+}
+
+// How far a shape must move so its chosen edge/center matches the target's.
+// Each edge moves exactly one axis — align never disturbs the other.
+function alignDelta(
+  edge: Extract<ScratchOp, { kind: 'align' }>['edge'],
+  target: Bounds,
+  b: Bounds
+): { dx: number; dy: number } {
+  switch (edge) {
+    case 'left':
+      return { dx: target.x - b.x, dy: 0 }
+    case 'right':
+      return { dx: target.x + target.w - (b.x + b.w), dy: 0 }
+    case 'center-x':
+      return { dx: target.x + target.w / 2 - (b.x + b.w / 2), dy: 0 }
+    case 'top':
+      return { dx: 0, dy: target.y - b.y }
+    case 'bottom':
+      return { dx: 0, dy: target.y + target.h - (b.y + b.h) }
+    case 'center-y':
+      return { dx: 0, dy: target.y + target.h / 2 - (b.y + b.h / 2) }
+  }
+}
+
+/** Align each listed shape's edge/center to the anchor's (`to`, default the
+ * first listed). Anchor stays put; arrows in the list are skipped. */
+export function applyAlign(store: TLStore, op: Extract<ScratchOp, { kind: 'align' }>): void {
+  const anchorName = op.to ?? op.names[0]
+  const target = shapeBounds(getShapeRecord(store, anchorName))
+  if (!target) throw new Error(`Cannot align to arrow "${anchorName}" — pick a non-arrow anchor`)
+  for (const name of op.names) {
+    if (name === anchorName) continue
+    const rec = getShapeRecord(store, name)
+    const b = shapeBounds(rec)
+    if (!b) continue // arrows follow their bound shapes; never move them directly
+    const { dx, dy } = alignDelta(op.edge, target, b)
+    if (dx === 0 && dy === 0) continue
+    const s = rec as unknown as ShapeLike
+    store.put([{ ...rec, x: s.x + dx, y: s.y + dy } as TLRecord])
+  }
+}
+
+/**
+ * Distribute shapes along an axis, in their current spatial order. With `gap`,
+ * repack at exactly that spacing (the first shape stays put); without, keep the
+ * first and last where they are and equalize the gaps between.
+ */
+export function applyDistribute(
+  store: TLStore,
+  op: Extract<ScratchOp, { kind: 'distribute' }>
+): void {
+  const items: { name: string; rec: TLRecord; b: Bounds }[] = []
+  for (const name of op.names) {
+    const rec = getShapeRecord(store, name)
+    const b = shapeBounds(rec)
+    if (b) items.push({ name, rec, b }) // arrows (null bounds) never distribute
+  }
+  const pos = (b: Bounds) => (op.axis === 'x' ? b.x : b.y)
+  const len = (b: Bounds) => (op.axis === 'x' ? b.w : b.h)
+  // Spatial order, name as a deterministic tie-break for stacked shapes.
+  items.sort((a, z) => pos(a.b) - pos(z.b) || a.name.localeCompare(z.name))
+  if (items.length < 2) throw new Error('distribute needs at least 2 non-arrow shapes')
+
+  const moveTo = (item: (typeof items)[number], target: number) => {
+    const delta = target - pos(item.b)
+    if (delta === 0) return
+    const s = item.rec as unknown as ShapeLike
+    store.put([
+      {
+        ...item.rec,
+        ...(op.axis === 'x' ? { x: s.x + delta } : { y: s.y + delta })
+      } as TLRecord
+    ])
+  }
+
+  if (op.gap !== undefined) {
+    let cursor = pos(items[0].b) + len(items[0].b)
+    for (const item of items.slice(1)) {
+      moveTo(item, cursor + op.gap)
+      cursor += op.gap + len(item.b)
+    }
+    return
+  }
+  if (items.length < 3) {
+    throw new Error(
+      'distribute without --gap needs at least 3 shapes (the first and last stay fixed)'
+    )
+  }
+  const first = items[0]
+  const last = items[items.length - 1]
+  const middle = items.slice(1, -1)
+  const free =
+    pos(last.b) - (pos(first.b) + len(first.b)) - middle.reduce((sum, m) => sum + len(m.b), 0)
+  const gap = free / (middle.length + 1)
+  let cursor = pos(first.b) + len(first.b)
+  for (const item of middle) {
+    moveTo(item, cursor + gap)
+    cursor += gap + len(item.b)
+  }
+}
+
+/** Re-fit each listed rect to its label (same sizing as an auto-sized add),
+ * keeping its top-left. Non-rect or unlabeled ids fail the whole op — the
+ * executor is all-or-nothing, so nothing persists on error. */
+export function applyAutosize(store: TLStore, op: Extract<ScratchOp, { kind: 'autosize' }>): void {
+  const fits = op.names.map(name => {
+    const rec = getShapeRecord(store, name)
+    const s = rec as unknown as ShapeLike
+    if (s.type !== 'geo') {
+      throw new Error(`Cannot autosize "${name}": only labeled rects refit (it is a ${s.type})`)
+    }
+    const text = extractText(s.props)
+    if (!text) throw new Error(`Cannot autosize "${name}": it has no label to fit`)
+    const sizeToken = typeof s.props.size === 'string' ? s.props.size : undefined
+    return { rec, s, fit: autoRectSize(text, sizeToken) }
+  })
+  for (const { rec, s, fit } of fits) {
+    store.put([{ ...rec, props: { ...s.props, w: fit.w, h: fit.h } } as TLRecord])
+  }
+}
+
+// Two edges/centers closer than this get pulled exactly together by tidy —
+// the "almost lined up" band a human eyeballs away.
+const NEAR = 10
+
+type ClusterEntry = { s: ShapeLike; value: number; locked: boolean }
+
+// Cluster near-equal values and snap each cluster of ≥2 onto one shared line.
+// Sorted by (value, id) first, and a value joins the open cluster while it sits
+// within NEAR of the cluster's first member — both make the grouping
+// deterministic. The shared line is the grid-rounded mean of the cluster's
+// locked members when any exist (so already-aligned shapes stay put and others
+// come to them), else of the whole cluster. Returns the ids that clustered.
+function snapClusters(
+  entries: ClusterEntry[],
+  grid: number,
+  apply: (s: ShapeLike, delta: number) => void
+): Set<string> {
+  const snapped = new Set<string>()
+  const sorted = [...entries].sort((a, b) => a.value - b.value || a.s.id.localeCompare(b.s.id))
+  let cluster: ClusterEntry[] = []
+  const flush = () => {
+    if (cluster.length >= 2) {
+      const locked = cluster.filter(e => e.locked)
+      const pool = locked.length > 0 ? locked : cluster
+      const mean = pool.reduce((sum, e) => sum + e.value, 0) / pool.length
+      const target = Math.round(mean / grid) * grid
+      for (const e of cluster) {
+        snapped.add(e.s.id)
+        if (!e.locked && e.value !== target) apply(e.s, target - e.value)
+      }
+    }
+    cluster = []
+  }
+  for (const e of sorted) {
+    if (cluster.length > 0 && e.value - cluster[0].value > NEAR) flush()
+    cluster.push(e)
+  }
+  flush()
+  return snapped
+}
+
+/**
+ * Canvas-wide cleanup: snap every non-arrow shape's position (and geo w/h) to
+ * the grid, then pull nearly-aligned left edges, horizontal centers, and top
+ * edges exactly together. Bound arrows follow their shapes on their own.
+ */
+export function applyTidy(store: TLStore, op: Extract<ScratchOp, { kind: 'tidy' }>): void {
+  const grid = op.grid ?? 8
+  if (!Number.isFinite(grid) || grid <= 0) throw new Error('Grid must be a positive number')
+  const snap = (v: number) => Math.round(v / grid) * grid
+
+  // Work on copies, mutate through the passes, and put once at the end.
+  const shapes: ShapeLike[] = []
+  for (const record of store.allRecords()) {
+    if (record.typeName !== 'shape') continue
+    const s = record as unknown as ShapeLike
+    if (s.type === 'arrow') continue
+    shapes.push({ ...s, props: { ...s.props } })
+  }
+
+  // Pass 1 — grid snap. Sizes only for geo: notes/text size themselves, and
+  // resampling an image's w/h would stretch it for no visual gain.
+  for (const s of shapes) {
+    s.x = snap(s.x)
+    s.y = snap(s.y)
+    if (s.type === 'geo') {
+      if (typeof s.props.w === 'number') s.props.w = Math.max(grid, snap(s.props.w))
+      if (typeof s.props.h === 'number') s.props.h = Math.max(grid, snap(s.props.h))
+    }
+  }
+
+  // Widths/heights don't change in the remaining passes; positions do.
+  const dims = new Map<string, { w: number; h: number }>()
+  for (const s of shapes) {
+    const b = shapeBounds(s as unknown as TLRecord)
+    dims.set(s.id, { w: b?.w ?? 0, h: b?.h ?? 0 })
+  }
+
+  // Pass 2 — left edges. Pass 3 — horizontal centers, where shapes whose left
+  // edge just clustered are locked: they anchor a center cluster but never move
+  // again on x, so centering can't undo the left alignment. Pass 4 — top edges.
+  const leftAligned = snapClusters(
+    shapes.map(s => ({ s, value: s.x, locked: false })),
+    grid,
+    (s, d) => {
+      s.x += d
+    }
+  )
+  snapClusters(
+    shapes.map(s => ({
+      s,
+      value: s.x + (dims.get(s.id)?.w ?? 0) / 2,
+      locked: leftAligned.has(s.id)
+    })),
+    grid,
+    (s, d) => {
+      s.x += d
+    }
+  )
+  snapClusters(
+    shapes.map(s => ({ s, value: s.y, locked: false })),
+    grid,
+    (s, d) => {
+      s.y += d
+    }
+  )
+
+  if (shapes.length > 0) store.put(shapes as unknown as TLRecord[])
+}

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -19,10 +19,26 @@ import {
   toRichText
 } from 'tldraw'
 
-import type { ScratchImageQuality, ScratchOp, ScratchOpResult, ScratchStyle } from '@/lib/types'
+import type {
+  ScratchImageQuality,
+  ScratchOp,
+  ScratchOpResult,
+  ScratchPlacement,
+  ScratchStyle
+} from '@/lib/types'
 
 import { publishEvent } from './events'
 import { type ScratchpadDoc, loadScratchpadDoc, saveScratchpadDoc } from './scratchpad'
+import {
+  applyAlign,
+  applyAutosize,
+  applyDistribute,
+  applyTidy,
+  autoRectSize,
+  noteAddSize,
+  resolvePlacement,
+  textAddSize
+} from './scratchpad-arrange'
 
 // Server-side Scratchpad writer. The browser is no longer required to draw: we run
 // the same ops against a *headless* tldraw store here, persist the snapshot, and
@@ -208,6 +224,22 @@ async function applyAddImage(
   return { name: op.name }
 }
 
+// Where an add op lands: absolute x/y from `--at`, or a relative placement
+// resolved against the anchor's bounds — deciding needs the store, so it
+// happens here, not in the CLI. `size` is the new shape's footprint (known for
+// rects, estimated for text, fixed for notes), used for cross-axis alignment.
+function resolveAddPosition(
+  store: TLStore,
+  op: { x?: number; y?: number; place?: ScratchPlacement },
+  size: { w: number; h: number }
+): { x: number; y: number } {
+  if (op.place) return resolvePlacement(store, op.place, size)
+  if (typeof op.x === 'number' && typeof op.y === 'number') return { x: op.x, y: op.y }
+  throw new Error(
+    'Missing position: pass --at "x,y" or a relative flag (--below/--above/--left-of/--right-of)'
+  )
+}
+
 // Apply one mutating op to the store. `read` and `view` are handled elsewhere
 // (disk / browser) and never reach here. Returns the op's result.
 function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
@@ -220,19 +252,26 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
 
   switch (op.kind) {
     case 'add-rect': {
+      // No `--size` → fit the box to its label (or the default node box), so a
+      // freshly placed rect can never overflow its own text.
+      const size =
+        op.w !== undefined && op.h !== undefined
+          ? { w: op.w, h: op.h }
+          : autoRectSize(op.text, op.size)
+      const { x, y } = resolveAddPosition(store, op, size)
       store.put([
         shapeRecord({
           id: createShapeId(op.name),
           type: 'geo',
-          x: op.x,
-          y: op.y,
+          x,
+          y,
           index: nextIndex(store, pageId),
           parentId: pageId,
           props: {
             ...defaultProps('geo'),
             geo: 'rectangle',
-            w: op.w,
-            h: op.h,
+            w: size.w,
+            h: size.h,
             ...styleProps(op),
             ...(op.text ? { richText: toRichText(op.text) } : {})
           }
@@ -241,12 +280,13 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
       return { name: op.name }
     }
     case 'add-text': {
+      const { x, y } = resolveAddPosition(store, op, textAddSize(op.text, op.size))
       store.put([
         shapeRecord({
           id: createShapeId(op.name),
           type: 'text',
-          x: op.x,
-          y: op.y,
+          x,
+          y,
           index: nextIndex(store, pageId),
           parentId: pageId,
           props: { ...defaultProps('text'), richText: toRichText(op.text), ...styleProps(op) }
@@ -255,12 +295,13 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
       return { name: op.name }
     }
     case 'add-note': {
+      const { x, y } = resolveAddPosition(store, op, noteAddSize())
       store.put([
         shapeRecord({
           id: createShapeId(op.name),
           type: 'note',
-          x: op.x,
-          y: op.y,
+          x,
+          y,
           index: nextIndex(store, pageId),
           parentId: pageId,
           props: { ...defaultProps('note'), richText: toRichText(op.text), ...styleProps(op) }
@@ -310,6 +351,23 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
       store.put([
         { ...shape, props: { ...shape.props, richText: toRichText(op.text) } } as TLRecord
       ])
+      return { ok: true }
+    }
+    // The arrangement verbs (geometry lives in scratchpad-arrange.ts).
+    case 'align': {
+      applyAlign(store, op)
+      return { ok: true }
+    }
+    case 'distribute': {
+      applyDistribute(store, op)
+      return { ok: true }
+    }
+    case 'autosize': {
+      applyAutosize(store, op)
+      return { ok: true }
+    }
+    case 'tidy': {
+      applyTidy(store, op)
       return { ok: true }
     }
     case 'delete': {

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -62,8 +62,9 @@ function omitBase64(text: string): string {
 
 // Pull readable text out of a shape's props. tldraw stores labels as `richText`
 // (a ProseMirror-style doc) on most shapes; older/simple shapes may use a flat
-// `text` string. Best-effort — never throw on an unexpected shape.
-function extractText(props: unknown): string | undefined {
+// `text` string. Best-effort — never throw on an unexpected shape. Exported for
+// the arrangement verbs (autosize refits a rect to this extracted label).
+export function extractText(props: unknown): string | undefined {
   if (!props || typeof props !== 'object') return undefined
   const p = props as { text?: unknown; richText?: unknown }
   if (typeof p.text === 'string' && p.text.length > 0) return p.text

--- a/server/test/scratchpad-arrange.test.ts
+++ b/server/test/scratchpad-arrange.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'path'
+
+import { createTLStore, defaultBindingUtils, defaultShapeUtils, loadSnapshot } from 'tldraw'
+
+import type { ScratchOp } from '@/lib/types'
+
+import { executeScratchOp } from '../scratchpad-executor'
+import { loadScratchpadDoc, readScratchpadShapes } from '../scratchpad'
+import { fitRectToLabel } from '../scratchpad-metrics'
+
+// The arrangement layer: relative placement on add, auto-sized rects, and the
+// align / distribute / autosize / tidy verbs. Same contract as the executor
+// tests — every op must leave a snapshot the browser could load.
+
+let WS: string
+beforeEach(() => {
+  WS = mkdtempSync(join(import.meta.dir, 'scratch-arrange-test-'))
+})
+afterEach(() => {
+  rmSync(WS, { recursive: true, force: true })
+})
+
+const run = (op: ScratchOp) => executeScratchOp(WS, 'ws-test', op)
+
+// Loads the persisted snapshot into a fresh store the way the browser does. Throws
+// (failing the test) if any record is invalid, then returns the shape count.
+async function assertLoadable(): Promise<number> {
+  const { document } = await loadScratchpadDoc(WS)
+  const store = createTLStore({ shapeUtils: defaultShapeUtils, bindingUtils: defaultBindingUtils })
+  loadSnapshot(store, { document } as unknown as Parameters<typeof loadSnapshot>[1])
+  return store.allRecords().filter(r => r.typeName === 'shape').length
+}
+
+async function shapeById(id: string) {
+  const shape = (await readScratchpadShapes(WS)).find(s => s.id === id)
+  if (!shape) throw new Error(`Shape "${id}" not found`)
+  return shape
+}
+
+const rect = (name: string, x: number, y: number, w: number, h: number): ScratchOp => ({
+  kind: 'add-rect',
+  name,
+  x,
+  y,
+  w,
+  h
+})
+
+describe('relative placement (place on add)', () => {
+  // Anchor: a 200×100 rect at (100,100); every placed shape is 100×50.
+  const place = (side: 'above' | 'below' | 'left' | 'right', gap: number, align = 'center') =>
+    ({
+      kind: 'add-rect',
+      name: `p-${side}-${align}`,
+      place: { anchor: 'a', side, gap, align },
+      w: 100,
+      h: 50
+    }) as ScratchOp
+
+  test('--below with gap and center align computes x/y from the anchor bounds', async () => {
+    await run(rect('a', 100, 100, 200, 100))
+    await run(place('below', 48))
+    // y: anchor bottom (200) + gap; x: centers match (100 + (200-100)/2).
+    expect(await shapeById('p-below-center')).toMatchObject({ x: 150, y: 248 })
+    expect(await assertLoadable()).toBe(2)
+  })
+
+  test('all four sides place on the right axis', async () => {
+    await run(rect('a', 100, 100, 200, 100))
+    await run(place('above', 20))
+    await run(place('left', 30))
+    await run(place('right', 30))
+    expect(await shapeById('p-above-center')).toMatchObject({ x: 150, y: 30 })
+    expect(await shapeById('p-left-center')).toMatchObject({ x: -30, y: 125 })
+    expect(await shapeById('p-right-center')).toMatchObject({ x: 330, y: 125 })
+    expect(await assertLoadable()).toBe(4)
+  })
+
+  test('cross-axis align: start = leading edges flush, end = trailing edges flush', async () => {
+    await run(rect('a', 100, 100, 200, 100))
+    await run(place('below', 48, 'start'))
+    await run(place('below', 48, 'end'))
+    expect(await shapeById('p-below-start')).toMatchObject({ x: 100, y: 248 })
+    expect(await shapeById('p-below-end')).toMatchObject({ x: 200, y: 248 })
+  })
+
+  test('unknown or arrow anchors error clearly', async () => {
+    await run(rect('a', 0, 0, 10, 10))
+    await run(rect('b', 100, 0, 10, 10))
+    await run({ kind: 'add-arrow', name: 'arr', from: { name: 'a' }, to: { name: 'b' } })
+    await expect(
+      run({
+        kind: 'add-rect',
+        name: 'x',
+        place: { anchor: 'ghost', side: 'below', gap: 48, align: 'center' }
+      })
+    ).rejects.toThrow(/ghost/)
+    await expect(
+      run({
+        kind: 'add-rect',
+        name: 'x',
+        place: { anchor: 'arr', side: 'below', gap: 48, align: 'center' }
+      })
+    ).rejects.toThrow(/arrow/)
+  })
+
+  test('an add without --at or a placement errors clearly', async () => {
+    await expect(run({ kind: 'add-note', name: 'n', text: 'hi' })).rejects.toThrow(/--at/)
+  })
+})
+
+describe('auto-sized rects', () => {
+  test('a labeled rect without --size fits its label exactly', async () => {
+    const text = 'reverse proxy on localhost:3000 with TLS termination'
+    await run({ kind: 'add-rect', name: 'box', x: 0, y: 0, text })
+    const fit = fitRectToLabel(text, { size: 'm', targetWidth: 260 })
+    expect(await shapeById('box')).toMatchObject({ w: fit.w, h: fit.h })
+    expect(await assertLoadable()).toBe(1)
+  })
+
+  test('the label font size feeds the fit', async () => {
+    const text = 'Big headline box'
+    await run({ kind: 'add-rect', name: 'big', x: 0, y: 0, text, size: 'xl' })
+    const fit = fitRectToLabel(text, { size: 'xl', targetWidth: 260 })
+    expect(await shapeById('big')).toMatchObject({ w: fit.w, h: fit.h })
+  })
+
+  test('an unlabeled rect without --size gets the default node box', async () => {
+    await run({ kind: 'add-rect', name: 'plain', x: 0, y: 0 })
+    expect(await shapeById('plain')).toMatchObject({ w: 160, h: 96 })
+  })
+})
+
+describe('align', () => {
+  test('--edge left makes left edges equal, moving x only', async () => {
+    await run(rect('a', 100, 0, 50, 50))
+    await run(rect('b', 137, 100, 80, 40))
+    await run(rect('c', 90, 200, 60, 60))
+    await run({ kind: 'align', names: ['a', 'b', 'c'], edge: 'left' })
+    expect(await shapeById('b')).toMatchObject({ x: 100, y: 100 })
+    expect(await shapeById('c')).toMatchObject({ x: 100, y: 200 })
+    expect(await assertLoadable()).toBe(3)
+  })
+
+  test('center-x aligns centers, honoring --to', async () => {
+    await run(rect('a', 0, 0, 100, 50)) // center 50
+    await run(rect('b', 200, 100, 40, 40)) // center 220
+    await run({ kind: 'align', names: ['a', 'b'], edge: 'center-x', to: 'b' })
+    // a's center moves to 220 → x = 220 - 50; the anchor stays put.
+    expect(await shapeById('a')).toMatchObject({ x: 170, y: 0 })
+    expect(await shapeById('b')).toMatchObject({ x: 200, y: 100 })
+  })
+
+  test('unknown ids error clearly', async () => {
+    await run(rect('a', 0, 0, 10, 10))
+    await expect(run({ kind: 'align', names: ['a', 'ghost'], edge: 'left' })).rejects.toThrow(
+      /ghost/
+    )
+  })
+})
+
+describe('distribute', () => {
+  test('--axis x --gap 48 repacks at exact gaps, first shape fixed', async () => {
+    await run(rect('a', 0, 0, 100, 50))
+    await run(rect('b', 300, 10, 80, 50))
+    await run(rect('c', 500, 20, 60, 50))
+    await run({ kind: 'distribute', names: ['a', 'b', 'c'], axis: 'x', gap: 48 })
+    expect(await shapeById('a')).toMatchObject({ x: 0, y: 0 })
+    expect(await shapeById('b')).toMatchObject({ x: 148, y: 10 })
+    expect(await shapeById('c')).toMatchObject({ x: 276, y: 20 })
+    expect(await assertLoadable()).toBe(3)
+  })
+
+  test('gapless mode equalizes spacing with the endpoints fixed', async () => {
+    await run(rect('a', 0, 0, 100, 50))
+    await run(rect('b', 190, 0, 100, 50))
+    await run(rect('c', 500, 0, 100, 50))
+    await run({ kind: 'distribute', names: ['a', 'b', 'c'], axis: 'x' })
+    // Free space between a's right edge (100) and c's left edge (500) minus
+    // b's width = 300 → two gaps of 150 → b sits at 250.
+    expect(await shapeById('a')).toMatchObject({ x: 0 })
+    expect(await shapeById('b')).toMatchObject({ x: 250 })
+    expect(await shapeById('c')).toMatchObject({ x: 500 })
+  })
+
+  test('gapless mode needs at least 3 shapes', async () => {
+    await run(rect('a', 0, 0, 10, 10))
+    await run(rect('b', 100, 0, 10, 10))
+    await expect(run({ kind: 'distribute', names: ['a', 'b'], axis: 'x' })).rejects.toThrow(
+      /at least 3/
+    )
+  })
+})
+
+describe('autosize', () => {
+  test('grows an overflowing rect to fit its label, keeping the top-left', async () => {
+    const text = 'a label far too long for a hundred-pixel box to hold'
+    await run({ kind: 'add-rect', name: 'tight', x: 40, y: 60, w: 100, h: 40, text })
+    await run({ kind: 'autosize', names: ['tight'] })
+    const fit = fitRectToLabel(text, { size: 'm', targetWidth: 260 })
+    const shape = await shapeById('tight')
+    expect(shape).toMatchObject({ x: 40, y: 60, w: fit.w, h: fit.h })
+    expect(fit.w).toBeGreaterThan(100)
+    expect(fit.h).toBeGreaterThan(40)
+    expect(await assertLoadable()).toBe(1)
+  })
+
+  test('non-rect and unlabeled ids fail with per-id errors', async () => {
+    await run({ kind: 'add-note', name: 'memo', x: 0, y: 0, text: 'hi' })
+    await run(rect('bare', 100, 0, 50, 50))
+    await expect(run({ kind: 'autosize', names: ['memo'] })).rejects.toThrow(/memo/)
+    await expect(run({ kind: 'autosize', names: ['bare'] })).rejects.toThrow(/no label/)
+  })
+})
+
+describe('tidy', () => {
+  test('snaps positions to the grid (13,7 → 16,8 at grid 8)', async () => {
+    await run(rect('a', 13, 7, 96, 48))
+    await run({ kind: 'tidy' })
+    expect(await shapeById('a')).toMatchObject({ x: 16, y: 8, w: 96, h: 48 })
+    expect(await assertLoadable()).toBe(1)
+  })
+
+  test('pulls a 6px-off left edge onto its neighbor line; bound arrows still load', async () => {
+    await run(rect('a', 96, 0, 96, 48))
+    await run(rect('b', 102, 200, 96, 48))
+    await run({ kind: 'add-arrow', name: 'arr', from: { name: 'a' }, to: { name: 'b' } })
+    await run({ kind: 'tidy' })
+    const a = await shapeById('a')
+    const b = await shapeById('b')
+    expect(a.x).toBe(b.x)
+    // The arrow record wasn't touched, and the snapshot still loads cleanly.
+    expect(await assertLoadable()).toBe(3)
+  })
+
+  test('a custom --grid drives the snap step', async () => {
+    await run(rect('a', 30, 30, 96, 48))
+    await run({ kind: 'tidy', grid: 20 })
+    expect(await shapeById('a')).toMatchObject({ x: 40, y: 40 })
+  })
+})

--- a/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
+++ b/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
@@ -22,19 +22,38 @@ clean, agent-friendly view. Treat it exactly like `.moi/.workspace.json` — CLI
 ## Drawing
 
 ```
-moi scratch add text   --at <x,y> --text "..."           [--id NAME] [--color C] [--font-size S]
-moi scratch add rect   --at <x,y> --size <w,h> [--text]   [--id NAME] [--color C] [--fill F] [--font-size S]
-moi scratch add note   --at <x,y> --text "..."            [--id NAME] [--color C] [--font-size S]
+moi scratch add text   <pos> --text "..."                [--id NAME] [--color C] [--font-size S]
+moi scratch add rect   <pos> [--size <w,h>] [--text]      [--id NAME] [--color C] [--fill F] [--font-size S]
+moi scratch add note   <pos> --text "..."                 [--id NAME] [--color C] [--font-size S]
 moi scratch add arrow  --from <id|x,y> --to <id|x,y>      [--id NAME] [--color C] [--stroke W] [--elbow]
 moi scratch add image  <path>                             [--at <x,y>] [--id NAME] [--quality lo|hi]
 moi scratch move   <id> --to <x,y>
 moi scratch set    <id> --text "..."
+moi scratch align      <id> <id> [...] --edge left|right|top|bottom|center-x|center-y [--to <id>]
+moi scratch distribute <id> <id> <id> [...] --axis x|y [--gap N]
+moi scratch autosize   <id> [...]
+moi scratch tidy [--grid N]
 moi scratch delete <id>
 moi scratch clear
 ```
 
-- `--id` names a shape so later commands can address it (`move` / `set` / `delete`, or as an
-  arrow endpoint). Without it, the command prints the generated id.
+- `<pos>` is `--at <x,y>` **or a relative flag** — `--below <id>`, `--above <id>`,
+  `--left-of <id>`, `--right-of <id>` — plus optional `--gap N` (distance from the anchor,
+  default 48) and `--align start|center|end` (cross-axis, default `center`;
+  `--below a --align start` = left edges flush). Exactly one of the two. The server resolves
+  the anchor's real bounds, so relative placement lands exactly; arrows can't be anchors.
+- Omit `rect --size` when the rect has `--text`: the server measures the label with the real
+  canvas font and sizes the box so the text **never overflows**. Without text it defaults to
+  160×96. Only pass `--size` for boxes that aren't label-driven (containers, frames).
+- `align` lines shapes' chosen edge/center up with the anchor (`--to`, default the first
+  listed), moving them only on that axis. `distribute` spaces shapes along an axis: with
+  `--gap` it repacks at exactly that spacing (first shape stays put); without, first and last
+  stay fixed and the in-between gaps equalize (needs ≥3 shapes). `autosize` re-fits labeled
+  rects whose text outgrew them (e.g. after `set`), keeping each top-left. `tidy` cleans the
+  whole canvas: snap positions to the grid (default 8px) and pull edges/centers within 10px of
+  each other exactly together. All of these skip arrows — bound arrows follow their shapes.
+- `--id` names a shape so later commands can address it (`move` / `set` / `delete`, the
+  arrangement verbs, or as an arrow endpoint). Without it, the command prints the generated id.
 - `add arrow --from box1 --to box2` binds endpoints to those shapes, so the arrow follows when
   they move. Endpoints can also be bare `x,y`. `--elbow` routes with right angles.
 - `add image` resizes to fit the canvas — `--quality lo` (default) or `hi` for more pixels — so a
@@ -55,3 +74,43 @@ moi scratch clear
   A rect's outline is always a rough (hand-drawn) stroke, matching what the toolbar draws. Default
   fill is `semi`; pass `--fill none` for an outline-only box or `--fill solid` for an opaque block.
 - Coordinates are tldraw canvas space (origin top-left, y down).
+
+## Laying out a diagram
+
+**Never compute coordinates in your head** — guessed positions give overlapping boxes, clipped
+labels, and crooked rows. Instead:
+
+1. **Anchor** the first shape with `--at` (anywhere; `0,0` is fine).
+2. **Place everything else relatively** — `--below`, `--right-of`, `--gap`, `--align` — naming
+   the neighbor instead of doing arithmetic.
+3. **Omit `--size`** on labeled rects so each box fits its text.
+4. **Connect** with bound arrows (`--from <id> --to <id>`); they follow through every later move.
+5. **Finish** with `align` / `distribute` to straighten rows, `autosize` if a relabel outgrew
+   its box, and `tidy` to square the whole canvas up.
+
+Worked example — "expose a Tailscale service under your domain":
+
+```
+# Anchor one node, chain the rest off it. No --size: boxes fit their labels.
+moi scratch add rect --at 0,0 --text "Browser" --id browser
+moi scratch add rect --right-of browser --gap 140 --text "reverse proxy — proxy.example.com, terminates TLS" --id proxy
+moi scratch add rect --right-of proxy --gap 180 --text "web service on localhost:3000" --id service
+
+# Straighten the row (the boxes are different heights), space it exactly, connect it.
+moi scratch align browser proxy service --edge center-y
+moi scratch distribute browser proxy service --axis x --gap 140
+moi scratch add arrow --from browser --to proxy --elbow
+moi scratch add arrow --from proxy --to service --elbow
+
+# Private-network container: the one hand-sized box — read the service's bounds
+# (`moi scratch read`) and draw around them with ~40px padding.
+moi scratch add rect --at <sx-40>,<sy-40> --size <sw+80>,<sh+96> --fill none --color grey --id tailnet
+moi scratch add text --below service --gap 24 --text "private tailnet" --color grey --id tailnet-label
+
+# Title and side note hang off shapes too.
+moi scratch add text --above browser --gap 64 --align start --font-size big --text "Expose a Tailscale service under your domain" --id title
+moi scratch add note --below proxy --gap 96 --text "Cert via Let's Encrypt DNS-01 — no open ports needed" --id cert-note
+
+# Finish: square the whole canvas up. Bound arrows follow on their own.
+moi scratch tidy
+```


### PR DESCRIPTION
## The bet

The agent's topology instincts are fine — it needs a designer's hand tools instead of a calculator. Keeps the imperative model (so it works for annotating the user's own sketches too), removes the arithmetic.

Stacked on #26 (text-metrics foundation). Sibling approaches: A (ELK auto-layout), C (see + lint).

## What it does

```sh
moi scratch add rect --at 0,0 --text "Browser (internet)" --id browser
moi scratch add rect --right-of browser --gap 140 --text "reverse proxy — terminates TLS" --id proxy
moi scratch add rect --right-of proxy --gap 140 --text "service on localhost:3000" --id service
moi scratch align browser proxy service --edge center-y
moi scratch distribute browser proxy service --axis x --gap 140
moi scratch add text --above browser --gap 64 --align start --font-size big --text "Title"
moi scratch tidy
```

No coordinate ever computed by the agent; rects auto-size to their labels (no `--size` needed), so overflow can't happen on create.

## How

- **Relative placement on `add rect|note|text`**: `--below/--above/--left-of/--right-of <id>`, `--gap` (default 48), `--align start|center|end` (cross-axis). Resolved server-side in the executor against the live store (`place` field on add ops; `x`/`y` now optional).
- **Auto-sizing**: `add rect` without `--size` fits the label via `fitRectToLabel` (260px wrap target); unlabeled default 160×96.
- **`server/scratchpad-arrange.ts`** — `shapeBounds` without a DOM (geo/image props, note 200×200+growY, text estimated with font metrics), plus the four verbs:
  - `align <ids…> --edge left|right|top|bottom|center-x|center-y [--to <id>]`
  - `distribute <ids…> --axis x|y [--gap N]` (exact-gap repack, or endpoint-fixed equalize; spatial order, like design tools)
  - `autosize <ids…>` — re-fit labeled rects
  - `tidy [--grid N]` — grid snap + deterministic near-alignment clustering (10px tolerance, grid-rounded cluster means, center pass respects the edge pass)
- Arrows are never arranged directly — bound arrows follow their shapes, so all verbs skip them and reject them as anchors.
- Docs + agent skill teach the workflow: anchor once → place relatively → omit `--size` → finish with `align`/`distribute`/`tidy`.

## Tests

19 new tests (placement math on all four sides, auto-size fit, align/distribute/autosize/tidy behavior, binding survival, error cases), every block asserting browser-loadability. Full suite 338 green; lint/format clean.

## Trade-offs

Multi-step: the scenario takes ~12 commands vs. one `diagram` call on approach A — but it's the only approach that helps mid-edit and around user-drawn shapes. Composable with A and C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4d4g5CV89L1AanPrEYp7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4d4g5CV89L1AanPrEYp7p)_