### PR TITLE
Bump actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
Silences the GitHub Actions deprecation warning: `actions/checkout@v4` targets Node.js 20, which is being force-run on Node.js 24. v5 targets Node 24 natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)