### PR TITLE
File-backed scratchpad assets: store images as sidecar files

### DIFF
--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -157,6 +157,15 @@ const SCRATCH_OVERRIDES: TLUiOverrides = {
 // One page only — disables the page selector and all multi-page UI.
 const SCRATCH_OPTIONS = { maxPages: 1 }
 
+// Browser drag/drop/paste limits (tldraw defaults: reject >10MB, no rescale). We
+// accept larger drops and rescale big images to fit so a phone-sized photo lands
+// as a lightweight asset instead of bloating the snapshot's sidecar files. The
+// size check runs BEFORE the rescale, so a 32MB drop is admitted and then shrunk.
+// (The agent's `moi scratch add image` path has its own presets — see the
+// executor's IMAGE_PRESETS; this only governs what the browser accepts.)
+const MAX_DROP_BYTES = 32 * 1024 * 1024
+const MAX_IMAGE_DIMENSION = 2048
+
 type IconC = typeof IconPointer2
 
 // The curated left-bar entries, grouped by `sep` dividers. `tool` selects a
@@ -908,6 +917,10 @@ export function Scratchpad() {
           components={SCRATCH_COMPONENTS}
           overrides={SCRATCH_OVERRIDES}
           options={SCRATCH_OPTIONS}
+          // Accept drops up to 32MB and rescale big images to fit (tldraw checks
+          // the size before rescaling, so a large photo is admitted then shrunk).
+          maxAssetSize={MAX_DROP_BYTES}
+          maxImageDimension={MAX_IMAGE_DIMENSION}
           // Hand focus control entirely to us: tldraw's own `autoFocus` only seeds
           // the `isFocused` flag (hotkeys would fire window-wide, even from the
           // chat) without ever DOM-focusing the canvas. Instead onMount focuses

--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -1,8 +1,17 @@
-import { Fragment, type ReactElement, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Fragment,
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import {
   type Editor,
   type StyleProp,
+  type TLAssetStore,
   type TLComponents,
   type TLDefaultColorStyle,
   type TLDefaultDashStyle,
@@ -82,6 +91,34 @@ function makeExecutor(editor: Editor) {
       padding: 32
     })
     return { image: url }
+  }
+}
+
+// File-backed assets: without this, tldraw inlines every pasted/dropped image as
+// a base64 data URL inside the document — megabytes re-serialized into
+// `.moi/.scratchpad.json` on every autosave and shipped over every GET/PUT.
+// Instead `upload` POSTs the bytes once and stores a tiny `asset:<file>` src on
+// the record; `resolve` maps it back to the serving URL at render time. Legacy
+// snapshots still holding data URLs pass through `resolve` untouched (the
+// server extracts them to files on the next save). See server/scratchpad-assets.ts.
+function makeAssetStore(workspaceId: string): TLAssetStore {
+  const base = `/api/workspaces/${workspaceId}/scratchpad/assets`
+  return {
+    async upload(_asset, file) {
+      const res = await fetch(base, {
+        method: 'POST',
+        headers: { 'Content-Type': file.type || 'application/octet-stream' },
+        body: file
+      })
+      if (!res.ok) throw new Error(`Upload failed: ${await res.text()}`)
+      const { src } = (await res.json()) as { src: string }
+      return { src }
+    },
+    resolve(asset) {
+      const src = asset.props.src
+      if (src?.startsWith('asset:')) return `${base}/${src.slice('asset:'.length)}`
+      return src
+    }
   }
 }
 
@@ -748,6 +785,8 @@ export function Scratchpad() {
   // Reactive handle to the mounted editor, used to render the custom tool bar.
   const [editor, setEditor] = useState<Editor | null>(null)
   const { loaded, snapshot, skew, flagSkew } = useScratchpadSnapshot(workspaceId)
+  // Stable per workspace — a new identity would remount tldraw's asset handling.
+  const assetStore = useMemo(() => makeAssetStore(workspaceId), [workspaceId])
 
   const save = useCallback(() => {
     const editor = editorRef.current
@@ -865,6 +904,7 @@ export function Scratchpad() {
       <div className="absolute inset-0">
         <Tldraw
           snapshot={snapshot}
+          assets={assetStore}
           licenseKey={LICENSE_KEY}
           onMount={onMount}
           components={SCRATCH_COMPONENTS}

--- a/client/components/Scratchpad.tsx
+++ b/client/components/Scratchpad.tsx
@@ -1,12 +1,4 @@
-import {
-  Fragment,
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { Fragment, type ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   type Editor,
@@ -785,8 +777,14 @@ export function Scratchpad() {
   // Reactive handle to the mounted editor, used to render the custom tool bar.
   const [editor, setEditor] = useState<Editor | null>(null)
   const { loaded, snapshot, skew, flagSkew } = useScratchpadSnapshot(workspaceId)
-  // Stable per workspace — a new identity would remount tldraw's asset handling.
-  const assetStore = useMemo(() => makeAssetStore(workspaceId), [workspaceId])
+  // Stable identity per workspace, held in a ref rather than useMemo (which React
+  // may discard): a fresh `assets` identity makes <Tldraw> rebuild its store and
+  // remount the editor, dropping unsaved edits and resetting the camera.
+  const assetStoreRef = useRef<{ id: string; store: TLAssetStore } | null>(null)
+  if (assetStoreRef.current?.id !== workspaceId) {
+    assetStoreRef.current = { id: workspaceId, store: makeAssetStore(workspaceId) }
+  }
+  const assetStore = assetStoreRef.current.store
 
   const save = useCallback(() => {
     const editor = editorRef.current

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -106,8 +106,12 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
   Old workspaces with inline base64 images keep working — they render and `read-image`
   as-is; every save extracts any inline base64 it finds (legacy snapshots migrate on their
   next save; a stale tab PUTting blobs converges on the same files by content address) and
-  then sweeps asset files the document no longer references, with a grace window so a
-  just-uploaded file survives until its autosave lands.
+  then sweeps asset files that neither the document nor the `.bak` backup references, with
+  a grace window so a just-uploaded file survives until its autosave lands. If a referenced
+  file does go missing (say the snapshot was copied without its sidecar dir), nothing
+  breaks loudly: the canvas shows a broken-image placeholder, `read` flags the shape with
+  `missing: true`, and `read-image` errors naming the expected location — move the `.moi`
+  directory as a whole and the references heal, since file names are content-addressed.
 - **Reading** (`moi scratch read`, `read-image`) parses that snapshot straight off disk — the
   shape listing, or one image's bytes. No browser, no tldraw runtime.
 - **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server: it loads the snapshot

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -97,8 +97,8 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
   after each agent mutation. Either writer publishes a "canvas updated" signal, and every open
   tab reloads from disk, so all viewers converge.
 - **Image bytes live outside the snapshot.** Pasted/dropped/agent-added images are
-  content-addressed files in `.moi/.scratchpad/` (`<sha256>.<ext>` — a hidden sidecar dir
-  next to the snapshot, moi-internal like the snapshot itself), referenced from asset
+  content-addressed files in `.moi/.scratchpad/` (`asset-<sha256>.<ext>` — a hidden sidecar
+  dir next to the snapshot, moi-internal like the snapshot itself), referenced from asset
   records by `asset:` srcs — one of tldraw's native src protocols. The browser uploads
   via a custom `TLAssetStore` (POST `/scratchpad/assets`, resolved back through GET); the
   server writes files directly. This keeps the constantly-rewritten JSON small: without it,

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -97,12 +97,14 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
   after each agent mutation. Either writer publishes a "canvas updated" signal, and every open
   tab reloads from disk, so all viewers converge.
 - **Image bytes live outside the snapshot.** Pasted/dropped/agent-added images are
-  content-addressed files in `.moi/scratchpad-assets/` (`<sha256>.<ext>`), referenced from
-  asset records by `asset:` srcs — one of tldraw's native src protocols. The browser uploads
+  content-addressed files in `.moi/.scratchpad/` (`<sha256>.<ext>` — a hidden sidecar dir
+  next to the snapshot, moi-internal like the snapshot itself), referenced from asset
+  records by `asset:` srcs — one of tldraw's native src protocols. The browser uploads
   via a custom `TLAssetStore` (POST `/scratchpad/assets`, resolved back through GET); the
   server writes files directly. This keeps the constantly-rewritten JSON small: without it,
   every autosave and every tab reload would re-serialize and re-ship megabytes of base64.
-  Every save extracts any inline base64 it still finds (legacy snapshots migrate on their
+  Old workspaces with inline base64 images keep working — they render and `read-image`
+  as-is; every save extracts any inline base64 it finds (legacy snapshots migrate on their
   next save; a stale tab PUTting blobs converges on the same files by content address) and
   then sweeps asset files the document no longer references, with a grace window so a
   just-uploaded file survives until its autosave lands.

--- a/docs/moi-scratchpad.md
+++ b/docs/moi-scratchpad.md
@@ -28,11 +28,12 @@ The agent works the canvas through a `moi scratch` CLI — it both **sees** and 
 - `moi scratch read` — dump the canvas as **structured JSON**: each shape with its `id`,
   `type`, position, size, and text. Use this to reason about exact shapes — what's where,
   what to move, what to relabel. Works whether or not a browser tab is open. Image shapes
-  carry a `src`, but **base64 data URLs are omitted** (reported as `base64:omitted`) — the
-  blob is huge and unreadable as text, so use `read-image` or `view` for the pixels.
+  carry a `src` — an `asset:` file reference or an https URL; the pixels never appear in
+  the JSON (a legacy inline blob is reported as `base64:omitted`), so use `read-image` or
+  `view` to actually see them.
 - `moi scratch read-image <id>` — save a single image shape's bytes to a file (prints the
-  path). Served off disk, like `read` — this is how the agent pulls the pixels of one image
-  that `read` omitted. A remote (`http`) asset prints its URL instead.
+  path). Served off disk, like `read` — this is how the agent pulls the pixels behind the
+  reference `read` surfaced. A remote (`http`) asset prints its URL instead.
 - `moi scratch view` — render the **whole canvas** to a **PNG**. Use this to actually _see_
   what the user drew (freehand, layout, anything structure can't capture).
 
@@ -70,11 +71,12 @@ moi scratch clear                           # wipe the whole canvas
   weight, `small` or `large`. Omit the size/stroke flags to keep tldraw's default. The agent's
   options deliberately match what the user can pick by hand — neither surface can make something
   the other can't.
-- `add image <path>` embeds a local image file. The server **resizes it to fit the canvas** —
+- `add image <path>` adds a local image file. The server **resizes it to fit the canvas** —
   `--quality lo` (default, long side ≤768px) or `hi` (≤2048px) — re-encoding to WebP so a 10MB
-  paste never lands on the canvas whole. `lo` keeps the constantly-rewritten snapshot light and
-  is well within Claude's vision budget; reach for `hi` only when fine detail (e.g. screenshot
-  text) matters. EXIF orientation is baked in; images are never enlarged.
+  paste never lands on the canvas whole. `lo` is well within Claude's vision budget; reach for
+  `hi` only when fine detail (e.g. screenshot text) matters. EXIF orientation is baked in;
+  images are never enlarged. The bytes are stored as an asset file beside the snapshot (see
+  Persistence below), never inlined into it.
 - `clear` deletes every shape on the canvas in one shot.
 - Coordinates are tldraw canvas space (origin top-left, y down).
 
@@ -94,6 +96,16 @@ on the server (the mutations). Only `view` — rendering pixels — genuinely re
   hand-edited). The browser autosaves it ~500ms after you stop drawing; the server writes it
   after each agent mutation. Either writer publishes a "canvas updated" signal, and every open
   tab reloads from disk, so all viewers converge.
+- **Image bytes live outside the snapshot.** Pasted/dropped/agent-added images are
+  content-addressed files in `.moi/scratchpad-assets/` (`<sha256>.<ext>`), referenced from
+  asset records by `asset:` srcs — one of tldraw's native src protocols. The browser uploads
+  via a custom `TLAssetStore` (POST `/scratchpad/assets`, resolved back through GET); the
+  server writes files directly. This keeps the constantly-rewritten JSON small: without it,
+  every autosave and every tab reload would re-serialize and re-ship megabytes of base64.
+  Every save extracts any inline base64 it still finds (legacy snapshots migrate on their
+  next save; a stale tab PUTting blobs converges on the same files by content address) and
+  then sweeps asset files the document no longer references, with a grace window so a
+  just-uploaded file survives until its autosave lands.
 - **Reading** (`moi scratch read`, `read-image`) parses that snapshot straight off disk — the
   shape listing, or one image's bytes. No browser, no tldraw runtime.
 - **Drawing** (`add`/`move`/`set`/`delete`/`clear`) runs on the server: it loads the snapshot

--- a/server/api.ts
+++ b/server/api.ts
@@ -26,6 +26,7 @@ import {
   tildify
 } from './registry'
 import { loadScratchpadDoc, saveScratchpadDoc } from './scratchpad'
+import { MAX_ASSET_BYTES, scratchpadAssetFile, storeScratchpadAsset } from './scratchpad-assets'
 import { DIST_DIR, prebuilt } from './static'
 import { getSessionEvents, getSessions } from './state'
 import { getThreadConfig, saveThreadConfig } from './thread-config'
@@ -387,6 +388,38 @@ one.put('/scratchpad', async c => {
     origin: typeof body.origin === 'string' ? body.origin : undefined
   })
   return c.body(null, 204)
+})
+
+// Scratchpad assets: pasted/dropped image bytes live as content-addressed files
+// in `.moi/scratchpad-assets/`, referenced from the snapshot by `asset:` srcs —
+// never inlined as base64 in the JSON (see server/scratchpad-assets.ts). The
+// browser's TLAssetStore POSTs the raw file here on paste and resolves `asset:`
+// srcs back through the GET when rendering.
+one.post('/scratchpad/assets', async c => {
+  const length = Number(c.req.header('content-length') ?? 0)
+  if (length > MAX_ASSET_BYTES) {
+    return c.text(`Asset too large (max ${MAX_ASSET_BYTES / (1024 * 1024)} MB)`, 413)
+  }
+  const bytes = new Uint8Array(await c.req.arrayBuffer())
+  if (bytes.length === 0) return c.text('Empty body', 400)
+  if (bytes.length > MAX_ASSET_BYTES) {
+    return c.text(`Asset too large (max ${MAX_ASSET_BYTES / (1024 * 1024)} MB)`, 413)
+  }
+  const mimeType = c.req.header('content-type') ?? 'application/octet-stream'
+  return c.json(await storeScratchpadAsset(c.get('ws').path, bytes, mimeType))
+})
+
+// The file name is content-addressed (sha256 of the bytes), so a hit is
+// immutable — let the browser cache it indefinitely.
+one.get('/scratchpad/assets/:file', async c => {
+  const resolved = scratchpadAssetFile(c.get('ws').path, c.req.param('file'))
+  if (!resolved || !(await resolved.file.exists())) return c.text('Not found', 404)
+  return new Response(resolved.file, {
+    headers: {
+      'Content-Type': resolved.mimeType,
+      'Cache-Control': 'public, max-age=31536000, immutable'
+    }
+  })
 })
 
 // Workspace icon. PUT a raw image body (png/jpg/gif/webp) — the server resizes

--- a/server/api.ts
+++ b/server/api.ts
@@ -391,7 +391,7 @@ one.put('/scratchpad', async c => {
 })
 
 // Scratchpad assets: pasted/dropped image bytes live as content-addressed files
-// in `.moi/scratchpad-assets/`, referenced from the snapshot by `asset:` srcs —
+// in `.moi/.scratchpad/`, referenced from the snapshot by `asset:` srcs —
 // never inlined as base64 in the JSON (see server/scratchpad-assets.ts). The
 // browser's TLAssetStore POSTs the raw file here on paste and resolves `asset:`
 // srcs back through the GET when rendering.

--- a/server/api.ts
+++ b/server/api.ts
@@ -417,7 +417,12 @@ one.get('/scratchpad/assets/:file', async c => {
   return new Response(resolved.file, {
     headers: {
       'Content-Type': resolved.mimeType,
-      'Cache-Control': 'public, max-age=31536000, immutable'
+      'Cache-Control': 'public, max-age=31536000, immutable',
+      // Assets are only ever consumed via <img>/<video>/fetch (which all ignore
+      // this), so force a download on direct navigation and block MIME sniffing:
+      // a pasted/uploaded SVG must not execute as script in the app origin.
+      'Content-Disposition': 'attachment',
+      'X-Content-Type-Options': 'nosniff'
     }
   })
 })

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -1310,14 +1310,21 @@ const scratchView = defineCommand({
   }
 })
 
-// Image data URL mime → file extension, for naming the saved file.
+// Image/video data URL mime → file extension, for naming the saved file. Kept in
+// sync with the server's MIME_EXT (scratchpad-assets.ts) so avif/apng/video assets
+// round-trip through `read-image` with a real extension instead of `.bin`.
 const IMAGE_EXT: Record<string, string> = {
   'image/png': 'png',
   'image/jpeg': 'jpg',
   'image/jpg': 'jpg',
   'image/webp': 'webp',
   'image/gif': 'gif',
-  'image/svg+xml': 'svg'
+  'image/svg+xml': 'svg',
+  'image/avif': 'avif',
+  'image/apng': 'apng',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/quicktime': 'mov'
 }
 
 const scratchReadImage = defineCommand({

--- a/server/scratchpad-assets.ts
+++ b/server/scratchpad-assets.ts
@@ -131,11 +131,35 @@ export async function extractInlineAssets(
 // cleared canvas, abandoned upload).
 const SWEEP_GRACE_MS = 5 * 60_000
 
-// Delete asset files the (just-saved) document no longer references. Runs after
-// every save; best-effort — a sweep failure must never surface into the save.
+// Asset file names referenced by the schema-change backup (`.scratchpad.json.bak`
+// — see backupOnSchemaChange in scratchpad.ts). The sweep must not eat those:
+// the .bak is the manual escape hatch after a downgrade, and restoring it with
+// its images gone would defeat the point. A raw regex scan (no JSON parse — the
+// .bak may be a huge legacy file), cached by mtime since the file only changes
+// on a schema upgrade. The pattern is `asset:` + ASSET_FILE_RE.
+const BAK_SRC_RE = /asset:(asset-[0-9a-f]{64}\.[a-z0-9]{1,8})/g
+const bakRefsCache = new Map<string, { mtimeMs: number; refs: Set<string> }>()
+async function bakReferencedAssets(bakFile: string): Promise<Set<string>> {
+  try {
+    const { mtimeMs } = await stat(bakFile)
+    const cached = bakRefsCache.get(bakFile)
+    if (cached && cached.mtimeMs === mtimeMs) return cached.refs
+    const refs = new Set<string>()
+    for (const m of (await Bun.file(bakFile).text()).matchAll(BAK_SRC_RE)) refs.add(m[1])
+    bakRefsCache.set(bakFile, { mtimeMs, refs })
+    return refs
+  } catch {
+    return new Set()
+  }
+}
+
+// Delete asset files that neither the (just-saved) document nor the snapshot's
+// `.bak` backup references. Runs after every save; best-effort — a sweep
+// failure must never surface into the save.
 export async function sweepOrphanAssets(
   workspacePath: string,
-  document: ScratchpadDoc
+  document: ScratchpadDoc,
+  bakFile?: string
 ): Promise<void> {
   try {
     const dir = getScratchpadAssetsDir(workspacePath)
@@ -150,6 +174,7 @@ export async function sweepOrphanAssets(
       const name = assetSrcFileName(r.props.src)
       if (name) referenced.add(name)
     }
+    if (bakFile) for (const name of await bakReferencedAssets(bakFile)) referenced.add(name)
 
     const now = Date.now()
     for (const name of files) {

--- a/server/scratchpad-assets.ts
+++ b/server/scratchpad-assets.ts
@@ -1,0 +1,161 @@
+import { readdir, stat, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { ScratchpadDoc } from './scratchpad'
+
+// Scratchpad image/video bytes live as content-addressed files here, NOT as
+// base64 data URLs inside `.moi/.scratchpad.json`. The snapshot is rewritten on
+// every autosave (~500ms after each user edit) and shipped whole over GET/PUT,
+// so a few pasted screenshots inlined as base64 would make every save and every
+// tab reload carry megabytes of pixels. Instead an asset record's `src` is
+// `asset:<sha256>.<ext>` — a tldraw-valid src protocol — pointing at a file in
+// `.moi/scratchpad-assets/`. The browser uploads/resolves through the
+// `/scratchpad/assets` routes (see its TLAssetStore in Scratchpad.tsx); the
+// server's `add image` writes files directly; `read-image` reads them back.
+//
+// Content addressing (the file name is the sha256 of the bytes) buys dedup —
+// the same image pasted twice is one file — and makes every write idempotent,
+// so re-extracting a stale tab's base64 PUT converges on the same file.
+
+export function getScratchpadAssetsDir(workspacePath: string): string {
+  return join(workspacePath, '.moi', 'scratchpad-assets')
+}
+
+// Matches executor-side MAX_IMAGE_BYTES — the most anyone can hand us.
+export const MAX_ASSET_BYTES = 50 * 1024 * 1024
+
+const ASSET_SRC_PREFIX = 'asset:'
+
+// The only file names we ever create or serve: `<sha256 hex>.<short ext>`.
+// Anything else (traversal attempts included) is rejected at the boundary.
+const ASSET_FILE_RE = /^[0-9a-f]{64}\.[a-z0-9]{1,8}$/
+
+const MIME_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/svg+xml': 'svg',
+  'image/avif': 'avif',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/quicktime': 'mov'
+}
+const EXT_MIME: Record<string, string> = Object.fromEntries(
+  Object.entries(MIME_EXT).map(([mime, ext]) => [ext, mime])
+)
+
+// The stored file name behind an `asset:` src, or null when the src is a
+// different scheme (http, data) or malformed.
+export function assetSrcFileName(src: string): string | null {
+  if (!src.startsWith(ASSET_SRC_PREFIX)) return null
+  const name = src.slice(ASSET_SRC_PREFIX.length)
+  return ASSET_FILE_RE.test(name) ? name : null
+}
+
+// A served asset file by (validated) name — the GET route and `read-image`
+// resolve through this. Null for a name we'd never have written.
+export function scratchpadAssetFile(
+  workspacePath: string,
+  fileName: string
+): { file: ReturnType<typeof Bun.file>; mimeType: string } | null {
+  if (!ASSET_FILE_RE.test(fileName)) return null
+  const ext = fileName.slice(fileName.lastIndexOf('.') + 1)
+  return {
+    file: Bun.file(join(getScratchpadAssetsDir(workspacePath), fileName)),
+    mimeType: EXT_MIME[ext] ?? 'application/octet-stream'
+  }
+}
+
+// Persist one asset's bytes and return the `asset:` src to store on the record.
+// Idempotent: identical bytes land on the same file. (Bun.write creates the
+// directory tree as needed.)
+export async function storeScratchpadAsset(
+  workspacePath: string,
+  bytes: Uint8Array,
+  mimeType: string
+): Promise<{ src: string }> {
+  const hasher = new Bun.CryptoHasher('sha256')
+  hasher.update(bytes)
+  const ext = MIME_EXT[mimeType.split(';')[0].trim().toLowerCase()] ?? 'bin'
+  const fileName = `${hasher.digest('hex')}.${ext}`
+  const path = join(getScratchpadAssetsDir(workspacePath), fileName)
+  if (!(await Bun.file(path).exists())) await Bun.write(path, bytes)
+  return { src: `${ASSET_SRC_PREFIX}${fileName}` }
+}
+
+// A base64 data URL on an asset record — the shape tldraw's default (inline)
+// asset store produces, and what legacy snapshots hold.
+const INLINE_SRC_RE = /^data:([\w.+-]+\/[\w.+-]+);base64,([A-Za-z0-9+/=]+)$/
+
+// Rewrite every asset record whose src is an inline base64 data URL to an
+// `asset:` file reference, writing the bytes out. This is the migration path
+// for snapshots written before file-backed assets AND the safety net for a
+// stale tab whose live store still holds base64 and PUTs it back — every
+// writer funnels through saveScratchpadDoc, which calls this. Returns the same
+// document when nothing needed rewriting; never throws on a malformed record
+// (a bad asset is left as-is rather than blocking the save).
+export async function extractInlineAssets(
+  document: ScratchpadDoc,
+  workspacePath: string
+): Promise<ScratchpadDoc> {
+  const store = document?.store
+  if (!store || typeof store !== 'object') return document
+
+  let rewritten: Record<string, unknown> | null = null
+  for (const [key, record] of Object.entries(store)) {
+    if (!record || typeof record !== 'object') continue
+    const r = record as { typeName?: string; props?: { src?: unknown } }
+    if (r.typeName !== 'asset' || typeof r.props?.src !== 'string') continue
+    const m = r.props.src.match(INLINE_SRC_RE)
+    if (!m) continue
+    try {
+      const bytes = new Uint8Array(Buffer.from(m[2], 'base64'))
+      if (bytes.length === 0) continue
+      const { src } = await storeScratchpadAsset(workspacePath, bytes, m[1])
+      // Records off getSnapshot may be frozen — replace, don't mutate.
+      rewritten ??= { ...store }
+      rewritten[key] = { ...r, props: { ...r.props, src } }
+    } catch {}
+  }
+  return rewritten ? { ...document, store: rewritten } : document
+}
+
+// Files uploaded but not yet referenced by a saved snapshot: the browser's
+// TLAssetStore uploads first, and the asset record only lands on disk with the
+// next autosave (~500ms-1s later). The grace keeps the sweep from eating that
+// window; anything unreferenced *and* old is a genuine orphan (deleted image,
+// cleared canvas, abandoned upload).
+const SWEEP_GRACE_MS = 5 * 60_000
+
+// Delete asset files the (just-saved) document no longer references. Runs after
+// every save; best-effort — a sweep failure must never surface into the save.
+export async function sweepOrphanAssets(
+  workspacePath: string,
+  document: ScratchpadDoc
+): Promise<void> {
+  try {
+    const dir = getScratchpadAssetsDir(workspacePath)
+    const files = await readdir(dir).catch(() => [] as string[])
+    if (files.length === 0) return
+
+    const referenced = new Set<string>()
+    for (const record of Object.values(document?.store ?? {})) {
+      if (!record || typeof record !== 'object') continue
+      const r = record as { typeName?: string; props?: { src?: unknown } }
+      if (r.typeName !== 'asset' || typeof r.props?.src !== 'string') continue
+      const name = assetSrcFileName(r.props.src)
+      if (name) referenced.add(name)
+    }
+
+    const now = Date.now()
+    for (const name of files) {
+      if (!ASSET_FILE_RE.test(name) || referenced.has(name)) continue
+      const path = join(dir, name)
+      try {
+        const { mtimeMs } = await stat(path)
+        if (now - mtimeMs > SWEEP_GRACE_MS) await unlink(path)
+      } catch {}
+    }
+  } catch {}
+}

--- a/server/scratchpad-assets.ts
+++ b/server/scratchpad-assets.ts
@@ -27,9 +27,11 @@ export const MAX_ASSET_BYTES = 50 * 1024 * 1024
 
 const ASSET_SRC_PREFIX = 'asset:'
 
-// The only file names we ever create or serve: `<sha256 hex>.<short ext>`.
-// Anything else (traversal attempts included) is rejected at the boundary.
-const ASSET_FILE_RE = /^[0-9a-f]{64}\.[a-z0-9]{1,8}$/
+// The only file names we ever create or serve: `asset-<sha256 hex>.<short ext>`.
+// The `asset-` prefix marks the files as canvas assets, keeping the sidecar dir
+// unambiguous if it ever holds anything else. Anything else (traversal attempts
+// included) is rejected at the boundary.
+const ASSET_FILE_RE = /^asset-[0-9a-f]{64}\.[a-z0-9]{1,8}$/
 
 const MIME_EXT: Record<string, string> = {
   'image/png': 'png',
@@ -79,7 +81,7 @@ export async function storeScratchpadAsset(
   const hasher = new Bun.CryptoHasher('sha256')
   hasher.update(bytes)
   const ext = MIME_EXT[mimeType.split(';')[0].trim().toLowerCase()] ?? 'bin'
-  const fileName = `${hasher.digest('hex')}.${ext}`
+  const fileName = `asset-${hasher.digest('hex')}.${ext}`
   const path = join(getScratchpadAssetsDir(workspacePath), fileName)
   if (!(await Bun.file(path).exists())) await Bun.write(path, bytes)
   return { src: `${ASSET_SRC_PREFIX}${fileName}` }

--- a/server/scratchpad-assets.ts
+++ b/server/scratchpad-assets.ts
@@ -1,4 +1,4 @@
-import { readdir, stat, unlink } from 'node:fs/promises'
+import { readdir, rename, stat, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { ScratchpadDoc } from './scratchpad'
@@ -30,8 +30,11 @@ const ASSET_SRC_PREFIX = 'asset:'
 // The only file names we ever create or serve: `asset-<sha256 hex>.<short ext>`.
 // The `asset-` prefix marks the files as canvas assets, keeping the sidecar dir
 // unambiguous if it ever holds anything else. Anything else (traversal attempts
-// included) is rejected at the boundary.
-const ASSET_FILE_RE = /^asset-[0-9a-f]{64}\.[a-z0-9]{1,8}$/
+// included) is rejected at the boundary. The core pattern is shared with the
+// `.bak` scanner below (BAK_SRC_RE) so the two can never drift — a drift would
+// let the sweep delete files the schema-change backup still references.
+const ASSET_NAME_PATTERN = 'asset-[0-9a-f]{64}\\.[a-z0-9]{1,8}'
+const ASSET_FILE_RE = new RegExp(`^${ASSET_NAME_PATTERN}$`)
 
 const MIME_EXT: Record<string, string> = {
   'image/png': 'png',
@@ -40,6 +43,7 @@ const MIME_EXT: Record<string, string> = {
   'image/gif': 'gif',
   'image/svg+xml': 'svg',
   'image/avif': 'avif',
+  'image/apng': 'apng',
   'video/mp4': 'mp4',
   'video/webm': 'webm',
   'video/quicktime': 'mov'
@@ -82,8 +86,17 @@ export async function storeScratchpadAsset(
   hasher.update(bytes)
   const ext = MIME_EXT[mimeType.split(';')[0].trim().toLowerCase()] ?? 'bin'
   const fileName = `asset-${hasher.digest('hex')}.${ext}`
-  const path = join(getScratchpadAssetsDir(workspacePath), fileName)
-  if (!(await Bun.file(path).exists())) await Bun.write(path, bytes)
+  const dir = getScratchpadAssetsDir(workspacePath)
+  const path = join(dir, fileName)
+  // Content-addressed, so an existing file already holds these exact bytes.
+  // Write through a temp sibling + atomic rename: a crash or full disk mid-write
+  // must never leave a truncated file at `path`, whose name would then claim a
+  // hash its bytes don't match and be served forever by the exists() skip above.
+  if (!(await Bun.file(path).exists())) {
+    const tmp = join(dir, `.tmp-${crypto.randomUUID()}`)
+    await Bun.write(tmp, bytes)
+    await rename(tmp, path)
+  }
   return { src: `${ASSET_SRC_PREFIX}${fileName}` }
 }
 
@@ -124,20 +137,30 @@ export async function extractInlineAssets(
   return rewritten ? { ...document, store: rewritten } : document
 }
 
-// Files uploaded but not yet referenced by a saved snapshot: the browser's
-// TLAssetStore uploads first, and the asset record only lands on disk with the
-// next autosave (~500ms-1s later). The grace keeps the sweep from eating that
-// window; anything unreferenced *and* old is a genuine orphan (deleted image,
-// cleared canvas, abandoned upload).
+// A file is reclaimed only after it has stayed unreferenced for this long. The
+// clock starts when the sweep FIRST observes the file unreferenced — NOT when
+// the file was written — so every reference drop gets the same recovery window a
+// fresh upload gets. (Keying on file mtime instead gave a long-referenced image
+// zero grace the instant it went unreferenced — e.g. `clear` racing an open
+// tab's pending autosave — letting the sweep permanently delete a file the
+// surviving snapshot still pointed at.) The window covers the upload→autosave
+// gap and a stale tab that re-PUTs an old, still-referencing document alike.
 const SWEEP_GRACE_MS = 5 * 60_000
+
+// When each still-unreferenced asset file was first seen unreferenced, keyed by
+// absolute path. In-memory and per-process: a restart just restarts the clock
+// (delaying cleanup, never losing data). Entries drop as soon as a file is
+// referenced again or unlinked, so this only ever holds currently-unreferenced
+// files within their grace window.
+const firstUnreferencedAt = new Map<string, number>()
 
 // Asset file names referenced by the schema-change backup (`.scratchpad.json.bak`
 // — see backupOnSchemaChange in scratchpad.ts). The sweep must not eat those:
 // the .bak is the manual escape hatch after a downgrade, and restoring it with
 // its images gone would defeat the point. A raw regex scan (no JSON parse — the
 // .bak may be a huge legacy file), cached by mtime since the file only changes
-// on a schema upgrade. The pattern is `asset:` + ASSET_FILE_RE.
-const BAK_SRC_RE = /asset:(asset-[0-9a-f]{64}\.[a-z0-9]{1,8})/g
+// on a schema upgrade. Built from the same ASSET_NAME_PATTERN as ASSET_FILE_RE.
+const BAK_SRC_RE = new RegExp(`asset:(${ASSET_NAME_PATTERN})`, 'g')
 const bakRefsCache = new Map<string, { mtimeMs: number; refs: Set<string> }>()
 async function bakReferencedAssets(bakFile: string): Promise<Set<string>> {
   try {
@@ -159,7 +182,8 @@ async function bakReferencedAssets(bakFile: string): Promise<Set<string>> {
 export async function sweepOrphanAssets(
   workspacePath: string,
   document: ScratchpadDoc,
-  bakFile?: string
+  bakFile?: string,
+  now: number = Date.now()
 ): Promise<void> {
   try {
     const dir = getScratchpadAssetsDir(workspacePath)
@@ -176,14 +200,24 @@ export async function sweepOrphanAssets(
     }
     if (bakFile) for (const name of await bakReferencedAssets(bakFile)) referenced.add(name)
 
-    const now = Date.now()
     for (const name of files) {
-      if (!ASSET_FILE_RE.test(name) || referenced.has(name)) continue
+      if (!ASSET_FILE_RE.test(name)) continue
       const path = join(dir, name)
-      try {
-        const { mtimeMs } = await stat(path)
-        if (now - mtimeMs > SWEEP_GRACE_MS) await unlink(path)
-      } catch {}
+      if (referenced.has(name)) {
+        firstUnreferencedAt.delete(path) // referenced (again) — reset its clock
+        continue
+      }
+      const since = firstUnreferencedAt.get(path)
+      if (since === undefined) {
+        firstUnreferencedAt.set(path, now) // first seen unreferenced — start clock
+        continue
+      }
+      if (now - since > SWEEP_GRACE_MS) {
+        try {
+          await unlink(path)
+          firstUnreferencedAt.delete(path)
+        } catch {}
+      }
     }
   } catch {}
 }

--- a/server/scratchpad-assets.ts
+++ b/server/scratchpad-assets.ts
@@ -9,8 +9,9 @@ import type { ScratchpadDoc } from './scratchpad'
 // so a few pasted screenshots inlined as base64 would make every save and every
 // tab reload carry megabytes of pixels. Instead an asset record's `src` is
 // `asset:<sha256>.<ext>` — a tldraw-valid src protocol — pointing at a file in
-// `.moi/scratchpad-assets/`. The browser uploads/resolves through the
-// `/scratchpad/assets` routes (see its TLAssetStore in Scratchpad.tsx); the
+// `.moi/.scratchpad/` (a hidden sidecar dir next to `.moi/.scratchpad.json`,
+// moi-internal like the snapshot itself). The browser uploads/resolves through
+// the `/scratchpad/assets` routes (see its TLAssetStore in Scratchpad.tsx); the
 // server's `add image` writes files directly; `read-image` reads them back.
 //
 // Content addressing (the file name is the sha256 of the bytes) buys dedup —
@@ -18,7 +19,7 @@ import type { ScratchpadDoc } from './scratchpad'
 // so re-extracting a stale tab's base64 PUT converges on the same file.
 
 export function getScratchpadAssetsDir(workspacePath: string): string {
-  return join(workspacePath, '.moi', 'scratchpad-assets')
+  return join(workspacePath, '.moi', '.scratchpad')
 }
 
 // Matches executor-side MAX_IMAGE_BYTES — the most anyone can hand us.

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -35,6 +35,7 @@ import {
   loadScratchpadDoc,
   saveScratchpadDoc
 } from './scratchpad'
+import { storeScratchpadAsset } from './scratchpad-assets'
 
 // Server-side Scratchpad writer. The browser is no longer required to draw: we run
 // the same ops against a *headless* tldraw store here, persist the snapshot, and
@@ -173,10 +174,10 @@ function arrowBinding(
   } as unknown as TLRecord
 }
 
-// Resize an image file to fit the canvas and embed it as a webp data URL, never
-// enlarging — so a 10MB paste becomes a lightweight asset. `quality` picks the
-// preset: 'lo' caps the long side smaller (default), 'hi' keeps more pixels.
-// `.rotate()` bakes in EXIF orientation (phone photos).
+// Resize an image file to fit the canvas, never enlarging — so a 10MB paste
+// becomes a lightweight asset. `quality` picks the preset: 'lo' caps the long
+// side smaller (default), 'hi' keeps more pixels. `.rotate()` bakes in EXIF
+// orientation (phone photos).
 const IMAGE_PRESETS: Record<ScratchImageQuality, { dim: number; quality: number }> = {
   lo: { dim: 768, quality: 78 },
   hi: { dim: 2048, quality: 88 }
@@ -186,7 +187,7 @@ const MAX_IMAGE_BYTES = 50 * 1024 * 1024
 async function processCanvasImage(
   path: string,
   quality: ScratchImageQuality
-): Promise<{ src: string; w: number; h: number; mimeType: string; name: string }> {
+): Promise<{ data: Buffer; w: number; h: number; mimeType: string; name: string }> {
   const file = Bun.file(path)
   if (!(await file.exists())) throw new Error(`Image file not found: ${path}`)
   const bytes = new Uint8Array(await file.arrayBuffer())
@@ -200,23 +201,21 @@ async function processCanvasImage(
     .resize(preset.dim, preset.dim, { fit: 'inside', withoutEnlargement: true })
     .webp({ quality: preset.quality })
     .toBuffer({ resolveWithObject: true })
-  return {
-    src: `data:image/webp;base64,${data.toString('base64')}`,
-    w: info.width,
-    h: info.height,
-    mimeType: 'image/webp',
-    name: basename(path)
-  }
+  return { data, w: info.width, h: info.height, mimeType: 'image/webp', name: basename(path) }
 }
 
-// Create an image shape and its backing asset from a file. Async — unlike the
-// other ops — because it decodes and resizes the image first.
+// Create an image shape and its backing asset from a file. The resized bytes go
+// to `.moi/scratchpad-assets/` and the asset record holds the `asset:` file
+// reference — never a base64 blob (see scratchpad-assets.ts). Async — unlike
+// the other ops — because it decodes and resizes the image first.
 async function applyAddImage(
   store: TLStore,
+  workspacePath: string,
   op: Extract<ScratchOp, { kind: 'add-image' }>
 ): Promise<ScratchOpResult> {
   const pageId = firstPageId(store)
-  const { src, w, h, mimeType, name } = await processCanvasImage(op.path, op.quality ?? 'lo')
+  const { data, w, h, mimeType, name } = await processCanvasImage(op.path, op.quality ?? 'lo')
+  const { src } = await storeScratchpadAsset(workspacePath, new Uint8Array(data), mimeType)
   const assetId = AssetRecordType.createId()
   store.put([
     {
@@ -354,9 +353,11 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
       return { ok: true }
     }
     case 'clear': {
+      // Assets go too — with every shape gone they're unreachable, and dropping
+      // the records lets the post-save sweep reclaim their files on disk.
       const ids = store
         .allRecords()
-        .filter(r => r.typeName === 'shape' || r.typeName === 'binding')
+        .filter(r => r.typeName === 'shape' || r.typeName === 'binding' || r.typeName === 'asset')
         .map(r => r.id)
       if (ids.length > 0) store.remove(ids)
       return { ok: true }
@@ -404,7 +405,8 @@ export function executeScratchOp(
     const { document, writer } = await loadScratchpadDoc(workspacePath)
     const store = buildStore(document, writer)
     // add-image decodes/resizes the file first, so it's the one async op.
-    const result = op.kind === 'add-image' ? await applyAddImage(store, op) : applyOp(store, op)
+    const result =
+      op.kind === 'add-image' ? await applyAddImage(store, workspacePath, op) : applyOp(store, op)
     const next = getSnapshot(store).document as unknown as ScratchpadDoc
     await saveScratchpadDoc(next, workspacePath)
     publishEvent({ type: 'scratchpad:updated', workspaceId })

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -205,7 +205,7 @@ async function processCanvasImage(
 }
 
 // Create an image shape and its backing asset from a file. The resized bytes go
-// to `.moi/scratchpad-assets/` and the asset record holds the `asset:` file
+// to `.moi/.scratchpad/` and the asset record holds the `asset:` file
 // reference — never a base64 blob (see scratchpad-assets.ts). Async — unlike
 // the other ops — because it decodes and resizes the image first.
 async function applyAddImage(

--- a/server/scratchpad-executor.ts
+++ b/server/scratchpad-executor.ts
@@ -214,8 +214,14 @@ async function applyAddImage(
   op: Extract<ScratchOp, { kind: 'add-image' }>
 ): Promise<ScratchOpResult> {
   const pageId = firstPageId(store)
+  // Re-adding under an existing id replaces that shape; note its current asset so
+  // we can drop it below once nothing else references it (else its file leaks).
+  const prev = store.get(createShapeId(op.name)) as unknown as
+    | { props?: { assetId?: unknown } }
+    | undefined
+  const prevAssetId = typeof prev?.props?.assetId === 'string' ? prev.props.assetId : undefined
   const { data, w, h, mimeType, name } = await processCanvasImage(op.path, op.quality ?? 'lo')
-  const { src } = await storeScratchpadAsset(workspacePath, new Uint8Array(data), mimeType)
+  const { src } = await storeScratchpadAsset(workspacePath, data, mimeType)
   const assetId = AssetRecordType.createId()
   store.put([
     {
@@ -237,6 +243,11 @@ async function applyAddImage(
       props: { ...defaultProps('image'), w, h, assetId }
     })
   ])
+  // The replaced shape's old asset is now unreachable — drop it so the sweep can
+  // reclaim its file.
+  if (prevAssetId && prevAssetId !== assetId && !anyShapeUsesAsset(store, prevAssetId)) {
+    store.remove([prevAssetId as unknown as TLRecord['id']])
+  }
   return { name: op.name }
 }
 
@@ -346,10 +357,17 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
     }
     case 'delete': {
       const id = createShapeId(op.name)
+      const shape = store.get(id) as unknown as { props?: { assetId?: unknown } } | undefined
+      const assetId = typeof shape?.props?.assetId === 'string' ? shape.props.assetId : undefined
       // Remove the shape plus any binding that references it, or the leftover
       // binding would dangle and invalidate the snapshot.
       const ids = [id, ...bindingsTouching(store, op.name)]
       store.remove(ids)
+      // If that was the last shape using the image's asset, drop the asset record
+      // too so the post-save sweep can reclaim its file (mirrors `clear`).
+      if (assetId && !anyShapeUsesAsset(store, assetId)) {
+        store.remove([assetId as unknown as TLRecord['id']])
+      }
       return { ok: true }
     }
     case 'clear': {
@@ -367,6 +385,18 @@ function applyOp(store: TLStore, op: ScratchOp): ScratchOpResult {
       // is an unknown op kind.
       throw new Error(`Cannot execute op "${op.kind}" on the server`)
   }
+}
+
+// True if any shape still references the given asset id. tldraw lets several
+// shapes share one asset (e.g. a duplicated image), so delete/replace only drops
+// the asset record when its last user is gone — leaving the file for the sweep.
+function anyShapeUsesAsset(store: TLStore, assetId: string): boolean {
+  for (const record of store.allRecords()) {
+    if (record.typeName !== 'shape') continue
+    const props = (record as unknown as { props?: { assetId?: unknown } }).props
+    if (props?.assetId === assetId) return true
+  }
+  return false
 }
 
 // Ids of bindings whose start/end is the named shape.

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -83,7 +83,7 @@ export async function saveScratchpadDoc(
   const path = getScratchpadPath(workspacePath)
   // Every writer funnels through here, so this is where inline base64 assets
   // (legacy snapshots, or a stale tab still holding blobs in its live store)
-  // get extracted to `.moi/scratchpad-assets/` files — the snapshot on disk
+  // get extracted to `.moi/.scratchpad/` files — the snapshot on disk
   // never carries image bytes. The sweep after the write reclaims files the
   // saved document no longer references (see scratchpad-assets.ts).
   document = await extractInlineAssets(document, workspacePath)
@@ -177,7 +177,7 @@ export async function readScratchpadImage(
       if (!fileName) return { src: a.props.src }
       const resolved = scratchpadAssetFile(workspacePath, fileName)
       if (!resolved || !(await resolved.file.exists())) {
-        return { error: `Image "${id}" file is missing from .moi/scratchpad-assets` }
+        return { error: `Image "${id}" file is missing from .moi/.scratchpad` }
       }
       const bytes = Buffer.from(await resolved.file.arrayBuffer())
       return { src: `data:${resolved.mimeType};base64,${bytes.toString('base64')}` }

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -5,12 +5,19 @@ import tldrawPkg from 'tldraw/package.json'
 import type { ScratchpadWriter } from '@/lib/types'
 
 import moiPkg from '../package.json'
+import {
+  assetSrcFileName,
+  extractInlineAssets,
+  scratchpadAssetFile,
+  sweepOrphanAssets
+} from './scratchpad-assets'
 
 // The Scratchpad is a shared tldraw canvas per workspace, persisted as a tldraw
 // *document* snapshot here (the per-tab `session` is intentionally dropped). Two
 // writers: the browser autosaves on user edits, and the server writes on agent
 // draws (see scratchpad-executor.ts). This module owns the on-disk shape: load,
-// save, and the `moi scratch read` parser. See docs/moi-scratchpad.md.
+// save, and the `moi scratch read` parser. Image bytes live beside the snapshot
+// as files, not inside it (see scratchpad-assets.ts). See docs/moi-scratchpad.md.
 
 // A tldraw document snapshot: `getSnapshot(store).document`. Opaque to us apart
 // from `.store` (the record map) which `read` walks. `null` means empty canvas.
@@ -36,8 +43,9 @@ export type ScratchShape = {
   w?: number
   h?: number
   text?: string
-  // Image/asset src. Base64 data URLs are omitted (see omitBase64) — the agent
-  // calls `moi scratch view` to actually see pixels; only the URL kind passes through.
+  // Image/asset src: an `asset:` file reference or an https URL, passed through
+  // as-is. A legacy inline base64 blob is omitted (see omitBase64) — the agent
+  // calls `moi scratch read-image`/`view` to actually see pixels.
   src?: string
 }
 
@@ -73,8 +81,15 @@ export async function saveScratchpadDoc(
   workspacePath: string
 ): Promise<void> {
   const path = getScratchpadPath(workspacePath)
+  // Every writer funnels through here, so this is where inline base64 assets
+  // (legacy snapshots, or a stale tab still holding blobs in its live store)
+  // get extracted to `.moi/scratchpad-assets/` files — the snapshot on disk
+  // never carries image bytes. The sweep after the write reclaims files the
+  // saved document no longer references (see scratchpad-assets.ts).
+  document = await extractInlineAssets(document, workspacePath)
   await backupOnSchemaChange(path, document)
   await Bun.write(path, JSON.stringify({ document, writer: SCRATCHPAD_WRITER }, null, 2))
+  await sweepOrphanAssets(workspacePath, document)
 }
 
 // When a save is about to overwrite a snapshot with a *different* schema (i.e.
@@ -91,11 +106,12 @@ async function backupOnSchemaChange(path: string, document: ScratchpadDoc): Prom
   } catch {}
 }
 
-// tldraw embeds pasted/dropped images as `data:<mime>;base64,<blob>` URLs (on
-// asset records, and occasionally inline in rich text). Those blobs are huge and
+// Asset records now reference image bytes as `asset:` files (see
+// scratchpad-assets.ts), but base64 data URLs can still appear — in a legacy
+// snapshot not yet re-saved, or inline in rich text. Those blobs are huge and
 // useless for reasoning about structure, so we replace each one with a short
-// marker — the agent calls `moi scratch view` when it actually needs the pixels.
-// Non-base64 srcs (e.g. https URLs) pass through untouched.
+// marker — the agent calls `moi scratch read-image`/`view` when it actually
+// needs the pixels. Every other src (`asset:`, https) passes through untouched.
 const BASE64_DATA_URL_RE = /data:[\w.+-]*\/?[\w.+-]*;base64,[A-Za-z0-9+/=]+/g
 function omitBase64(text: string): string {
   return text.replace(BASE64_DATA_URL_RE, 'base64:omitted')
@@ -124,11 +140,13 @@ function extractText(props: unknown): string | undefined {
 }
 
 // Resolve a single image shape's source by id, straight off the disk snapshot —
-// no browser. The shape references an `asset` record by `props.assetId`; we return
-// that asset's `src` (a `data:` URL for pasted/dropped images, or an `https:` URL).
-// `moi scratch read` deliberately omits these blobs, so this is how the agent pulls
-// the actual pixels for one image. Ids match with or without the `shape:` prefix
-// (read surfaces them stripped).
+// no browser. The shape references an `asset` record by `props.assetId`; that
+// asset's `src` is an `asset:` file reference (read back off disk and returned
+// as a `data:` URL so the CLI's decoding keeps working), an `https:` URL
+// (returned as-is), or — in a legacy snapshot — an inline `data:` URL.
+// `moi scratch read` never carries the pixels, so this is how the agent pulls
+// them for one image. Ids match with or without the `shape:` prefix (read
+// surfaces them stripped).
 export async function readScratchpadImage(
   workspacePath: string,
   id: string
@@ -155,7 +173,14 @@ export async function readScratchpadImage(
     if (!record || typeof record !== 'object') continue
     const a = record as { typeName?: string; id?: string; props?: { src?: unknown } }
     if (a.typeName === 'asset' && a.id === assetId && typeof a.props?.src === 'string') {
-      return { src: a.props.src }
+      const fileName = assetSrcFileName(a.props.src)
+      if (!fileName) return { src: a.props.src }
+      const resolved = scratchpadAssetFile(workspacePath, fileName)
+      if (!resolved || !(await resolved.file.exists())) {
+        return { error: `Image "${id}" file is missing from .moi/scratchpad-assets` }
+      }
+      const bytes = Buffer.from(await resolved.file.arrayBuffer())
+      return { src: `data:${resolved.mimeType};base64,${bytes.toString('base64')}` }
     }
   }
   return { error: `Image "${id}" has no stored data` }

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -47,6 +47,10 @@ export type ScratchShape = {
   // as-is. A legacy inline base64 blob is omitted (see omitBase64) — the agent
   // calls `moi scratch read-image`/`view` to actually see pixels.
   src?: string
+  // True when `src` is an `asset:` reference whose backing file is gone from
+  // .moi/.scratchpad (sidecar dir lost or pruned) — `read-image` will error and
+  // the canvas shows a broken image. Absent otherwise.
+  missing?: true
 }
 
 // The snapshot is a hidden dotfile (like `.moi/.workspace.json`): it's moi-internal
@@ -89,7 +93,9 @@ export async function saveScratchpadDoc(
   document = await extractInlineAssets(document, workspacePath)
   await backupOnSchemaChange(path, document)
   await Bun.write(path, JSON.stringify({ document, writer: SCRATCHPAD_WRITER }, null, 2))
-  await sweepOrphanAssets(workspacePath, document)
+  // The `.bak` path keeps the sweep from orphaning the schema-change backup's
+  // images — a restored .bak should still render.
+  await sweepOrphanAssets(workspacePath, document, `${path}.bak`)
 }
 
 // When a save is about to overwrite a snapshot with a *different* schema (i.e.
@@ -195,13 +201,23 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
 
   // Images live as `asset` records (typeName 'asset'); a shape references one by
   // `props.assetId`. Index asset src first so we can surface it on the shape —
-  // with base64 blobs omitted — without dumping the asset record itself.
+  // with base64 blobs omitted — without dumping the asset record itself. A
+  // file-backed src whose file is gone is flagged so the agent learns it's
+  // dangling from `read` instead of from a failing `read-image` later.
   const assetSrc = new Map<string, string>()
+  const assetGone = new Set<string>()
   for (const record of Object.values(store)) {
     if (!record || typeof record !== 'object') continue
     const a = record as { typeName?: string; id?: string; props?: { src?: unknown } }
     if (a.typeName !== 'asset' || typeof a.id !== 'string') continue
-    if (typeof a.props?.src === 'string') assetSrc.set(a.id, a.props.src)
+    if (typeof a.props?.src === 'string') {
+      assetSrc.set(a.id, a.props.src)
+      const fileName = assetSrcFileName(a.props.src)
+      if (fileName) {
+        const resolved = scratchpadAssetFile(workspacePath, fileName)
+        if (!resolved || !(await resolved.file.exists())) assetGone.add(a.id)
+      }
+    }
   }
 
   const shapes: ScratchShape[] = []
@@ -218,7 +234,8 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
     if (r.typeName !== 'shape') continue
     const w = typeof r.props?.w === 'number' ? r.props.w : undefined
     const h = typeof r.props?.h === 'number' ? r.props.h : undefined
-    const rawSrc = typeof r.props?.assetId === 'string' ? assetSrc.get(r.props.assetId) : undefined
+    const assetId = typeof r.props?.assetId === 'string' ? r.props.assetId : undefined
+    const rawSrc = assetId !== undefined ? assetSrc.get(assetId) : undefined
     shapes.push({
       id: (r.id ?? '').replace(/^shape:/, ''),
       type: r.type ?? 'unknown',
@@ -230,7 +247,8 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
         const text = extractText(r.props)
         return text !== undefined ? { text: omitBase64(text) } : {}
       })(),
-      ...(rawSrc !== undefined ? { src: omitBase64(rawSrc) } : {})
+      ...(rawSrc !== undefined ? { src: omitBase64(rawSrc) } : {}),
+      ...(assetId !== undefined && assetGone.has(assetId) ? { missing: true as const } : {})
     })
   }
   return shapes

--- a/server/scratchpad.ts
+++ b/server/scratchpad.ts
@@ -47,9 +47,10 @@ export type ScratchShape = {
   // as-is. A legacy inline base64 blob is omitted (see omitBase64) — the agent
   // calls `moi scratch read-image`/`view` to actually see pixels.
   src?: string
-  // True when `src` is an `asset:` reference whose backing file is gone from
-  // .moi/.scratchpad (sidecar dir lost or pruned) — `read-image` will error and
-  // the canvas shows a broken image. Absent otherwise.
+  // True when the shape references an asset that can't be resolved to pixels: an
+  // `asset:` file gone from .moi/.scratchpad (sidecar dir lost or pruned), or the
+  // asset record absent entirely — `read-image` will error and the canvas shows a
+  // broken image. Absent otherwise.
   missing?: true
 }
 
@@ -236,6 +237,11 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
     const h = typeof r.props?.h === 'number' ? r.props.h : undefined
     const assetId = typeof r.props?.assetId === 'string' ? r.props.assetId : undefined
     const rawSrc = assetId !== undefined ? assetSrc.get(assetId) : undefined
+    // Flag `missing` when a shape references an asset we can't resolve to pixels:
+    // its backing file is gone (assetGone), or the asset record is absent / has a
+    // non-string src (rawSrc undefined). Either way `read-image` can't return
+    // bytes, so warn from `read` rather than let it fail later.
+    const missing = assetId !== undefined && (assetGone.has(assetId) || rawSrc === undefined)
     shapes.push({
       id: (r.id ?? '').replace(/^shape:/, ''),
       type: r.type ?? 'unknown',
@@ -248,7 +254,7 @@ export async function readScratchpadShapes(workspacePath: string): Promise<Scrat
         return text !== undefined ? { text: omitBase64(text) } : {}
       })(),
       ...(rawSrc !== undefined ? { src: omitBase64(rawSrc) } : {}),
-      ...(assetId !== undefined && assetGone.has(assetId) ? { missing: true as const } : {})
+      ...(missing ? { missing: true as const } : {})
     })
   }
   return shapes

--- a/server/test/scratchpad-assets.test.ts
+++ b/server/test/scratchpad-assets.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { readdir, utimes } from 'node:fs/promises'
 import { join } from 'path'
 
-import { loadScratchpadDoc, readScratchpadImage, saveScratchpadDoc } from '../scratchpad'
+import {
+  loadScratchpadDoc,
+  readScratchpadImage,
+  readScratchpadShapes,
+  saveScratchpadDoc
+} from '../scratchpad'
 import type { ScratchpadDoc } from '../scratchpad'
 import {
   assetSrcFileName,
@@ -134,6 +139,27 @@ describe('saveScratchpadDoc migration', () => {
   })
 })
 
+describe('missing asset files (dangling references)', () => {
+  test('read flags the shape, read-image errors clearly, intact shapes unflagged', async () => {
+    await saveScratchpadDoc(legacyDoc(), WS)
+    const dir = getScratchpadAssetsDir(WS)
+
+    // Intact: no `missing` flag on the shape.
+    let pic = (await readScratchpadShapes(WS)).find(s => s.id === 'pic')
+    expect(pic?.src).toMatch(/^asset:asset-/)
+    expect(pic?.missing).toBeUndefined()
+
+    // Lose the sidecar file (e.g. snapshot copied without `.moi/.scratchpad/`).
+    for (const name of await readdir(dir)) rmSync(join(dir, name))
+
+    pic = (await readScratchpadShapes(WS)).find(s => s.id === 'pic')
+    expect(pic?.missing).toBe(true)
+    expect(await readScratchpadImage(WS, 'pic')).toEqual({
+      error: expect.stringMatching(/missing/)
+    })
+  })
+})
+
 describe('sweepOrphanAssets', () => {
   test('deletes old unreferenced files, keeps referenced and recent ones', async () => {
     const { src } = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
@@ -163,6 +189,35 @@ describe('sweepOrphanAssets', () => {
     expect(left).toContain(referenced)
     expect(left).toContain(freshOrphan)
     expect(left).not.toContain(oldOrphan)
+  })
+
+  test('keeps files the .bak backup still references', async () => {
+    const { src: bakSrc } = await storeScratchpadAsset(WS, new Uint8Array([7, 8, 9]), 'image/png')
+    const bakKept = assetSrcFileName(bakSrc)!
+    const { src: orphanSrc } = await storeScratchpadAsset(WS, new Uint8Array([1, 2]), 'image/png')
+    const orphan = assetSrcFileName(orphanSrc)!
+
+    // A .bak referencing only bakKept — the downgrade escape hatch.
+    const bakFile = join(WS, '.moi', '.scratchpad.json.bak')
+    await Bun.write(
+      bakFile,
+      JSON.stringify({
+        document: {
+          store: { 'asset:old': { typeName: 'asset', type: 'image', props: { src: bakSrc } } }
+        }
+      })
+    )
+
+    const dir = getScratchpadAssetsDir(WS)
+    const past = new Date(Date.now() - 60 * 60_000)
+    for (const name of [bakKept, orphan]) await utimes(join(dir, name), past, past)
+
+    // Current document references neither file.
+    await sweepOrphanAssets(WS, { store: {} }, bakFile)
+
+    const left = await readdir(dir)
+    expect(left).toContain(bakKept)
+    expect(left).not.toContain(orphan)
   })
 
   test('is a no-op when the assets dir does not exist', async () => {

--- a/server/test/scratchpad-assets.test.ts
+++ b/server/test/scratchpad-assets.test.ts
@@ -57,7 +57,7 @@ describe('storeScratchpadAsset', () => {
     const a = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
     const b = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
     expect(a.src).toBe(b.src)
-    expect(a.src).toMatch(/^asset:[0-9a-f]{64}\.png$/)
+    expect(a.src).toMatch(/^asset:asset-[0-9a-f]{64}\.png$/)
     expect(await readdir(getScratchpadAssetsDir(WS))).toHaveLength(1)
   })
 
@@ -70,15 +70,17 @@ describe('storeScratchpadAsset', () => {
 })
 
 describe('assetSrcFileName / scratchpadAssetFile', () => {
-  test('accepts only our own sha256.ext names — no traversal, no other schemes', () => {
+  test('accepts only our own asset-<sha256>.ext names — no traversal, no other schemes', () => {
     const hash = 'a'.repeat(64)
-    expect(assetSrcFileName(`asset:${hash}.png`)).toBe(`${hash}.png`)
+    expect(assetSrcFileName(`asset:asset-${hash}.png`)).toBe(`asset-${hash}.png`)
     expect(assetSrcFileName('asset:../../etc/passwd')).toBeNull()
-    expect(assetSrcFileName(`asset:${hash}`)).toBeNull()
+    expect(assetSrcFileName(`asset:asset-${hash}`)).toBeNull()
+    expect(assetSrcFileName(`asset:${hash}.png`)).toBeNull()
     expect(assetSrcFileName('data:image/png;base64,AAAA')).toBeNull()
     expect(assetSrcFileName('https://example.com/x.png')).toBeNull()
     expect(scratchpadAssetFile(WS, '../secret')).toBeNull()
-    expect(scratchpadAssetFile(WS, `${hash}.png`)).not.toBeNull()
+    expect(scratchpadAssetFile(WS, `${hash}.png`)).toBeNull()
+    expect(scratchpadAssetFile(WS, `asset-${hash}.png`)).not.toBeNull()
   })
 })
 
@@ -96,7 +98,7 @@ describe('extractInlineAssets', () => {
 
     const out = await extractInlineAssets(doc, WS)
     const outStore = out.store as Record<string, { props: { src?: string } }>
-    expect(outStore['asset:a1'].props.src).toMatch(/^asset:[0-9a-f]{64}\.png$/)
+    expect(outStore['asset:a1'].props.src).toMatch(/^asset:asset-[0-9a-f]{64}\.png$/)
     expect(outStore['asset:remote'].props.src).toBe('https://example.com/pic.png')
     // The original document is not mutated (snapshot records may be frozen).
     expect(store['asset:a1'].props.src).toStartWith('data:')
@@ -123,7 +125,7 @@ describe('saveScratchpadDoc migration', () => {
 
     const { document } = await loadScratchpadDoc(WS)
     const asset = (document?.store?.['asset:a1'] ?? {}) as { props?: { src?: string } }
-    expect(asset.props?.src).toMatch(/^asset:[0-9a-f]{64}\.png$/)
+    expect(asset.props?.src).toMatch(/^asset:asset-[0-9a-f]{64}\.png$/)
 
     // The agent's read-image path resolves the file back to a data URL.
     expect(await readScratchpadImage(WS, 'pic')).toEqual({

--- a/server/test/scratchpad-assets.test.ts
+++ b/server/test/scratchpad-assets.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../scratchpad-assets'
 
 // The file-backed asset store keeps image bytes OUT of `.moi/.scratchpad.json`:
-// content-addressed files under `.moi/scratchpad-assets/`, `asset:` srcs on the
+// content-addressed files under `.moi/.scratchpad/`, `asset:` srcs on the
 // records, lazy migration of legacy inline base64 on save, and an orphan sweep.
 
 let WS: string

--- a/server/test/scratchpad-assets.test.ts
+++ b/server/test/scratchpad-assets.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { readdir, utimes } from 'node:fs/promises'
+import { join } from 'path'
+
+import { loadScratchpadDoc, readScratchpadImage, saveScratchpadDoc } from '../scratchpad'
+import type { ScratchpadDoc } from '../scratchpad'
+import {
+  assetSrcFileName,
+  extractInlineAssets,
+  getScratchpadAssetsDir,
+  scratchpadAssetFile,
+  storeScratchpadAsset,
+  sweepOrphanAssets
+} from '../scratchpad-assets'
+
+// The file-backed asset store keeps image bytes OUT of `.moi/.scratchpad.json`:
+// content-addressed files under `.moi/scratchpad-assets/`, `asset:` srcs on the
+// records, lazy migration of legacy inline base64 on save, and an orphan sweep.
+
+let WS: string
+beforeEach(() => {
+  WS = mkdtempSync(join(import.meta.dir, 'scratch-assets-test-'))
+})
+afterEach(() => {
+  rmSync(WS, { recursive: true, force: true })
+})
+
+const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3])
+const PNG_B64 = Buffer.from(PNG_BYTES).toString('base64')
+
+// A minimal snapshot the way tldraw persists it: one image shape whose asset
+// record inlines the bytes as a base64 data URL (the legacy on-disk shape).
+function legacyDoc(): ScratchpadDoc {
+  return {
+    store: {
+      'asset:a1': {
+        id: 'asset:a1',
+        typeName: 'asset',
+        type: 'image',
+        props: { name: 'x.png', src: `data:image/png;base64,${PNG_B64}`, w: 4, h: 4 }
+      },
+      'shape:pic': {
+        id: 'shape:pic',
+        typeName: 'shape',
+        type: 'image',
+        x: 0,
+        y: 0,
+        props: { assetId: 'asset:a1', w: 4, h: 4 }
+      }
+    }
+  }
+}
+
+describe('storeScratchpadAsset', () => {
+  test('content-addresses the file and dedupes identical bytes', async () => {
+    const a = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
+    const b = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
+    expect(a.src).toBe(b.src)
+    expect(a.src).toMatch(/^asset:[0-9a-f]{64}\.png$/)
+    expect(await readdir(getScratchpadAssetsDir(WS))).toHaveLength(1)
+  })
+
+  test('unknown mime types fall back to a .bin file served as octet-stream', async () => {
+    const { src } = await storeScratchpadAsset(WS, PNG_BYTES, 'application/x-weird')
+    expect(src).toEndWith('.bin')
+    const resolved = scratchpadAssetFile(WS, assetSrcFileName(src) ?? '')
+    expect(resolved?.mimeType).toBe('application/octet-stream')
+  })
+})
+
+describe('assetSrcFileName / scratchpadAssetFile', () => {
+  test('accepts only our own sha256.ext names — no traversal, no other schemes', () => {
+    const hash = 'a'.repeat(64)
+    expect(assetSrcFileName(`asset:${hash}.png`)).toBe(`${hash}.png`)
+    expect(assetSrcFileName('asset:../../etc/passwd')).toBeNull()
+    expect(assetSrcFileName(`asset:${hash}`)).toBeNull()
+    expect(assetSrcFileName('data:image/png;base64,AAAA')).toBeNull()
+    expect(assetSrcFileName('https://example.com/x.png')).toBeNull()
+    expect(scratchpadAssetFile(WS, '../secret')).toBeNull()
+    expect(scratchpadAssetFile(WS, `${hash}.png`)).not.toBeNull()
+  })
+})
+
+describe('extractInlineAssets', () => {
+  test('rewrites inline base64 asset srcs to files; other srcs untouched', async () => {
+    const doc = legacyDoc()
+    const store = doc.store as Record<string, { props: { src?: string } }>
+    store['asset:remote'] = {
+      // @ts-expect-error minimal record for the walk
+      id: 'asset:remote',
+      typeName: 'asset',
+      type: 'image',
+      props: { src: 'https://example.com/pic.png' }
+    }
+
+    const out = await extractInlineAssets(doc, WS)
+    const outStore = out.store as Record<string, { props: { src?: string } }>
+    expect(outStore['asset:a1'].props.src).toMatch(/^asset:[0-9a-f]{64}\.png$/)
+    expect(outStore['asset:remote'].props.src).toBe('https://example.com/pic.png')
+    // The original document is not mutated (snapshot records may be frozen).
+    expect(store['asset:a1'].props.src).toStartWith('data:')
+
+    const fileName = assetSrcFileName(outStore['asset:a1'].props.src ?? '')
+    const resolved = scratchpadAssetFile(WS, fileName ?? '')
+    expect(new Uint8Array(await resolved!.file.arrayBuffer())).toEqual(PNG_BYTES)
+  })
+
+  test('returns the same document when there is nothing to extract', async () => {
+    const doc: ScratchpadDoc = { store: { 'shape:s': { typeName: 'shape', id: 'shape:s' } } }
+    expect(await extractInlineAssets(doc, WS)).toBe(doc)
+  })
+})
+
+describe('saveScratchpadDoc migration', () => {
+  test('a legacy inline snapshot is extracted on save and read-image still works', async () => {
+    await saveScratchpadDoc(legacyDoc(), WS)
+
+    // On disk: no base64 left in the JSON, one sidecar file.
+    const raw = await Bun.file(join(WS, '.moi', '.scratchpad.json')).text()
+    expect(raw).not.toInclude(';base64,')
+    expect(await readdir(getScratchpadAssetsDir(WS))).toHaveLength(1)
+
+    const { document } = await loadScratchpadDoc(WS)
+    const asset = (document?.store?.['asset:a1'] ?? {}) as { props?: { src?: string } }
+    expect(asset.props?.src).toMatch(/^asset:[0-9a-f]{64}\.png$/)
+
+    // The agent's read-image path resolves the file back to a data URL.
+    expect(await readScratchpadImage(WS, 'pic')).toEqual({
+      src: `data:image/png;base64,${PNG_B64}`
+    })
+  })
+})
+
+describe('sweepOrphanAssets', () => {
+  test('deletes old unreferenced files, keeps referenced and recent ones', async () => {
+    const { src } = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
+    const referenced = assetSrcFileName(src)!
+    const { src: orphanSrc } = await storeScratchpadAsset(
+      WS,
+      new Uint8Array([1, 2, 3]),
+      'image/png'
+    )
+    const oldOrphan = assetSrcFileName(orphanSrc)!
+    const { src: freshSrc } = await storeScratchpadAsset(WS, new Uint8Array([4, 5, 6]), 'image/png')
+    const freshOrphan = assetSrcFileName(freshSrc)!
+
+    // Age everything past the grace window, then re-touch the fresh orphan.
+    const dir = getScratchpadAssetsDir(WS)
+    const past = new Date(Date.now() - 60 * 60_000)
+    for (const name of [referenced, oldOrphan]) await utimes(join(dir, name), past, past)
+
+    const doc: ScratchpadDoc = {
+      store: {
+        'asset:a1': { id: 'asset:a1', typeName: 'asset', type: 'image', props: { src } }
+      }
+    }
+    await sweepOrphanAssets(WS, doc)
+
+    const left = await readdir(dir)
+    expect(left).toContain(referenced)
+    expect(left).toContain(freshOrphan)
+    expect(left).not.toContain(oldOrphan)
+  })
+
+  test('is a no-op when the assets dir does not exist', async () => {
+    await sweepOrphanAssets(WS, { store: {} })
+  })
+})

--- a/server/test/scratchpad-assets.test.ts
+++ b/server/test/scratchpad-assets.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'node:fs'
-import { readdir, utimes } from 'node:fs/promises'
+import { readdir } from 'node:fs/promises'
 import { join } from 'path'
 
 import {
@@ -161,7 +161,7 @@ describe('missing asset files (dangling references)', () => {
 })
 
 describe('sweepOrphanAssets', () => {
-  test('deletes old unreferenced files, keeps referenced and recent ones', async () => {
+  test('reclaims a file only after it has stayed unreferenced past the grace window', async () => {
     const { src } = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
     const referenced = assetSrcFileName(src)!
     const { src: orphanSrc } = await storeScratchpadAsset(
@@ -169,26 +169,54 @@ describe('sweepOrphanAssets', () => {
       new Uint8Array([1, 2, 3]),
       'image/png'
     )
-    const oldOrphan = assetSrcFileName(orphanSrc)!
-    const { src: freshSrc } = await storeScratchpadAsset(WS, new Uint8Array([4, 5, 6]), 'image/png')
-    const freshOrphan = assetSrcFileName(freshSrc)!
-
-    // Age everything past the grace window, then re-touch the fresh orphan.
+    const orphan = assetSrcFileName(orphanSrc)!
     const dir = getScratchpadAssetsDir(WS)
-    const past = new Date(Date.now() - 60 * 60_000)
-    for (const name of [referenced, oldOrphan]) await utimes(join(dir, name), past, past)
-
     const doc: ScratchpadDoc = {
       store: {
         'asset:a1': { id: 'asset:a1', typeName: 'asset', type: 'image', props: { src } }
       }
     }
-    await sweepOrphanAssets(WS, doc)
 
+    const t0 = 1_000_000
+    // First sweep only starts the orphan's clock; nothing is deleted yet.
+    await sweepOrphanAssets(WS, doc, undefined, t0)
+    expect(await readdir(dir)).toContain(orphan)
+
+    // Still within the grace window — kept.
+    await sweepOrphanAssets(WS, doc, undefined, t0 + 60_000)
+    expect(await readdir(dir)).toContain(orphan)
+
+    // Past the window, the still-unreferenced orphan is reclaimed; the referenced
+    // file was never on the clock and survives.
+    await sweepOrphanAssets(WS, doc, undefined, t0 + 6 * 60_000)
     const left = await readdir(dir)
     expect(left).toContain(referenced)
-    expect(left).toContain(freshOrphan)
-    expect(left).not.toContain(oldOrphan)
+    expect(left).not.toContain(orphan)
+  })
+
+  test('a long-referenced file gets a fresh grace window when it becomes unreferenced', async () => {
+    const { src } = await storeScratchpadAsset(WS, PNG_BYTES, 'image/png')
+    const name = assetSrcFileName(src)!
+    const dir = getScratchpadAssetsDir(WS)
+    const withImg: ScratchpadDoc = {
+      store: { 'asset:a1': { id: 'asset:a1', typeName: 'asset', type: 'image', props: { src } } }
+    }
+    const empty: ScratchpadDoc = { store: {} }
+
+    const t0 = 5_000_000
+    // Referenced across sweeps spanning an hour.
+    await sweepOrphanAssets(WS, withImg, undefined, t0)
+    await sweepOrphanAssets(WS, withImg, undefined, t0 + 60 * 60_000)
+
+    // It becomes unreferenced (e.g. `clear`). Despite the file being an hour old,
+    // the next sweep must NOT delete it — the clock starts here, not at write time.
+    // This is the sweep-race data-loss regression the grace anchoring fixes.
+    await sweepOrphanAssets(WS, empty, undefined, t0 + 60 * 60_000)
+    expect(await readdir(dir)).toContain(name)
+
+    // Only after the grace elapses from the un-reference moment is it reclaimed.
+    await sweepOrphanAssets(WS, empty, undefined, t0 + 60 * 60_000 + 6 * 60_000)
+    expect(await readdir(dir)).not.toContain(name)
   })
 
   test('keeps files the .bak backup still references', async () => {
@@ -209,14 +237,13 @@ describe('sweepOrphanAssets', () => {
     )
 
     const dir = getScratchpadAssetsDir(WS)
-    const past = new Date(Date.now() - 60 * 60_000)
-    for (const name of [bakKept, orphan]) await utimes(join(dir, name), past, past)
-
-    // Current document references neither file.
-    await sweepOrphanAssets(WS, { store: {} }, bakFile)
+    // Current document references neither file; run twice past the grace window.
+    const t0 = 2_000_000
+    await sweepOrphanAssets(WS, { store: {} }, bakFile, t0)
+    await sweepOrphanAssets(WS, { store: {} }, bakFile, t0 + 6 * 60_000)
 
     const left = await readdir(dir)
-    expect(left).toContain(bakKept)
+    expect(left).toContain(bakKept) // pinned by the .bak, never on the clock
     expect(left).not.toContain(orphan)
   })
 

--- a/server/test/scratchpad-executor.test.ts
+++ b/server/test/scratchpad-executor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
 import { join } from 'path'
 import sharp from 'sharp'
 
@@ -14,6 +15,7 @@ import {
   readScratchpadImage,
   readScratchpadShapes
 } from '../scratchpad'
+import { getScratchpadAssetsDir } from '../scratchpad-assets'
 
 // The headless write path: `executeScratchOp` must produce a snapshot that (a)
 // `read` reflects and (b) the *browser* could load — i.e. it survives a fresh
@@ -104,7 +106,7 @@ describe('executeScratchOp (headless)', () => {
     expect(await Bun.file(getScratchpadPath(WS)).exists()).toBe(true)
   })
 
-  test('add-image resizes to fit, embeds it, and read-image pulls it back', async () => {
+  test('add-image resizes to fit, stores a file asset, and read-image pulls it back', async () => {
     // A 4000×2000 source — larger than both presets, so it's always scaled down.
     const file = join(WS, 'big.png')
     await sharp({
@@ -119,10 +121,34 @@ describe('executeScratchOp (headless)', () => {
     const shape = (await readScratchpadShapes(WS)).find(s => s.id === 'pic')
     // Default 'lo' caps the long side at 768, aspect preserved (2:1 → 768×384).
     expect(shape).toMatchObject({ type: 'image', x: 40, y: 50, w: 768, h: 384 })
-    // read omits the blob; read-image returns the actual (re-encoded webp) data URL.
-    expect(shape?.src).toBe('base64:omitted')
+    // The bytes live as a content-addressed sidecar file, referenced by an
+    // `asset:` src — the snapshot JSON itself must carry no base64 blob.
+    expect(shape?.src).toMatch(/^asset:[0-9a-f]{64}\.webp$/)
+    const files = await readdir(getScratchpadAssetsDir(WS))
+    expect(files).toHaveLength(1)
+    expect(`asset:${files[0]}`).toBe(shape?.src ?? '')
+    expect(await Bun.file(getScratchpadPath(WS)).text()).not.toInclude(';base64,')
+    // read-image resolves the file back into the (re-encoded webp) data URL.
     const img = await readScratchpadImage(WS, 'pic')
     expect(img).toEqual({ src: expect.stringMatching(/^data:image\/webp;base64,/) })
+  })
+
+  test('clear drops asset records so the sweep can reclaim their files', async () => {
+    const file = join(WS, 'img.png')
+    await sharp({
+      create: { width: 64, height: 64, channels: 3, background: { r: 5, g: 5, b: 5 } }
+    })
+      .png()
+      .toFile(file)
+    await run({ kind: 'add-image', name: 'pic', x: 0, y: 0, path: file })
+
+    await run({ kind: 'clear' })
+    const { document } = await loadScratchpadDoc(WS)
+    const assets = Object.values(document?.store ?? {}).filter(
+      r => (r as { typeName?: string }).typeName === 'asset'
+    )
+    expect(assets).toHaveLength(0)
+    expect(await assertLoadable()).toBe(0)
   })
 
   test('add-image --quality hi keeps more pixels', async () => {

--- a/server/test/scratchpad-executor.test.ts
+++ b/server/test/scratchpad-executor.test.ts
@@ -151,6 +151,26 @@ describe('executeScratchOp (headless)', () => {
     expect(await assertLoadable()).toBe(0)
   })
 
+  test('delete drops the sole asset reference so the sweep can reclaim its file', async () => {
+    const file = join(WS, 'img.png')
+    await sharp({
+      create: { width: 32, height: 32, channels: 3, background: { r: 9, g: 9, b: 9 } }
+    })
+      .png()
+      .toFile(file)
+    await run({ kind: 'add-image', name: 'pic', x: 0, y: 0, path: file })
+    expect(await readdir(getScratchpadAssetsDir(WS))).toHaveLength(1)
+
+    await run({ kind: 'delete', name: 'pic' })
+    // The shape's asset record goes with it (no other shape used it), so the
+    // sweep is free to reclaim the file — nothing pins it anymore.
+    const { document } = await loadScratchpadDoc(WS)
+    const assets = Object.values(document?.store ?? {}).filter(
+      r => (r as { typeName?: string }).typeName === 'asset'
+    )
+    expect(assets).toHaveLength(0)
+  })
+
   test('add-image --quality hi keeps more pixels', async () => {
     const file = join(WS, 'big.png')
     await sharp({

--- a/server/test/scratchpad-executor.test.ts
+++ b/server/test/scratchpad-executor.test.ts
@@ -123,7 +123,7 @@ describe('executeScratchOp (headless)', () => {
     expect(shape).toMatchObject({ type: 'image', x: 40, y: 50, w: 768, h: 384 })
     // The bytes live as a content-addressed sidecar file, referenced by an
     // `asset:` src — the snapshot JSON itself must carry no base64 blob.
-    expect(shape?.src).toMatch(/^asset:[0-9a-f]{64}\.webp$/)
+    expect(shape?.src).toMatch(/^asset:asset-[0-9a-f]{64}\.webp$/)
     const files = await readdir(getScratchpadAssetsDir(WS))
     expect(files).toHaveLength(1)
     expect(`asset:${files[0]}`).toBe(shape?.src ?? '')

--- a/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
+++ b/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
@@ -12,9 +12,10 @@ tldraw's and shifts without notice, blobs are stripped, and `moi scratch read` a
 clean, agent-friendly view. Treat it exactly like `.moi/.workspace.json` — CLI only.
 
 - `moi scratch read` — dump the canvas as JSON: each shape's `id`, `type`, position, size, and
-  text. Off disk, so it works whether or not a browser tab is open.
-- `moi scratch read-image <id>` — save one image shape to a file (its actual bytes; `read` omits
-  the blob). Off disk too.
+  text. Off disk, so it works whether or not a browser tab is open. An image shape's `src` is a
+  reference (`asset:...` or a URL), never the pixels.
+- `moi scratch read-image <id>` — save one image shape to a file (its actual bytes; `read` only
+  carries the reference). Off disk too.
 - `moi scratch view` — render the whole canvas to a PNG. Needs an open Scratchpad tab.
 
 `read` is for logic; `view` / `read-image` are for vision.

--- a/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
+++ b/workspace/.claude/skills/moi-workspace/SCRATCHPAD.md
@@ -13,7 +13,8 @@ clean, agent-friendly view. Treat it exactly like `.moi/.workspace.json` — CLI
 
 - `moi scratch read` — dump the canvas as JSON: each shape's `id`, `type`, position, size, and
   text. Off disk, so it works whether or not a browser tab is open. An image shape's `src` is a
-  reference (`asset:...` or a URL), never the pixels.
+  reference (`asset:...` or a URL), never the pixels; `missing: true` on a shape means its image
+  file is gone, so don't bother calling `read-image` on it.
 - `moi scratch read-image <id>` — save one image shape to a file (its actual bytes; `read` only
   carries the reference). Off disk too.
 - `moi scratch view` — render the whole canvas to a PNG. Needs an open Scratchpad tab.

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -84,6 +84,7 @@ my-agent-folder/
     package.json              <- Applet dependencies that you manage
     .workspace.json           <- Auto-generated. Do NOT read, edit, or `cat` this file. Use Moi CLI instead.
     .scratchpad.json          <- Scratchpad canvas snapshot. Internal — inspect only via `moi scratch read`, never open it.
+    .scratchpad/              <- Scratchpad image files. Internal — pull pixels via `moi scratch read-image`, never open it.
 ```
 
 # Build environment


### PR DESCRIPTION
## Summary

Move scratchpad image bytes from inline base64 data URLs in `.moi/.scratchpad.json` to content-addressed files in `.moi/.scratchpad/`. This prevents megabytes of pixels from being re-serialized on every autosave and shipped over every GET/PUT, while maintaining backward compatibility with legacy snapshots.

## Key Changes

- **New module `server/scratchpad-assets.ts`**: Implements file-backed asset storage with:
  - Content-addressed file naming (SHA256 hash of bytes) for automatic deduplication
  - MIME type to file extension mapping
  - Validation of asset sources to prevent directory traversal attacks
  - Orphan asset cleanup with a grace period to handle async uploads
  - Migration of legacy inline base64 data URLs to files on save

- **Browser asset store (`client/components/Scratchpad.tsx`)**: 
  - Implements `TLAssetStore` to POST image bytes to `/scratchpad/assets` on paste/drop
  - Resolves `asset:` file references back to serving URLs at render time
  - Transparently handles legacy data URLs (passed through unchanged)

- **Server API routes (`server/api.ts`)**:
  - `POST /scratchpad/assets` — accepts raw image bytes, stores as content-addressed file, returns `asset:` src
  - `GET /scratchpad/assets/:file` — serves stored assets with immutable cache headers

- **Scratchpad save pipeline (`server/scratchpad.ts`)**:
  - Calls `extractInlineAssets()` before every save to migrate any base64 blobs to files
  - Calls `sweepOrphanAssets()` after save to reclaim unreferenced files
  - Updated comments to reflect new asset model

- **Server-side image processing (`server/scratchpad-executor.ts`)**:
  - `add-image` now stores resized WebP bytes as a file asset instead of embedding as base64
  - Returns `asset:` src on the asset record

- **Image reading (`server/scratchpad.ts`)**:
  - `readScratchpadImage()` resolves `asset:` file references back to data URLs for CLI compatibility
  - Handles legacy inline data URLs and remote https URLs transparently

- **Tests**: Comprehensive test suite covering:
  - Content addressing and deduplication
  - Source validation and security
  - Inline asset extraction and migration
  - Orphan asset cleanup with grace period
  - End-to-end save/load cycle

## Implementation Details

- **Content addressing**: File names are `asset-<sha256>.<ext>`, making every write idempotent and enabling automatic deduplication when identical images are pasted multiple times
- **Backward compatibility**: Legacy snapshots with inline base64 are transparently migrated on the next save; stale browser tabs holding base64 in their live store are handled the same way
- **Grace period**: Orphan sweep waits 5 minutes before deleting unreferenced files, allowing for the async upload → asset record save window
- **Security**: Strict validation of asset file names prevents directory traversal and only serves files we created
- **Immutable caching**: Assets are served with `Cache-Control: public, max-age=31536000, immutable` since content addressing guarantees they never change

https://claude.ai/code/session_01T3HuarjiNPZL3FiwvCTaXf