### PR TITLE
Add widget builder support and stale build detection

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,9 +33,11 @@ export type ViewInfo = {
 
 export type ViewBuilderStatus = 'draft' | 'building' | 'waiting' | 'ready'
 
-// The two applet kinds a builder can track. Absent on records written before
-// the field existed — treat a missing kind as 'view'.
-export type ViewBuilderKind = 'view' | 'widget'
+// The kind of an applet — a custom UI unit embedded in a workspace. Shared by
+// the bundler pipeline and the build-status records. On a builder record the
+// field is absent for rows written before it existed; treat a missing kind as
+// 'view' (only views surface in the UI — the view builder page is view-only).
+export type AppletKind = 'view' | 'widget'
 
 export type ViewBuilderInput = {
   requirements: string
@@ -43,7 +45,7 @@ export type ViewBuilderInput = {
 
 export type ViewBuilder = {
   id: string
-  kind?: ViewBuilderKind
+  kind?: AppletKind
   status: ViewBuilderStatus
   input: ViewBuilderInput
   sessionId: string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,12 +33,17 @@ export type ViewInfo = {
 
 export type ViewBuilderStatus = 'draft' | 'building' | 'waiting' | 'ready'
 
+// The two applet kinds a builder can track. Absent on records written before
+// the field existed — treat a missing kind as 'view'.
+export type ViewBuilderKind = 'view' | 'widget'
+
 export type ViewBuilderInput = {
   requirements: string
 }
 
 export type ViewBuilder = {
   id: string
+  kind?: ViewBuilderKind
   status: ViewBuilderStatus
   input: ViewBuilderInput
   sessionId: string
@@ -46,6 +51,9 @@ export type ViewBuilder = {
   title?: string
   icon?: string
   error?: string
+  // Wall-clock ms when this builder last entered `building`. Used by reconcile
+  // to demote a build that has been running too long (a hung/abandoned turn).
+  buildingSince?: number
   createdAt: number
   updatedAt: number
 }

--- a/lib/view-builder-meta.ts
+++ b/lib/view-builder-meta.ts
@@ -13,7 +13,7 @@ export function appendViewBuilderMeta(
     `Builder id: ${builderId}`,
     `Available view icons: ${availableIcons.join(', ')}`,
     'Your first action must be to infer a stable view id, sentence-case title, and relevant icon from the requirements, then run:',
-    `moi view-builder claim --builder ${builderId} --id <view-id> --title "<title>" --icon <icon-id>`,
+    `moi builder set <view-id> --builder ${builderId} --kind view --title "<title>" --icon <icon-id>`,
     'Do this before reading files, planning, or writing code. Choose the icon id from the available view icons above.',
     'Capitalize only the first word of the title.',
     'Use the same icon id in the view config.',

--- a/server/api.ts
+++ b/server/api.ts
@@ -169,7 +169,9 @@ one.get('/view-builders', async c => {
     await getViewList(ws.path),
     activeSessionIds
   )
-  return c.json({ builders })
+  // Widget builders are record-only for now — reconciled server-side but kept
+  // out of the host's view-builder tab list until their UI lands.
+  return c.json({ builders: builders.filter(builder => builder.kind !== 'widget') })
 })
 
 one.post('/view-builders', async c => {

--- a/server/bundler/build-applet.ts
+++ b/server/bundler/build-applet.ts
@@ -8,15 +8,16 @@ import tailwind from 'bun-plugin-tailwind'
 import { realpathSync } from 'node:fs'
 import { basename, dirname, join, relative, sep } from 'path'
 
-import type { ViewConfig, WidgetConfig } from '@/lib/types'
+import type { AppletKind, ViewConfig, WidgetConfig } from '@/lib/types'
 
 import { scopeAppletCss } from './applet-css'
 
 // An **applet** is any custom UI unit embedded in a workspace; `widget` and
 // `view` are its kinds (more may follow). All compile through this pipeline —
 // `kind` only diverges at the edges: which `config` schema is parsed, the
-// synthetic-CSS filename, and the CSS scope/registry namespace.
-export type AppletKind = 'widget' | 'view'
+// synthetic-CSS filename, and the CSS scope/registry namespace. The type is
+// canonical in lib/types; re-exported here for this pipeline's consumers.
+export type { AppletKind }
 
 // Baked into the bundle wherever a runtime URL needs the workspace's API base
 // (RPC + workspace files). The serve route string-replaces it with the real

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -403,6 +403,11 @@ const bundle = defineCommand({
     only: {
       type: 'string',
       description: 'Narrow the build to "widgets" or "views" (default: both)'
+    },
+    status: {
+      type: 'boolean',
+      description: 'Advance a view builder to ready on success (use --no-status to skip)',
+      default: true
     }
   },
   async run({ args }) {
@@ -413,7 +418,15 @@ const bundle = defineCommand({
     const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
 
     ws.onopen = () =>
-      ws.send(JSON.stringify({ type: 'bundle', path, force: args.force, only: args.only }))
+      ws.send(
+        JSON.stringify({
+          type: 'bundle',
+          path,
+          force: args.force,
+          only: args.only,
+          noStatus: !args.status
+        })
+      )
 
     ws.onmessage = event => {
       const res = JSON.parse(String(event.data))
@@ -480,17 +493,22 @@ const bundle = defineCommand({
   }
 })
 
-const viewBuilderClaim = defineCommand({
-  meta: { name: 'claim', description: 'Claim the id, title, and icon for a view builder' },
+const builderSet = defineCommand({
+  meta: { name: 'set', description: 'Set a view or widget builder id, status, title, and icon' },
   args: {
-    builder: { type: 'string', required: true, description: 'View builder id' },
-    id: { type: 'string', required: true, description: 'Stable view id' },
-    title: { type: 'string', required: true, description: 'View title' },
-    icon: { type: 'string', required: true, description: 'App icon registry id' },
+    id: { type: 'positional', required: true, description: 'View or widget id' },
     dir: {
       type: 'positional',
       default: '.',
       description: 'Workspace directory (default: current)'
+    },
+    kind: { type: 'string', default: 'view', description: '"view" or "widget"' },
+    status: { type: 'string', description: 'Report build state: "building" or "waiting"' },
+    title: { type: 'string', description: 'Display title' },
+    icon: { type: 'string', description: 'App icon registry id' },
+    builder: {
+      type: 'string',
+      description: 'Builder handle for a pending view builder (from its request)'
     }
   },
   run({ args }) {
@@ -499,12 +517,14 @@ const viewBuilderClaim = defineCommand({
     ws.onopen = () =>
       ws.send(
         JSON.stringify({
-          type: 'view-builder:claim',
+          type: 'builder:set',
           path,
-          builder: args.builder,
           id: args.id,
+          kind: args.kind,
+          status: args.status,
           title: args.title,
-          icon: args.icon
+          icon: args.icon,
+          builder: args.builder
         })
       )
     ws.onmessage = event => {
@@ -517,7 +537,7 @@ const viewBuilderClaim = defineCommand({
       console.log(
         '\n' +
           pc.green('✓') +
-          ' View builder claimed ' +
+          ' Builder set ' +
           pc.bold(String(result.builder?.viewId ?? args.id)) +
           '\n'
       )
@@ -531,9 +551,9 @@ const viewBuilderClaim = defineCommand({
   }
 })
 
-const viewBuilder = defineCommand({
-  meta: { name: 'view-builder', description: 'Manage an active view builder' },
-  subCommands: { claim: viewBuilderClaim }
+const builder = defineCommand({
+  meta: { name: 'builder', description: 'Manage a view or widget builder' },
+  subCommands: { set: builderSet }
 })
 
 const refresh = defineCommand({
@@ -1786,7 +1806,7 @@ const main = defineCommand({
     init,
     start,
     bundle,
-    'view-builder': viewBuilder,
+    builder,
     refresh,
     theme,
     config,

--- a/server/control.ts
+++ b/server/control.ts
@@ -15,8 +15,13 @@ import { relayScratchOp } from './scratchpad-relay'
 import { broadcastAll } from './state'
 import { applyThemeUpdate, matchColorTheme } from './theme'
 import { handleBundle } from './widgets'
-import { handleBundleViews, hasViewId } from './views'
-import { ViewBuilderError, claimViewBuilder, listViewBuilders } from './view-builders'
+import { getViewList, handleBundleViews, hasViewId } from './views'
+import {
+  ViewBuilderError,
+  listViewBuilders,
+  reconcileViewBuilders,
+  setBuilder
+} from './view-builders'
 import { getWorkspaceConfig, setWorkspaceConfig } from './workspace-config'
 
 type ControlSocket = { send(data: string): void }
@@ -84,6 +89,9 @@ export const control = Bun.serve({
           if (!match) return
           const workspacePath = match.path
           const force = !!data.force
+          // `--no-status`: compile without advancing any view builder to `ready`
+          // (status stays whatever the agent last reported).
+          const skipStatus = data.noStatus === true
           // `only` narrows to one kind; default builds both. Results carry a
           // `kind` so the CLI can label each row.
           const only = data.only === 'widgets' || data.only === 'views' ? data.only : undefined
@@ -104,7 +112,8 @@ export const control = Bun.serve({
                 publishEvent,
                 match.id,
                 workspacePath,
-                force
+                force,
+                skipStatus
               )) {
                 results.push({ kind: 'view', name: r.name, status: r.status, error: r.error })
               }
@@ -114,27 +123,29 @@ export const control = Bun.serve({
           return
         }
 
-        if (data.type === 'view-builder:claim') {
+        if (data.type === 'builder:set') {
           const match = await resolveWorkspace(ws, data.path)
           if (!match) return
+          const appletId = typeof data.id === 'string' ? data.id.trim() : ''
           const builderId = typeof data.builder === 'string' ? data.builder.trim() : ''
-          const viewId = typeof data.id === 'string' ? data.id.trim() : ''
-          const title = typeof data.title === 'string' ? data.title.trim() : ''
-          const icon = typeof data.icon === 'string' ? data.icon.trim() : ''
-          if (!builderId || !viewId || !title || !icon) {
-            ws.send(JSON.stringify({ error: 'Builder, view id, title, and icon are required' }))
+          const kind = data.kind === 'widget' ? 'widget' : 'view'
+          const status =
+            data.status === 'building' || data.status === 'waiting' ? data.status : undefined
+          const title = typeof data.title === 'string' ? data.title.trim() : undefined
+          const icon = typeof data.icon === 'string' ? data.icon.trim() : undefined
+          if (!appletId) {
+            ws.send(JSON.stringify({ error: 'A view or widget id is required' }))
             return
           }
-          if (!/^[a-z0-9][a-z0-9_-]*$/.test(viewId)) {
+          if (!/^[a-z0-9][a-z0-9_-]*$/.test(appletId)) {
             ws.send(
               JSON.stringify({
-                error:
-                  'View id must start with a lowercase letter or number and use a-z, 0-9, _, or -'
+                error: 'Id must start with a lowercase letter or number and use a-z, 0-9, _, or -'
               })
             )
             return
           }
-          if (!/^[a-z0-9][a-z0-9-]*$/.test(icon)) {
+          if (icon && !/^[a-z0-9][a-z0-9-]*$/.test(icon)) {
             ws.send(
               JSON.stringify({
                 error: 'Icon must start with a lowercase letter or number and use a-z, 0-9, or -'
@@ -143,27 +154,29 @@ export const control = Bun.serve({
             return
           }
           try {
-            const current = (await listViewBuilders(match.path)).find(
-              builder => builder.id === builderId
-            )
-            if (current?.viewId !== viewId && (await hasViewId(match.path, viewId))) {
-              ws.send(JSON.stringify({ error: `View id "${viewId}" already exists` }))
-              return
+            // A view can't claim an id that already exists on disk (unless this
+            // builder already owns it). Widgets live in a separate namespace.
+            if (kind === 'view') {
+              const current = (await listViewBuilders(match.path)).find(builder =>
+                builderId ? builder.id === builderId : builder.viewId === appletId
+              )
+              if (current?.viewId !== appletId && (await hasViewId(match.path, appletId))) {
+                ws.send(JSON.stringify({ error: `View id "${appletId}" already exists` }))
+                return
+              }
             }
-            const builder = await claimViewBuilder(
-              match.id,
-              match.path,
-              builderId,
-              viewId,
+            const builder = await setBuilder(match.id, match.path, appletId, {
+              builderId: builderId || undefined,
+              kind,
+              status,
               title,
               icon
-            )
+            })
             ws.send(JSON.stringify({ ok: true, builder, workspacePath: match.path }))
           } catch (err) {
             ws.send(
               JSON.stringify({
-                error:
-                  err instanceof ViewBuilderError ? err.message : 'Could not claim view builder'
+                error: err instanceof ViewBuilderError ? err.message : 'Could not set builder'
               })
             )
           }
@@ -319,3 +332,23 @@ export const control = Bun.serve({
     }
   }
 })
+
+// On boot, correct any builder a previous process left mid-flight. With no live
+// sessions yet, a persisted `building` record is by definition stale, so
+// reconcile hands it back to `waiting` — or promotes it to `ready` if its view
+// actually reached disk. GET-time reconcile would eventually do this too, but
+// only once a client reopens the workspace; this makes the stored state correct
+// even if no one does.
+async function reconcileBuildersOnBoot(): Promise<void> {
+  const workspaces = await listWorkspaces()
+  await Promise.all(
+    workspaces.map(async entry => {
+      try {
+        await reconcileViewBuilders(entry.id, entry.path, await getViewList(entry.path), new Set())
+      } catch (err) {
+        console.error('[control] boot reconcile failed', entry.path, err)
+      }
+    })
+  )
+}
+void reconcileBuildersOnBoot()

--- a/server/test/view-builder-meta.test.ts
+++ b/server/test/view-builder-meta.test.ts
@@ -15,7 +15,7 @@ describe('view builder message metadata', () => {
     expect(content).toContain('Your first action must be')
     expect(content).toContain('sentence-case title')
     expect(content).toContain('Capitalize only the first word')
-    expect(content).toContain('moi view-builder claim --builder builder-123')
+    expect(content).toContain('moi builder set <view-id> --builder builder-123 --kind view')
     expect(content).toContain('--icon <icon-id>')
     expect(content).toContain('before reading files')
     expect(stripViewBuilderMeta(content)).toBe('Build a project tracker')

--- a/server/test/view-builders.test.ts
+++ b/server/test/view-builders.test.ts
@@ -3,10 +3,11 @@ import { mkdtemp, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { ViewBuilder } from '@/lib/types'
+
 import {
   ViewBuilderError,
   beginViewBuilder,
-  claimViewBuilder,
   createViewBuilder,
   deleteViewBuilder,
   listViewBuilders,
@@ -14,6 +15,7 @@ import {
   markViewBuilderWaitingBySession,
   reconcileViewBuilders,
   renameViewBuilderSession,
+  setBuilder,
   setViewBuilderStorePath,
   updateViewBuilderInput
 } from '../view-builders'
@@ -32,6 +34,23 @@ beforeAll(async () => {
 afterAll(async () => {
   await rm(storeDir, { recursive: true, force: true })
 })
+
+// Backdate a builder's buildingSince directly in the store to simulate a build
+// that has been running longer than the stale threshold (no fake clock needed).
+async function mutateBuildingSince(builderId: string, value: number): Promise<boolean> {
+  const store = JSON.parse(await Bun.file(storePath).text()) as Record<string, ViewBuilder[]>
+  let found = false
+  for (const builders of Object.values(store)) {
+    for (const builder of builders) {
+      if (builder.id === builderId) {
+        builder.buildingSince = value
+        found = true
+      }
+    }
+  }
+  await Bun.write(storePath, JSON.stringify(store, null, 2))
+  return found
+}
 
 describe('view builder storage', () => {
   test('serializes concurrent creates without losing builders', async () => {
@@ -79,50 +98,100 @@ describe('view builder storage', () => {
     const second = builders[1]
     await beginViewBuilder(workspaceId, workspacePath, second.id, 'Another view')
 
-    const claimed = await claimViewBuilder(
-      workspaceId,
-      workspacePath,
-      first.id,
-      'sales-dashboard',
-      'Sales dashboard',
-      'chart'
-    )
+    const claimed = await setBuilder(workspaceId, workspacePath, 'sales-dashboard', {
+      builderId: first.id,
+      title: 'Sales dashboard',
+      icon: 'chart'
+    })
     expect(claimed.viewId).toBe('sales-dashboard')
     expect(claimed.icon).toBe('chart')
 
-    const renamed = await claimViewBuilder(
-      workspaceId,
-      workspacePath,
-      first.id,
-      'sales-dashboard',
-      'Revenue dashboard',
-      'target'
-    )
+    const renamed = await setBuilder(workspaceId, workspacePath, 'sales-dashboard', {
+      builderId: first.id,
+      title: 'Revenue dashboard',
+      icon: 'target'
+    })
     expect(renamed.title).toBe('Revenue dashboard')
     expect(renamed.icon).toBe('target')
+    // A claimed builder can't be re-pointed at a different id.
     await expect(
-      claimViewBuilder(workspaceId, workspacePath, first.id, 'different-id', 'Different', 'file')
+      setBuilder(workspaceId, workspacePath, 'different-id', {
+        builderId: first.id,
+        title: 'Different',
+        icon: 'file'
+      })
     ).rejects.toBeInstanceOf(ViewBuilderError)
+    // Another builder can't claim an id already taken.
     await expect(
-      claimViewBuilder(
-        workspaceId,
-        workspacePath,
-        second.id,
-        'sales-dashboard',
-        'Duplicate',
-        'file'
-      )
+      setBuilder(workspaceId, workspacePath, 'sales-dashboard', {
+        builderId: second.id,
+        title: 'Duplicate',
+        icon: 'file'
+      })
     ).rejects.toBeInstanceOf(ViewBuilderError)
+    // Invalid icon id is rejected.
     await expect(
-      claimViewBuilder(
-        workspaceId,
-        workspacePath,
-        second.id,
-        'another-view',
-        'Another view',
-        'ChartBar'
-      )
+      setBuilder(workspaceId, workspacePath, 'another-view', {
+        builderId: second.id,
+        title: 'Another view',
+        icon: 'ChartBar'
+      })
     ).rejects.toBeInstanceOf(ViewBuilderError)
+  })
+
+  test('creates a standalone widget builder keyed by applet id and stamps buildingSince', async () => {
+    const created = await setBuilder(workspaceId, workspacePath, 'sales-widget', {
+      kind: 'widget',
+      status: 'building',
+      title: 'Sales widget'
+    })
+    expect(created.kind).toBe('widget')
+    expect(created.viewId).toBe('sales-widget')
+    expect(created.status).toBe('building')
+    expect(created.buildingSince).toBeGreaterThan(0)
+
+    // A second call with the same id upserts the existing record, not a new one.
+    const updated = await setBuilder(workspaceId, workspacePath, 'sales-widget', {
+      kind: 'widget',
+      title: 'Revenue widget'
+    })
+    expect(updated.id).toBe(created.id)
+    expect(updated.title).toBe('Revenue widget')
+
+    const stored = await listViewBuilders(workspacePath)
+    expect(stored.filter(builder => builder.viewId === 'sales-widget')).toHaveLength(1)
+
+    // Hand it back so it can be discarded (a building builder can't be), and
+    // clear it from the shared store before the later reconcile tests run.
+    const parked = await setBuilder(workspaceId, workspacePath, 'sales-widget', {
+      kind: 'widget',
+      status: 'waiting'
+    })
+    expect(parked.status).toBe('waiting')
+    await deleteViewBuilder(workspaceId, workspacePath, created.id)
+  })
+
+  test('a stale buildingSince demotes a build even with a live session', async () => {
+    const draft = (await listViewBuilders(workspacePath)).find(
+      builder => builder.status === 'draft'
+    )
+    if (!draft) throw new Error('expected a draft builder')
+    await beginViewBuilder(workspaceId, workspacePath, draft.id, 'Hung build')
+    const building = (await listViewBuilders(workspacePath)).find(
+      builder => builder.id === draft.id
+    )
+    expect(building?.status).toBe('building')
+
+    // Session is "live", but the build has been running far too long.
+    const stale = await mutateBuildingSince(draft.id, Date.now() - 20 * 60_000)
+    expect(stale).toBe(true)
+    const reconciled = await reconcileViewBuilders(
+      workspaceId,
+      workspacePath,
+      [],
+      new Set([draft.sessionId])
+    )
+    expect(reconciled.find(builder => builder.id === draft.id)?.status).toBe('waiting')
   })
 
   test('follows session renames and moves between waiting and building', async () => {

--- a/server/test/view-builders.test.ts
+++ b/server/test/view-builders.test.ts
@@ -171,6 +171,37 @@ describe('view builder storage', () => {
     await deleteViewBuilder(workspaceId, workspacePath, created.id)
   })
 
+  test('a view and a widget may share an applet id without clashing', async () => {
+    const view = await setBuilder(workspaceId, workspacePath, 'shared-id', {
+      kind: 'view',
+      title: 'Shared view',
+      icon: 'chart'
+    })
+    const widget = await setBuilder(workspaceId, workspacePath, 'shared-id', {
+      kind: 'widget',
+      title: 'Shared widget'
+    })
+    expect(view.id).not.toBe(widget.id)
+    expect(view.kind).toBe('view')
+    expect(widget.kind).toBe('widget')
+
+    // Setting the widget again resolves to the widget record, not the view.
+    const again = await setBuilder(workspaceId, workspacePath, 'shared-id', {
+      kind: 'widget',
+      title: 'Shared widget v2'
+    })
+    expect(again.id).toBe(widget.id)
+    expect(again.title).toBe('Shared widget v2')
+
+    for (const id of [view.id, widget.id]) {
+      await setBuilder(workspaceId, workspacePath, 'shared-id', {
+        kind: id === view.id ? 'view' : 'widget',
+        status: 'waiting'
+      })
+      await deleteViewBuilder(workspaceId, workspacePath, id)
+    }
+  })
+
   test('a stale buildingSince demotes a build even with a live session', async () => {
     const draft = (await listViewBuilders(workspacePath)).find(
       builder => builder.status === 'draft'

--- a/server/view-builders.ts
+++ b/server/view-builders.ts
@@ -1,12 +1,17 @@
 import { mkdir, rename } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type { ViewBuilder, ViewInfo } from '@/lib/types'
+import type { ViewBuilder, ViewBuilderKind, ViewInfo } from '@/lib/types'
 
 import { DATA_DIR } from './data-dir'
 import { publishEvent } from './events'
 
 type ViewBuilderStore = Record<string, ViewBuilder[]>
+
+// A build running past this is treated as hung/abandoned and reconciled back to
+// `waiting`, even if its session still looks live. Generous so a slow but real
+// build is never cut off mid-flight.
+const STALE_BUILD_MS = 10 * 60_000
 
 export class ViewBuilderError extends Error {
   status: 400 | 404 | 409
@@ -85,6 +90,9 @@ function findBuilder(builders: ViewBuilder[], builderId: string): [ViewBuilder, 
 }
 
 function publishUpdated(workspaceId: string, builder: ViewBuilder): void {
+  // Widget builders are record-only for now — no host UI consumes them, so keep
+  // them off the client event stream (and out of the view-builder tab list).
+  if (builder.kind === 'widget') return
   publishEvent({ type: 'view-builder:updated', workspaceId, builder })
 }
 
@@ -100,6 +108,7 @@ export async function createViewBuilder(
     const now = Date.now()
     const created: ViewBuilder = {
       id: crypto.randomUUID(),
+      kind: 'view',
       status: 'draft',
       input: { requirements: '' },
       sessionId: crypto.randomUUID(),
@@ -149,6 +158,7 @@ export async function beginViewBuilder(
       index,
       updated(withoutError as ViewBuilder, {
         status: 'building',
+        buildingSince: Date.now(),
         input: { requirements: text }
       })
     )
@@ -157,30 +167,90 @@ export async function beginViewBuilder(
   return builder
 }
 
-export async function claimViewBuilder(
+type SetBuilderInput = {
+  // Correlation handle for a pending, UI-initiated builder (the value injected
+  // into the agent's prompt). Omitted for a standalone/widget build, which is
+  // then keyed and upserted by its applet id.
+  builderId?: string
+  kind?: ViewBuilderKind
+  // The states the agent reports first-hand. `ready` is never accepted here —
+  // it stays server-derived from the compiled applet (bundle + reconcile).
+  status?: 'building' | 'waiting'
+  title?: string
+  icon?: string
+}
+
+// Bind an applet id (+ optional title/icon/status) to a builder — the single
+// write behind `moi builder set`. Locates the record by handle when claiming a
+// pending builder, otherwise by applet id (creating one for a standalone build).
+export async function setBuilder(
   workspaceId: string,
   workspacePath: string,
-  builderId: string,
-  viewId: string,
-  title: string,
-  icon: string
+  appletId: string,
+  input: SetBuilderInput
 ): Promise<ViewBuilder> {
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(icon)) {
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(appletId)) {
+    throw new ViewBuilderError('Invalid applet id', 400)
+  }
+  if (input.icon !== undefined && !/^[a-z0-9][a-z0-9-]*$/.test(input.icon)) {
     throw new ViewBuilderError('Invalid view icon id', 400)
   }
   const builder = await mutateBuilders(workspacePath, builders => {
-    const [current, index] = findBuilder(builders, builderId)
-    if (current.status === 'draft') {
+    const index = input.builderId
+      ? builders.findIndex(candidate => candidate.id === input.builderId)
+      : builders.findIndex(candidate => candidate.viewId === appletId)
+    if (input.builderId && index === -1) {
+      throw new ViewBuilderError('View builder not found', 404)
+    }
+    // The applet id is unique across builders in a workspace.
+    const clash = builders.find((candidate, i) => i !== index && candidate.viewId === appletId)
+    if (clash) throw new ViewBuilderError(`View id "${appletId}" is already claimed`, 409)
+
+    if (index === -1) {
+      // Standalone build (e.g. a widget) with no pending record — create one.
+      const now = Date.now()
+      const status = input.status ?? 'building'
+      const created: ViewBuilder = {
+        id: crypto.randomUUID(),
+        kind: input.kind ?? 'view',
+        status,
+        input: { requirements: '' },
+        sessionId: crypto.randomUUID(),
+        viewId: appletId,
+        ...(input.title ? { title: input.title } : {}),
+        ...(input.icon ? { icon: input.icon } : {}),
+        ...(status === 'building' ? { buildingSince: now } : {}),
+        createdAt: now,
+        updatedAt: now
+      }
+      builders.push(created)
+      return created
+    }
+
+    const current = builders[index]
+    if (input.builderId && current.status === 'draft') {
       throw new ViewBuilderError('View builder has not been submitted', 409)
     }
-    if (current.viewId && current.viewId !== viewId) {
+    if (current.viewId && current.viewId !== appletId) {
       throw new ViewBuilderError(`View builder already claimed "${current.viewId}"`, 409)
     }
-    const claimed = builders.find(
-      candidate => candidate.id !== builderId && candidate.viewId === viewId
+    // `ready` is terminal and server-owned: the agent's reported status can
+    // never move a built applet back to building/waiting.
+    const status = current.status === 'ready' ? 'ready' : (input.status ?? current.status)
+    const enteringBuild = status === 'building' && current.status !== 'building'
+    const { error: _error, ...withoutError } = current
+    return replace(
+      builders,
+      index,
+      updated(withoutError as ViewBuilder, {
+        viewId: appletId,
+        ...(input.kind ? { kind: input.kind } : {}),
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.icon !== undefined ? { icon: input.icon } : {}),
+        status,
+        ...(enteringBuild ? { buildingSince: Date.now() } : {})
+      })
     )
-    if (claimed) throw new ViewBuilderError(`View id "${viewId}" is already claimed`, 409)
-    return replace(builders, index, updated(current, { viewId, title, icon }))
   })
   publishUpdated(workspaceId, builder)
   return builder
@@ -195,7 +265,11 @@ export async function markViewBuilderBuildingBySession(
     const index = builders.findIndex(candidate => candidate.sessionId === sessionId)
     if (index === -1 || builders[index].status !== 'waiting') return null
     const { error: _error, ...withoutError } = builders[index]
-    return replace(builders, index, updated(withoutError as ViewBuilder, { status: 'building' }))
+    return replace(
+      builders,
+      index,
+      updated(withoutError as ViewBuilder, { status: 'building', buildingSince: Date.now() })
+    )
   })
   if (builder) publishUpdated(workspaceId, builder)
   return builder
@@ -293,12 +367,23 @@ export async function reconcileViewBuilders(
   views: ViewInfo[],
   activeSessionIds: Set<string>
 ): Promise<ViewBuilder[]> {
+  const now = Date.now()
   const changed = await mutateBuilders(workspacePath, builders => {
     const viewsById = new Map(views.map(view => [view.id, view]))
     const updates: ViewBuilder[] = []
     for (let index = 0; index < builders.length; index++) {
       const current = builders[index]
-      const view = current.viewId ? viewsById.get(current.viewId) : undefined
+      // Only view builders reconcile against the compiled view list; widget
+      // records track their own applet id in a separate namespace.
+      const view =
+        current.viewId && current.kind !== 'widget' ? viewsById.get(current.viewId) : undefined
+      // A build with no live session (server restart, drained turn) — or one that
+      // has been building far too long (a hung/abandoned turn that never drained)
+      // — is stuck; hand it back so the user can resume or discard it.
+      const stuck =
+        current.status === 'building' &&
+        (!activeSessionIds.has(current.sessionId) ||
+          (current.buildingSince !== undefined && now - current.buildingSince > STALE_BUILD_MS))
       if (view && current.status !== 'ready') {
         const { error: _error, ...withoutError } = current
         const next = updated(withoutError as ViewBuilder, {
@@ -308,7 +393,7 @@ export async function reconcileViewBuilders(
         })
         builders[index] = next
         updates.push(next)
-      } else if (current.status === 'building' && !activeSessionIds.has(current.sessionId)) {
+      } else if (stuck) {
         const next = updated(current, { status: 'waiting' })
         builders[index] = next
         updates.push(next)

--- a/server/view-builders.ts
+++ b/server/view-builders.ts
@@ -1,7 +1,7 @@
 import { mkdir, rename } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type { ViewBuilder, ViewBuilderKind, ViewInfo } from '@/lib/types'
+import type { AppletKind, ViewBuilder, ViewInfo } from '@/lib/types'
 
 import { DATA_DIR } from './data-dir'
 import { publishEvent } from './events'
@@ -172,7 +172,7 @@ type SetBuilderInput = {
   // into the agent's prompt). Omitted for a standalone/widget build, which is
   // then keyed and upserted by its applet id.
   builderId?: string
-  kind?: ViewBuilderKind
+  kind?: AppletKind
   // The states the agent reports first-hand. `ready` is never accepted here —
   // it stays server-derived from the compiled applet (bundle + reconcile).
   status?: 'building' | 'waiting'
@@ -195,15 +195,19 @@ export async function setBuilder(
   if (input.icon !== undefined && !/^[a-z0-9][a-z0-9-]*$/.test(input.icon)) {
     throw new ViewBuilderError('Invalid view icon id', 400)
   }
+  // Views and widgets are separate applet namespaces, so an id is only unique
+  // within a kind — a view and a widget may both be called "stats".
+  const kind: AppletKind = input.kind ?? 'view'
+  const sameApplet = (candidate: ViewBuilder) =>
+    candidate.viewId === appletId && (candidate.kind ?? 'view') === kind
   const builder = await mutateBuilders(workspacePath, builders => {
     const index = input.builderId
       ? builders.findIndex(candidate => candidate.id === input.builderId)
-      : builders.findIndex(candidate => candidate.viewId === appletId)
+      : builders.findIndex(sameApplet)
     if (input.builderId && index === -1) {
       throw new ViewBuilderError('View builder not found', 404)
     }
-    // The applet id is unique across builders in a workspace.
-    const clash = builders.find((candidate, i) => i !== index && candidate.viewId === appletId)
+    const clash = builders.find((candidate, i) => i !== index && sameApplet(candidate))
     if (clash) throw new ViewBuilderError(`View id "${appletId}" is already claimed`, 409)
 
     if (index === -1) {
@@ -212,7 +216,7 @@ export async function setBuilder(
       const status = input.status ?? 'building'
       const created: ViewBuilder = {
         id: crypto.randomUUID(),
-        kind: input.kind ?? 'view',
+        kind,
         status,
         input: { requirements: '' },
         sessionId: crypto.randomUUID(),

--- a/server/views.ts
+++ b/server/views.ts
@@ -149,7 +149,10 @@ export async function handleBundleViews(
   publish: (msg: unknown) => void,
   workspaceId: string,
   workspacePath: string,
-  force = false
+  force = false,
+  // When set, compile without advancing any view builder to `ready` (the
+  // `moi bundle --no-status` opt-out). The build still publishes `view:updated`.
+  skipStatus = false
 ) {
   const before = await readManifest(workspacePath)
   const beforeBuilt = new Set(await listBuiltViews(workspacePath))
@@ -173,13 +176,15 @@ export async function handleBundleViews(
   for (const r of results) {
     if (r.status === 'built') {
       publish({ type: 'view:updated', name: r.name, config: r.config ?? null })
-      await markViewBuilderReady(
-        workspaceId,
-        workspacePath,
-        r.name,
-        r.config?.title || r.name,
-        r.config?.icon
-      )
+      if (!skipStatus) {
+        await markViewBuilderReady(
+          workspaceId,
+          workspacePath,
+          r.name,
+          r.config?.title || r.name,
+          r.config?.icon
+        )
+      }
       for (const m of r.serverModules ?? []) changedServerModules.add(m)
     }
   }

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -269,14 +269,15 @@ id, a clear sentence-case title, and a relevant icon from the requirements. Capi
 first word of the title. Your first action must claim them:
 
 ```sh
-moi view-builder claim --builder <builder-id> --id <view-id> --title "<title>" --icon <icon-id>
+moi builder set <view-id> --builder <builder-id> --kind view --title "<title>" --icon <icon-id>
 ```
 
 Choose the icon id from the available view icons in the hidden context. The id must use lowercase
-letters, numbers, `_`, or `-`. The first claim locks the id; running the same claim again may update
-its title and icon. After the claim, write `.moi/views/<view-id>.tsx`, use the same icon id in its
+letters, numbers, `_`, or `-`. The first call locks the id; running the same command again may update
+its title and icon. After claiming, write `.moi/views/<view-id>.tsx`, use the same icon id in its
 config, and finish with `moi bundle --only views`. The tab uses the claimed title and icon while you
-work and changes into the built view after a successful bundle.
+work and changes into the built view after a successful bundle. (Bundling marks the view ready; the
+build state is otherwise server-managed, so you never set it to done by hand.)
 
 ```ts
 export const config = {


### PR DESCRIPTION
## Summary

Extends the view builder system to support standalone widget builders alongside view builders, adds detection and recovery for stale/hung builds, and refactors the builder claim API into a more flexible `setBuilder` operation.

## Key Changes

- **Widget builder support**: Introduces `ViewBuilderKind` type (`'view'` | `'widget'`) to distinguish between view and widget builders. Widget builders are keyed by applet id rather than a pending builder handle, and are excluded from the client's view-builder tab list (server-side record-only for now).

- **Stale build detection**: Adds `buildingSince` timestamp tracking to detect builds running longer than `STALE_BUILD_MS` (10 minutes). The reconciliation logic now demotes stale builds back to `waiting` status even if their session appears live, preventing hung/abandoned turns from blocking the user.

- **Unified builder API**: Replaces `claimViewBuilder` with `setBuilder`, which:
  - Accepts a flexible `SetBuilderInput` object supporting optional `builderId`, `kind`, `status`, `title`, and `icon`
  - Handles both pending view builders (claimed by handle) and standalone widget builders (created/upserted by applet id)
  - Stamps `buildingSince` when entering the `building` state
  - Prevents `ready` status from being overwritten by agent-reported status

- **Boot-time reconciliation**: Adds `reconcileBuildersOnBoot()` to correct any builders left in `building` state from a previous process crash, promoting them to `ready` if their view exists on disk or demoting them to `waiting` otherwise.

- **CLI updates**: Renames `moi view-builder claim` to `moi builder set` with a new positional `id` argument and optional `--kind`, `--status`, `--title`, `--icon`, and `--builder` flags. Adds `--no-status` flag to `moi bundle` to skip advancing builders to `ready`.

- **Test coverage**: Adds tests for widget builder creation/upsert, stale build detection with live sessions, and helper function `mutateBuildingSince` to simulate aged builds.

## Implementation Details

- Widget builders are filtered out of the `/view-builders` API response to keep them out of the host UI until their dedicated UI lands.
- The `buildingSince` field is optional on the `ViewBuilder` type to maintain backward compatibility with persisted records created before this change.
- `publishUpdated` skips publishing widget builders to the client event stream.
- View compilation can now skip advancing builders to `ready` via the `skipStatus` parameter, useful for dry-run or diagnostic builds.

https://claude.ai/code/session_01Et8HQQPTSoAFrYCPL7oHxb