### PR TITLE
Unify session activity state across harnesses

### DIFF
--- a/client/features/chat/chat-activity.test.ts
+++ b/client/features/chat/chat-activity.test.ts
@@ -1,0 +1,87 @@
+// How the client reduces session-activity frames into the live store: the
+// spinner state must survive lost frames (snapshot reconcile), clear on
+// terminal error/stopped frames, and treat `requires-action` as a tracked but
+// non-loader state.
+import { QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { __setQueryClientForTests, handleFrame } from '@/client/features/chat/chat-connection'
+import { liveStore } from '@/client/features/chat/chat-store'
+
+const WS = 'ws1'
+const SID = 'sess-1'
+
+function activityOf(sessionId = SID) {
+  return liveStore.getState().activity[`${WS}:${sessionId}`]
+}
+
+beforeEach(() => {
+  __setQueryClientForTests(new QueryClient())
+  liveStore.setState({
+    previews: {},
+    activity: {},
+    errors: {},
+    activeByWorkspace: {},
+    drafts: {}
+  })
+})
+
+describe('status frames', () => {
+  test('status frames mirror activity into the store', () => {
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'running' })
+    expect(activityOf()).toBe('running')
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'requires-action' })
+    expect(activityOf()).toBe('requires-action')
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'idle' })
+    expect(activityOf()).toBe('idle')
+  })
+
+  test('error frame is terminal: clears activity and records the error', () => {
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'running' })
+    handleFrame({ kind: 'error', workspaceId: WS, sessionId: SID, content: 'boom' })
+    expect(activityOf()).toBe('idle')
+    expect(liveStore.getState().errors[`${WS}:${SID}`]).toBe('boom')
+  })
+
+  test('stopped frame clears activity', () => {
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'running' })
+    handleFrame({ kind: 'stopped', workspaceId: WS, sessionId: SID })
+    expect(activityOf()).toBe('idle')
+  })
+})
+
+describe('status_snapshot reconcile', () => {
+  test('sessions absent from the snapshot are cleared (lost terminal frame heals)', () => {
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'running' })
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: 'other', activity: 'running' })
+    handleFrame({
+      type: 'status_snapshot',
+      sessions: [{ workspaceId: WS, sessionId: 'other', activity: 'running' }]
+    })
+    expect(activityOf()).toBeUndefined()
+    expect(activityOf('other')).toBe('running')
+  })
+
+  test('snapshot carries non-running activity through', () => {
+    handleFrame({
+      type: 'status_snapshot',
+      sessions: [{ workspaceId: WS, sessionId: SID, activity: 'requires-action' }]
+    })
+    expect(activityOf()).toBe('requires-action')
+  })
+
+  test('empty snapshot clears everything', () => {
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: SID, activity: 'running' })
+    handleFrame({ type: 'status_snapshot', sessions: [] })
+    expect(liveStore.getState().activity).toEqual({})
+  })
+})
+
+describe('session rename', () => {
+  test('activity migrates from the temp id to the real id', () => {
+    handleFrame({ type: 'status', workspaceId: WS, sessionId: 'temp-1', activity: 'running' })
+    handleFrame({ type: 'session_renamed', workspaceId: WS, from: 'temp-1', to: 'real-1' })
+    expect(activityOf('temp-1')).toBeUndefined()
+    expect(activityOf('real-1')).toBe('running')
+  })
+})

--- a/client/features/chat/chat-frames.ts
+++ b/client/features/chat/chat-frames.ts
@@ -8,6 +8,7 @@ import type {
   ClientMessage,
   PreviewFrame,
   ScratchOp,
+  SessionActivity,
   StreamEvent,
   ThreadConfig,
   ViewState
@@ -24,17 +25,19 @@ export function reduceChatFrame(data: Record<string, unknown>, context: ChatFram
   const store = liveStore.getState()
 
   if (data.type === 'status_snapshot') {
-    store.reconcileProcessing(
-      (data.running as { workspaceId: string; sessionId: string }[] | undefined) ?? []
+    store.reconcileActivity(
+      (data.sessions as
+        | { workspaceId: string; sessionId: string; activity: SessionActivity }[]
+        | undefined) ?? []
     )
     return
   }
   if (data.type === 'status') {
     const workspaceId = data.workspaceId as string
     const sessionId = data.sessionId as string
-    const processing = data.processing as boolean
-    store.setProcessing(workspaceId, sessionId, processing)
-    if (!processing) store.clearPreviewsForSession(workspaceId, sessionId)
+    const activity = data.activity as SessionActivity
+    store.setActivity(workspaceId, sessionId, activity)
+    if (activity !== 'running') store.clearPreviewsForSession(workspaceId, sessionId)
     return
   }
   if (data.type === 'preview') {
@@ -111,10 +114,14 @@ export function reduceChatFrame(data: Record<string, unknown>, context: ChatFram
   }
   if (kind === 'error' && typeof data.content === 'string') {
     store.setError(workspaceId, sessionId, data.content)
+    // Servers only emit `error` terminally, so it also ends the busy state —
+    // relying solely on a separate status frame left the spinner stuck when
+    // that frame was lost.
+    store.setActivity(workspaceId, sessionId, 'idle')
     store.clearPreviewsForSession(workspaceId, sessionId)
   }
   if (kind === 'stopped') {
-    store.setProcessing(workspaceId, sessionId, false)
+    store.setActivity(workspaceId, sessionId, 'idle')
     store.clearPreviewsForSession(workspaceId, sessionId)
   }
 }

--- a/client/features/chat/chat-send.test.ts
+++ b/client/features/chat/chat-send.test.ts
@@ -11,7 +11,7 @@ const workspaceId = 'workspace-1'
 const sessionId = 'session-1'
 
 afterEach(() => {
-  liveStore.setState({ processing: {}, errors: {} })
+  liveStore.setState({ activity: {}, errors: {} })
 })
 
 describe('startOptimisticTurn', () => {
@@ -27,7 +27,7 @@ describe('startOptimisticTurn', () => {
     const view = queryClient.getQueryData<ViewState>(workspaceKeys.events(workspaceId, sessionId))
     expect(optimisticId).toStartWith('optimistic:')
     expect(view?.turns[0]?.parts).toEqual([{ type: 'text', text: 'Build a dashboard' }])
-    expect(liveStore.getState().processing[`${workspaceId}:${sessionId}`]).toBe(true)
+    expect(liveStore.getState().activity[`${workspaceId}:${sessionId}`]).toBe('running')
   })
 })
 

--- a/client/features/chat/chat-send.ts
+++ b/client/features/chat/chat-send.ts
@@ -32,7 +32,7 @@ export function startOptimisticTurn({
       }
     })
   )
-  liveStore.getState().setProcessing(workspaceId, sessionId, true)
+  liveStore.getState().setActivity(workspaceId, sessionId, 'running')
   liveStore.getState().setError(workspaceId, sessionId, null)
   return optimisticId
 }

--- a/client/features/chat/chat-store.ts
+++ b/client/features/chat/chat-store.ts
@@ -1,7 +1,7 @@
 import { useStore } from 'zustand'
 import { createStore } from 'zustand/vanilla'
 
-import type { PreviewBlock, PreviewFrame, UploadInfo } from '@/lib/types'
+import type { PreviewBlock, PreviewFrame, SessionActivity, UploadInfo } from '@/lib/types'
 
 // One composer attachment, tracked per thread until the message is sent. It is
 // uploaded as soon as it's added (drop/paste/pick); `status` reflects that
@@ -20,7 +20,7 @@ export type ChatAttachment = {
 // App-level ephemeral chat state — the bits that are *pushed* from the server
 // over the WebSocket and can't be re-fetched as request/response data:
 //   - which thread is active per workspace (a UI selection),
-//   - per-session `processing` (spinner) flags,
+//   - per-session `activity` (spinner) state,
 //   - per-session error banners.
 //
 // The durable message transcripts live in the React Query cache (see
@@ -56,7 +56,10 @@ export type LivePreview = {
 
 export type LiveStore = {
   activeByWorkspace: Record<string, string | null>
-  processing: Record<string, boolean>
+  // Per-session activity mirrored from server `status` frames. Only `running`
+  // shows the loader/Stop; `requires-action` is tracked but not rendered yet.
+  // Missing key = idle.
+  activity: Record<string, SessionActivity>
   errors: Record<string, string | null>
   // Live token-streaming previews, keyed by `messageId` (the API `msg_...` id)
   // so concurrent streams never collide. Reconciled against the durable
@@ -73,11 +76,13 @@ export type LiveStore = {
   attachments: Record<string, ChatAttachment[]>
 
   setActive: (workspaceId: string, sessionId: string | null) => void
-  setProcessing: (workspaceId: string, sessionId: string, value: boolean) => void
+  setActivity: (workspaceId: string, sessionId: string, value: SessionActivity) => void
   // Authoritative reconcile from a server `status_snapshot`: exactly the listed
-  // sessions are processing; everything else is cleared (fixes a spinner whose
-  // terminal status was emitted while we were disconnected).
-  reconcileProcessing: (running: { workspaceId: string; sessionId: string }[]) => void
+  // sessions are active; everything else is cleared to idle (fixes a spinner
+  // whose terminal status frame was lost while we were disconnected).
+  reconcileActivity: (
+    sessions: { workspaceId: string; sessionId: string; activity: SessionActivity }[]
+  ) => void
   setError: (workspaceId: string, sessionId: string, message: string | null) => void
   setDraft: (workspaceId: string, sessionId: string | null, value: string) => void
   addAttachments: (workspaceId: string, sessionId: string | null, items: ChatAttachment[]) => void
@@ -107,7 +112,7 @@ export type LiveStore = {
 
 export const liveStore = createStore<LiveStore>()(set => ({
   activeByWorkspace: {},
-  processing: {},
+  activity: {},
   errors: {},
   drafts: {},
   previews: {},
@@ -116,12 +121,12 @@ export const liveStore = createStore<LiveStore>()(set => ({
   setActive: (workspaceId, sessionId) =>
     set(s => ({ activeByWorkspace: { ...s.activeByWorkspace, [workspaceId]: sessionId } })),
 
-  setProcessing: (workspaceId, sessionId, value) =>
-    set(s => ({ processing: { ...s.processing, [key(workspaceId, sessionId)]: value } })),
+  setActivity: (workspaceId, sessionId, value) =>
+    set(s => ({ activity: { ...s.activity, [key(workspaceId, sessionId)]: value } })),
 
-  reconcileProcessing: running =>
+  reconcileActivity: sessions =>
     set(() => ({
-      processing: Object.fromEntries(running.map(r => [key(r.workspaceId, r.sessionId), true]))
+      activity: Object.fromEntries(sessions.map(r => [key(r.workspaceId, r.sessionId), r.activity]))
     })),
 
   setError: (workspaceId, sessionId, message) =>
@@ -219,11 +224,11 @@ export const liveStore = createStore<LiveStore>()(set => ({
     set(s => {
       const fromKey = key(workspaceId, from)
       const toKey = key(workspaceId, to)
-      const processing = { ...s.processing }
+      const activity = { ...s.activity }
       const errors = { ...s.errors }
-      if (fromKey in processing) {
-        processing[toKey] = processing[fromKey]
-        delete processing[fromKey]
+      if (fromKey in activity) {
+        activity[toKey] = activity[fromKey]
+        delete activity[fromKey]
       }
       if (fromKey in errors) {
         errors[toKey] = errors[fromKey]
@@ -246,7 +251,7 @@ export const liveStore = createStore<LiveStore>()(set => ({
           previews[id] = { ...p, sessionId: to }
         }
       }
-      return { processing, errors, activeByWorkspace, previews }
+      return { activity, errors, activeByWorkspace, previews }
     })
 }))
 

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -25,9 +25,12 @@ export function useChat() {
   const modelsData = useWorkspaceModels(workspaceId).data
 
   const activeSessionId = useLive(s => s.activeByWorkspace[workspaceId] ?? null)
-  const processing = useLive(s =>
-    activeSessionId ? (s.processing[`${workspaceId}:${activeSessionId}`] ?? false) : false
+  const activity = useLive(s =>
+    activeSessionId ? (s.activity[`${workspaceId}:${activeSessionId}`] ?? 'idle') : 'idle'
   )
+  // Only `running` shows the loader/Stop. `requires-action` (agent blocked on
+  // user input) deliberately renders like idle until it gets its own UI.
+  const processing = activity === 'running'
   const error = useLive(s =>
     activeSessionId ? (s.errors[`${workspaceId}:${activeSessionId}`] ?? null) : null
   )

--- a/client/features/views/useViewBuilderActions.ts
+++ b/client/features/views/useViewBuilderActions.ts
@@ -54,7 +54,7 @@ export function useViewBuilderActions() {
         stream
       })
     } catch (error) {
-      liveStore.getState().setProcessing(workspaceId, builder.sessionId, false)
+      liveStore.getState().setActivity(workspaceId, builder.sessionId, 'idle')
       liveStore
         .getState()
         .setError(

--- a/client/lib/connection.stream.test.ts
+++ b/client/lib/connection.stream.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
   __setQueryClientForTests(qc)
   liveStore.setState({
     previews: {},
-    processing: {},
+    activity: {},
     errors: {},
     activeByWorkspace: {},
     drafts: {}
@@ -59,7 +59,7 @@ function assistantTurn(id: string, apiMessageId: string, text: string): Turn {
   }
 }
 function statusFrame(processing: boolean, sessionId = SID) {
-  return { type: 'status', workspaceId: WS, sessionId, processing }
+  return { type: 'status', workspaceId: WS, sessionId, activity: processing ? 'running' : 'idle' }
 }
 
 // Prime a thread's transcript so patchView/preview-guard treat it as loaded.
@@ -211,6 +211,6 @@ describe('streaming frame reduction', () => {
     expect(turns[1].role).toBe('assistant')
     expect(turns[1].parts).toEqual([{ type: 'text', text: 'Hello' }])
     // No preview-shaped junk leaked into the transcript.
-    expect(liveStore.getState().processing[`${WS}:${SID}`]).toBe(false)
+    expect(liveStore.getState().activity[`${WS}:${SID}`]).toBe('idle')
   })
 })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -330,13 +330,14 @@ export type BroadcastFrame =
   | Omit<ErrorFrame, 'workspaceId'>
   | Omit<StoppedFrame, 'workspaceId'>
 
-// Sent to a client right after it connects: the authoritative set of currently
-// running sessions across all workspaces. The client treats it as ground truth —
-// any session NOT listed is marked not-processing — which clears a spinner whose
-// terminal `status:false` was emitted while the client was disconnected.
+// Sent to a client right after it connects (and re-broadcast periodically): the
+// authoritative set of non-idle sessions across all workspaces. The client
+// treats it as ground truth — any session NOT listed is marked idle — which
+// clears a spinner whose terminal `status` frame was lost (disconnect window,
+// dropped frame, harness gap).
 export type StatusSnapshotMessage = {
   type: 'status_snapshot'
-  running: { workspaceId: string; sessionId: string }[]
+  sessions: { workspaceId: string; sessionId: string; activity: SessionActivity }[]
 }
 
 export type WorkspaceSwitchMessage = {
@@ -407,11 +408,20 @@ export type StoppedFrame = {
   sessionId: string
 }
 
+// Unified per-session activity state, mirrored from each harness's native
+// lifecycle signal (CC `session_state_changed`, Codex `turn/*`, OpenClaw run
+// lifecycle) rather than derived by counting messages:
+//   running         — the agent is working; the client shows the loader/Stop
+//   requires-action — the agent is blocked on user input (permission prompt,
+//                     MCP elicitation). Not rendered yet: no loader, no Stop.
+//   idle            — everything else, including interrupted/failed turns
+export type SessionActivity = 'idle' | 'running' | 'requires-action'
+
 export type StatusMessage = {
   type: 'status'
   workspaceId: string
   sessionId: string
-  processing: boolean
+  activity: SessionActivity
 }
 
 // Workspace layout persistence

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moi-computer",
-  "version": "0.3.0",
+  "version": "0.3.1-next.0",
   "description": "Local AI workspace powered by the Claude Agent SDK, Bun, React, and Tailwind. Requires Bun.",
   "license": "Elastic-2.0",
   "type": "module",

--- a/server/api.ts
+++ b/server/api.ts
@@ -166,7 +166,7 @@ one.get('/view-builders', async c => {
   const ws = c.get('ws')
   const activeSessionIds = new Set(
     allHarnesses()
-      .flatMap(h => h.runningSessions())
+      .flatMap(h => h.activeSessions())
       .filter(session => session.workspaceId === ws.id)
       .map(session => session.sessionId)
   )

--- a/server/harness/README.md
+++ b/server/harness/README.md
@@ -39,8 +39,13 @@ Socket-protocol notes the layers rely on (all defined in `lib/types.ts`):
   echoes it natively (`clientUserMessageId` → `clientId`), Claude Code never
   echoes (the server synthesizes the turn), OpenClaw echoes lagged (matched
   by text).
-- **`status` / `status_snapshot`** — busy/idle per session; the snapshot on
-  connect is authoritative (clears spinners for missed transitions).
+- **`status` / `status_snapshot`** — per-session `activity`
+  (`idle | running | requires-action`), mirrored from the backend's native
+  lifecycle signal — never derived by counting sends vs results. The snapshot
+  (sent on connect and re-broadcast periodically) is authoritative: the client
+  rebuilds its whole activity map from it, so a lost terminal frame self-heals.
+  `requires-action` (agent blocked on user input) is tracked but not rendered
+  yet — the client shows no loader for it.
 - **`preview`** — live token frames, cumulative text, never persisted;
   cleared when the turn with matching `meta.apiMessageId` lands.
 
@@ -137,8 +142,12 @@ doubles as the evaluation rubric for new harnesses.
 - **Interrupt / cancel** — stop the current turn without killing the session,
   and drop queued messages.
 - **Teardown** — graceful close on idle TTL, LRU eviction, server shutdown.
-- **Turn accounting** — know when a turn ends (CC: `result` message; Codex:
-  `turn/completed`) to drive busy/idle state and the processing spinner.
+- **Activity mirror** — map the backend's native lifecycle signal onto
+  `SessionActivity` (CC: `result` as the turn-over fallback plus
+  `session_state_changed` when the CLI emits it; Codex: `turn/started` /
+  `turn/completed`; OpenClaw: `agent` lifecycle phases). Flip to `running`
+  optimistically on send; a session with live background tasks (CC
+  `task_started`/`task_notification`) must not be idle-evicted.
 
 ### Per-request configuration
 

--- a/server/harness/claude-code/NOTES.md
+++ b/server/harness/claude-code/NOTES.md
@@ -247,16 +247,17 @@ Message
 
 ## 9. What's missing today vs. what the SDK emits
 
-Known blind spots the abstraction should close:
+Known blind spots the abstraction should close (historical audit — items marked
+CLOSED have since been handled; see adapter.ts / session.ts):
 
 - **Thinking blocks** — SDK emits them; `transformMessage` drops them. Would require a new repo-level block type.
 - **Server tool use** (`web_search`, `web_fetch`, `code_execution`, etc.) — completely invisible. An assistant using `WebSearch` currently looks like a silent gap between user turn and final answer.
 - **MCP tool calls proper** (`mcp_tool_use` / `mcp_tool_result` blocks) — dropped. Regular `Task`/`Bash` MCP tools happen to survive because they wear the plain `tool_use` shape.
-- **Streaming** — `stream_event` dropped, so assistant text lands in one block per turn, not token-by-token.
-- **Session lifecycle signals** — `system/init`, `system/session_state_changed`, `system/status` dropped. UI can't display model name, current tools, permission mode, "thinking…", "awaiting permission".
-- **Sub-agent nesting** — subagent turns survive structurally but lose `parent_tool_use_id`, so they render flat. All `task_*` events dropped.
-- **Hooks / tasks / rate limits / api_retry** — all invisible.
-- **MessageBlock switch exhaustiveness** — any future repo-level type crashes render.
+- **Streaming** — CLOSED: `stream_event` drives live token previews (`preview` frames) when the client opts into streaming.
+- **Session lifecycle signals** — partially CLOSED: `system/init` feeds the session snapshot; `system/session_state_changed` mirrors into `SessionActivity` (note: current CLIs don't emit it in streaming-input mode — `result` is the everyday turn-over fallback); `requires-action` reaches the wire but has no UI yet. `system/status` (`requesting`/`compacting`) still dropped.
+- **Sub-agent nesting** — CLOSED: `task_started`/`task_progress`/`task_notification` build nested subagent records; `task_started`/`task_updated`/`task_notification` also track live background tasks for the idle-eviction keep-alive (session.ts `bgTasks`).
+- **Hooks / rate limits / api_retry** — CLOSED: surfaced as notices.
+- **MessageBlock switch exhaustiveness** — the UI layer this referred to (`MessageBlock.tsx`) no longer exists; turns render via `TurnView`/`ToolCallGroup`.
 
 ---
 

--- a/server/harness/claude-code/index.ts
+++ b/server/harness/claude-code/index.ts
@@ -10,7 +10,7 @@ import { getClaudeModels } from './models'
 import {
   SESSION_LIMITS,
   getCCDebugSnapshot,
-  getCCRunningSessions,
+  getCCActiveSessions,
   interruptCCSession,
   killAllCCSessions,
   restartWorkspaceSessions,
@@ -69,7 +69,7 @@ export const claudeCodeHarness: Harness = {
 
   sendMessage: input => sendCCMessage(input),
   interrupt: (workspaceId, sessionId) => interruptCCSession(workspaceId, sessionId),
-  runningSessions: () => getCCRunningSessions(),
+  activeSessions: () => getCCActiveSessions(),
 
   listSessions: ws => getSessions(ws.path),
   workspacePreview: (ws, includeFirstUserMessage) =>
@@ -87,7 +87,7 @@ export const claudeCodeHarness: Harness = {
 
   statusLines: now => {
     const cc = getCCDebugSnapshot()
-    const busy = cc.sessions.filter(s => s.busy).length
+    const busy = cc.sessions.filter(s => s.activity !== 'idle').length
     const lines = [
       `live CC sessions  ${cc.sessions.length}/${SESSION_LIMITS.maxLive}  ` +
         `(${busy} busy, ${cc.sessions.length - busy} idle, ${cc.aliases} alias${cc.aliases === 1 ? '' : 'es'}, ` +
@@ -99,10 +99,19 @@ export const claudeCodeHarness: Harness = {
     }
     // Busiest / most-recently-active first.
     const sorted = [...cc.sessions].sort(
-      (a, b) => Number(b.busy) - Number(a.busy) || b.lastActivityAt - a.lastActivityAt
+      (a, b) =>
+        Number(b.activity !== 'idle') - Number(a.activity !== 'idle') ||
+        b.lastActivityAt - a.lastActivityAt
     )
     for (const s of sorted) {
-      const mark = s.busy ? '▶ busy' : s.closed ? '✗ closed' : '○ idle'
+      const mark =
+        s.activity === 'running'
+          ? '▶ busy'
+          : s.activity === 'requires-action'
+            ? '⏸ input'
+            : s.closed
+              ? '✗ closed'
+              : '○ idle'
       const bits = [
         mark.padEnd(8),
         `ws=${s.workspaceId}`,
@@ -110,13 +119,13 @@ export const claudeCodeHarness: Harness = {
         `model=${s.model ?? 'default'}`,
         `effort=${s.effort ?? 'default'}`,
         `stream=${s.stream ? 'on' : 'off'}`,
-        `pending=${s.pendingTurns}`,
         `age=${fmtDuration(now - s.createdAt)}`,
         `lastActivity=${fmtAgo(s.lastActivityAt, now)}`
       ]
+      if (s.bgTasks > 0) bits.push(`bgTasks=${s.bgTasks}`)
       if (s.desiredEffort !== s.effort) bits.push(`desiredEffort=${s.desiredEffort ?? 'default'}`)
       if (s.desiredStream !== s.stream) bits.push(`desiredStream=${s.desiredStream ? 'on' : 'off'}`)
-      if (!s.busy && !s.hasIdleTimer) bits.push('(no idle timer)')
+      if (s.activity === 'idle' && !s.hasIdleTimer) bits.push('(no idle timer)')
       let line = '  ' + bits.join('  ')
       if (s.lastUserText) line += `\n      last: ${JSON.stringify(s.lastUserText)}`
       lines.push(line)

--- a/server/harness/claude-code/session.ts
+++ b/server/harness/claude-code/session.ts
@@ -21,6 +21,7 @@ import {
 import { ATTACHMENT_ONLY_PLACEHOLDER, appendAttachmentNote } from '@/lib/attachment-note'
 import { ClaudeAdapter } from './adapter'
 import type { Part } from '@/lib/format'
+import type { SessionActivity } from '@/lib/types'
 import { stripViewBuilderMeta } from '@/lib/view-builder-meta'
 
 import { debug } from '../../debug'
@@ -92,6 +93,11 @@ export function buildUserMessage(
 const MAX_LIVE_SESSIONS = 8
 const IDLE_TTL_MS = 5 * 60_000
 
+// SDK task types that keep running after the turn ends (background Bash,
+// workflow runs). Subagent Tasks complete within their turn, so they are
+// deliberately excluded — a leaked entry would keep the session alive forever.
+const BG_TASK_TYPES = new Set(['local_bash', 'local_workflow'])
+
 const ALLOWED_TOOLS = [
   'Bash',
   'Read',
@@ -119,9 +125,19 @@ type LiveSession = {
   adapter: ClaudeAdapter
   input: InputQueue
   abort: AbortController
-  // User messages enqueued but not yet completed. A turn ends on a `result`
-  // message; processing = pendingTurns > 0.
-  pendingTurns: number
+  // Session activity, mirrored from the SDK's `session_state_changed` events
+  // (authoritative — it fires `idle` only after the CLI's input queue drains,
+  // so queued messages merged into one model turn can't wedge it, unlike the
+  // old send/result counter). `sendCCMessage` flips it to 'running'
+  // optimistically so the loader doesn't wait a subprocess round-trip.
+  activity: SessionActivity
+  // Whether this query has emitted `session_state_changed` at all. When it
+  // never does (older CLI), the `result` handler falls back to declaring idle.
+  sawStateEvents: boolean
+  // Live background tasks (background Bash, workflows) keyed by task id, fed by
+  // the SDK's typed task events. Non-empty keeps the session alive past the
+  // idle TTL — tearing down the subprocess would kill its background children.
+  bgTasks: Set<string>
   model: string | undefined
   // Reasoning effort the query was created with. The SDK has no live setter for
   // it (unlike setModel), so a change tears the session down and resumes.
@@ -139,6 +155,9 @@ type LiveSession = {
   desiredStream: boolean
   idleTimer: ReturnType<typeof setTimeout> | null
   closed: boolean
+  // Last turn's error text (result subtype), consumed by the view-builder
+  // status update on the idle transition.
+  lastBuilderError: string | undefined
   // Introspection only (surfaced by /status) — not load-bearing.
   createdAt: number
   lastActivityAt: number
@@ -166,11 +185,17 @@ function liveKey(workspaceId: string, sessionId: string): string {
   return real ? recKey(workspaceId, real) : direct
 }
 
-// Running sessions across all workspaces, for the connect-time status snapshot.
-export function getCCRunningSessions(): { workspaceId: string; sessionId: string }[] {
-  const out: { workspaceId: string; sessionId: string }[] = []
+// Non-idle sessions across all workspaces, for the status snapshot.
+export function getCCActiveSessions(): {
+  workspaceId: string
+  sessionId: string
+  activity: SessionActivity
+}[] {
+  const out: { workspaceId: string; sessionId: string; activity: SessionActivity }[] = []
   for (const s of sessions.values()) {
-    if (s.pendingTurns > 0) out.push({ workspaceId: s.workspaceId, sessionId: s.sessionId })
+    if (s.activity !== 'idle') {
+      out.push({ workspaceId: s.workspaceId, sessionId: s.sessionId, activity: s.activity })
+    }
   }
   return out
 }
@@ -186,8 +211,8 @@ export type CCDebugSession = {
   desiredEffort: string | undefined
   stream: boolean
   desiredStream: boolean
-  pendingTurns: number
-  busy: boolean
+  activity: SessionActivity
+  bgTasks: number
   closed: boolean
   hasIdleTimer: boolean
   createdAt: number
@@ -207,8 +232,8 @@ export function getCCDebugSnapshot(): { sessions: CCDebugSession[]; aliases: num
       desiredEffort: s.desiredEffort,
       stream: s.stream,
       desiredStream: s.desiredStream,
-      pendingTurns: s.pendingTurns,
-      busy: s.pendingTurns > 0,
+      activity: s.activity,
+      bgTasks: s.bgTasks.size,
       closed: s.closed,
       hasIdleTimer: s.idleTimer !== null,
       createdAt: s.createdAt,
@@ -262,8 +287,12 @@ function createInputQueue(): InputQueue {
   }
 }
 
-function broadcastProcessing(s: LiveSession, processing: boolean) {
-  broadcast(s.workspaceId, { type: 'status', sessionId: s.sessionId, processing })
+// Set the session's activity and broadcast the transition (deduped — repeated
+// same-value events from the SDK don't re-broadcast).
+function setActivity(s: LiveSession, activity: SessionActivity) {
+  if (s.activity === activity) return
+  s.activity = activity
+  broadcast(s.workspaceId, { type: 'status', sessionId: s.sessionId, activity })
 }
 
 function clearIdle(s: LiveSession) {
@@ -276,13 +305,26 @@ function clearIdle(s: LiveSession) {
 function armIdle(s: LiveSession) {
   clearIdle(s)
   s.idleTimer = setTimeout(() => {
-    if (s.pendingTurns === 0) teardown(s)
+    if (s.activity === 'running') return
+    if (s.bgTasks.size > 0) {
+      // Tearing down would kill the subprocess and its background children
+      // (renders, watch loops). Keep the session alive until they finish.
+      debug(
+        `cc idle-keepalive ws=${s.workspaceId} session=${s.sessionId} bgTasks=${s.bgTasks.size}`
+      )
+      armIdle(s)
+      return
+    }
+    teardown(s)
   }, IDLE_TTL_MS)
 }
 
 function teardown(s: LiveSession) {
   if (s.closed) return
-  debug(`cc teardown ws=${s.workspaceId} session=${s.sessionId} pendingTurns=${s.pendingTurns}`)
+  debug(`cc teardown ws=${s.workspaceId} session=${s.sessionId} activity=${s.activity}`)
+  // Terminal status first, while the session is still registered — the consume
+  // finally can't be relied on (a hung SDK iterator never reaches it).
+  setActivity(s, 'idle')
   s.closed = true
   clearIdle(s)
   s.input.close()
@@ -308,6 +350,20 @@ function renameSession(s: LiveSession, realId: string) {
   sessions.set(recKey(s.workspaceId, realId), s)
   aliases.set(recKey(s.workspaceId, from), realId)
   broadcast(s.workspaceId, { type: 'session_renamed', from, to: realId })
+}
+
+// The session just went idle (state event, or `result` on a CLI without state
+// events): settle the view builder, then either rebuild for a deferred
+// effort/streaming change or arm the idle timer.
+async function onSessionIdle(s: LiveSession) {
+  await markViewBuilderWaitingBySession(
+    s.workspaceId,
+    s.workspacePath,
+    s.sessionId,
+    s.lastBuilderError
+  )
+  if (s.desiredEffort !== s.effort || s.desiredStream !== s.stream) teardown(s)
+  else armIdle(s)
 }
 
 async function consume(s: LiveSession) {
@@ -353,27 +409,68 @@ async function consume(s: LiveSession) {
       if (msg.type === 'system' && msg.subtype === 'init') {
         debug(`cc init ws=${s.workspaceId} session=${s.sessionId}`)
       }
+      // A turn is producing output while we think the session is idle: a
+      // queued message the CLI ran as its own turn after the previous result,
+      // or an SDK-initiated turn (e.g. a background-task notification waking
+      // the model). Re-assert running so the spinner tracks real activity.
+      if ((msg.type === 'assistant' || msg.type === 'stream_event') && s.activity === 'idle') {
+        setActivity(s, 'running')
+      }
+      // Authoritative activity mirror. The CLI emits `idle` only once its own
+      // input queue drains, so queued messages the model merged into one turn
+      // (one `result` for N sends) still end in a clean idle here. Observed
+      // empirically: current CLIs don't emit this in streaming-input mode, so
+      // the `result` fallback below is the everyday path.
+      if (msg.type === 'system' && msg.subtype === 'session_state_changed') {
+        s.sawStateEvents = true
+        s.lastActivityAt = Date.now()
+        debug(`cc state ws=${s.workspaceId} session=${s.sessionId} state=${msg.state}`)
+        if (msg.state === 'running') setActivity(s, 'running')
+        else if (msg.state === 'requires_action') setActivity(s, 'requires-action')
+        else if (msg.state === 'idle') {
+          setActivity(s, 'idle')
+          await onSessionIdle(s)
+        }
+      }
+      // Background-task lifecycle (typed SDK events): track live background
+      // work so idle eviction doesn't kill it (armIdle keep-alive). Only task
+      // types that outlive the turn count; subagent Tasks end within it.
+      if (msg.type === 'system' && msg.subtype === 'task_started') {
+        if (BG_TASK_TYPES.has(msg.task_type ?? '')) {
+          s.bgTasks.add(msg.task_id)
+          debug(
+            `cc bg-task start ws=${s.workspaceId} session=${s.sessionId} task=${msg.task_id} type=${msg.task_type} live=${s.bgTasks.size}`
+          )
+        }
+      }
+      if (msg.type === 'system' && msg.subtype === 'task_notification') {
+        if (s.bgTasks.delete(msg.task_id)) {
+          debug(
+            `cc bg-task end ws=${s.workspaceId} session=${s.sessionId} task=${msg.task_id} status=${msg.status} live=${s.bgTasks.size}`
+          )
+        }
+      }
+      if (msg.type === 'system' && msg.subtype === 'task_updated') {
+        const status = msg.patch?.status
+        if (status === 'completed' || status === 'failed' || status === 'killed') {
+          s.bgTasks.delete(msg.task_id)
+        }
+      }
       if (msg.type === 'result') {
         s.lastActivityAt = Date.now()
-        s.pendingTurns = Math.max(0, s.pendingTurns - 1)
-        debug(`cc result ws=${s.workspaceId} session=${s.sessionId} pendingTurns=${s.pendingTurns}`)
-        if (s.pendingTurns === 0) {
-          broadcastProcessing(s, false)
-          const builderError =
-            msg.subtype === 'success'
-              ? undefined
-              : msg.errors.join('\n') || msg.subtype.replaceAll('_', ' ')
-          await markViewBuilderWaitingBySession(
-            s.workspaceId,
-            s.workspacePath,
-            s.sessionId,
-            builderError
-          )
-          // A mid-turn effort/streaming change couldn't be applied live; now
-          // that the queue has drained, tear down so the next message resumes
-          // with it.
-          if (s.desiredEffort !== s.effort || s.desiredStream !== s.stream) teardown(s)
-          else armIdle(s)
+        // Remembered for the idle transition — the view builder shows the last
+        // turn's error once the queue drains.
+        s.lastBuilderError =
+          msg.subtype === 'success'
+            ? undefined
+            : msg.errors.join('\n') || msg.subtype.replaceAll('_', ' ')
+        debug(`cc result ws=${s.workspaceId} session=${s.sessionId} subtype=${msg.subtype}`)
+        // Fallback for CLIs that never emit `session_state_changed`: treat
+        // every result as turn-over. With state events, `idle` follows the
+        // result and drives the same path.
+        if (!s.sawStateEvents) {
+          setActivity(s, 'idle')
+          await onSessionIdle(s)
         }
       }
     }
@@ -391,20 +488,18 @@ async function consume(s: LiveSession) {
       await markViewBuilderWaitingBySession(s.workspaceId, s.workspacePath, s.sessionId, message)
     }
   } finally {
-    if (s.pendingTurns > 0) {
-      s.pendingTurns = 0
-      broadcastProcessing(s, false)
-    }
+    // teardown broadcasts the terminal idle status itself (deduped).
     teardown(s)
   }
 }
 
-// Close one idle session to stay under the cap. A busy session is never evicted;
-// if everything is busy we allow a temporary overflow rather than killing a run.
+// Close one idle session to stay under the cap. A running session — or one
+// with live background tasks — is never evicted; if everything is busy we allow
+// a temporary overflow rather than killing a run.
 function evictIfNeeded() {
   if (sessions.size < MAX_LIVE_SESSIONS) return
   for (const s of sessions.values()) {
-    if (s.pendingTurns === 0) {
+    if (s.activity === 'idle' && s.bgTasks.size === 0) {
       teardown(s)
       return
     }
@@ -467,7 +562,9 @@ function createLiveSession(input: {
     adapter: new ClaudeAdapter(),
     input: queue,
     abort,
-    pendingTurns: 0,
+    activity: 'idle',
+    sawStateEvents: false,
+    bgTasks: new Set(),
     model: input.model,
     effort: input.effort,
     desiredEffort: input.effort,
@@ -475,6 +572,7 @@ function createLiveSession(input: {
     desiredStream: input.stream,
     idleTimer: null,
     closed: false,
+    lastBuilderError: undefined,
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
     lastUserText: undefined
@@ -518,7 +616,7 @@ export async function sendCCMessage(input: {
   // construct-time, no SDK setter), so when either differs we tear the idle
   // session down and recreate it via resume — the change lands on this very
   // turn. A busy session keeps its settings until the in-flight turn ends.
-  if (s && (input.effort !== s.effort || wantStream !== s.stream) && s.pendingTurns === 0) {
+  if (s && (input.effort !== s.effort || wantStream !== s.stream) && s.activity === 'idle') {
     teardown(s)
     s = undefined
   }
@@ -590,36 +688,56 @@ export async function sendCCMessage(input: {
   const label = displayContent || uploads.map(u => u.filename).join(', ')
   s.lastUserText = label.replace(/\s+/g, ' ').slice(0, 120)
 
-  const wasIdle = s.pendingTurns === 0
-  s.pendingTurns++
-  if (wasIdle) {
+  // Optimistic flip — the authoritative `session_state_changed: running` from
+  // the subprocess confirms it moments later (setActivity dedupes).
+  if (s.activity !== 'running') {
     await markViewBuilderBuildingBySession(s.workspaceId, s.workspacePath, s.sessionId)
-    broadcastProcessing(s, true)
+    setActivity(s, 'running')
   }
+  clearIdle(s)
   s.input.push(content)
   tapWire(s.workspaceId, 'send', { type: 'user', content })
   debug(
-    `cc enqueue ws=${s.workspaceId} session=${s.sessionId} pendingTurns=${s.pendingTurns} text=${JSON.stringify(s.lastUserText)}`
+    `cc enqueue ws=${s.workspaceId} session=${s.sessionId} activity=${s.activity} text=${JSON.stringify(s.lastUserText)}`
   )
 }
 
-// Interrupt the current turn and drop any queued messages, but keep the session
-// alive for the next message.
+// How long Stop waits for the SDK's interrupt round-trip before declaring the
+// subprocess wedged and tearing it down. A hung subprocess never answers, and
+// without this cap the whole interrupt path (and the user's only escape hatch
+// from a stuck spinner) hangs with it.
+const INTERRUPT_TIMEOUT_MS = 5_000
+
+// Interrupt the current turn and drop any queued messages, keeping the session
+// alive for the next message. If the subprocess doesn't acknowledge in time it
+// is torn down instead — the next message respawns via resume.
 export async function interruptCCSession(workspaceId: string, sessionId: string): Promise<void> {
   const s = sessions.get(liveKey(workspaceId, sessionId))
   if (!s) return
-  debug(`cc interrupt ws=${workspaceId} session=${sessionId} pendingTurns=${s.pendingTurns}`)
+  debug(`cc interrupt ws=${workspaceId} session=${sessionId} activity=${s.activity}`)
   s.input.clear()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timedOut = Symbol('interrupt-timeout')
   try {
-    await s.q.interrupt()
+    const outcome = await Promise.race([
+      s.q.interrupt(),
+      new Promise(resolve => {
+        timer = setTimeout(() => resolve(timedOut), INTERRUPT_TIMEOUT_MS)
+      })
+    ])
+    if (outcome === timedOut) {
+      debug(`cc interrupt timeout ws=${workspaceId} session=${sessionId} — tearing down`)
+      teardown(s)
+    }
   } catch (err) {
     console.error('[cc-session] interrupt failed', err)
+  } finally {
+    clearTimeout(timer)
   }
-  s.pendingTurns = 0
   broadcast(s.workspaceId, { kind: 'stopped', sessionId: s.sessionId })
-  broadcastProcessing(s, false)
+  setActivity(s, 'idle')
   await markViewBuilderWaitingBySession(s.workspaceId, s.workspacePath, s.sessionId)
-  armIdle(s)
+  if (!s.closed) armIdle(s)
 }
 
 // Tear down a workspace's IDLE sessions so the next message respawns the agent
@@ -628,7 +746,7 @@ export async function interruptCCSession(workspaceId: string, sessionId: string)
 // turn ends (then idle-evict or get recreated on the next message via resume).
 export function restartWorkspaceSessions(workspacePath: string): void {
   for (const s of [...sessions.values()]) {
-    if (s.workspacePath === workspacePath && s.pendingTurns === 0) teardown(s)
+    if (s.workspacePath === workspacePath && s.activity === 'idle') teardown(s)
   }
 }
 

--- a/server/harness/codex/index.ts
+++ b/server/harness/codex/index.ts
@@ -13,7 +13,7 @@ import {
 } from './client'
 import {
   ensureCodexSessionLive,
-  getCodexRunningSessions,
+  getCodexActiveSessions,
   getLiveCodexEvents,
   interruptCodexRun,
   sendCodexMessage
@@ -31,7 +31,7 @@ export const codexHarness: Harness = {
 
   sendMessage: input => sendCodexMessage(input),
   interrupt: (workspaceId, sessionId) => interruptCodexRun({ workspaceId, sessionId }),
-  runningSessions: () => getCodexRunningSessions(),
+  activeSessions: () => getCodexActiveSessions(),
 
   listSessions: ws => getCodexSessions(ws.path),
   workspacePreview: (ws, includeFirstUserMessage) =>
@@ -62,10 +62,10 @@ export const codexHarness: Harness = {
   wireScope: ws => ws.path,
 
   statusLines: () => {
-    const running = getCodexRunningSessions()
+    const active = getCodexActiveSessions()
     return [
-      `live Codex runs  ${running.length}`,
-      ...running.map(r => `  ▶ busy  ws=${r.workspaceId}  session=${r.sessionId}`)
+      `live Codex runs  ${active.length}`,
+      ...active.map(r => `  ▶ busy  ws=${r.workspaceId}  session=${r.sessionId}`)
     ]
   }
 }

--- a/server/harness/codex/session.ts
+++ b/server/harness/codex/session.ts
@@ -17,7 +17,7 @@
 //     first-class (no text matching like OpenClaw needs).
 import { appendAttachmentNote } from '@/lib/attachment-note'
 import { type Part, type SubagentRecord, type Turn, applyEvent, emptyViewState } from '@/lib/format'
-import type { StreamEvent, ViewState } from '@/lib/types'
+import type { SessionActivity, StreamEvent, ViewState } from '@/lib/types'
 
 import {
   type CodexThread,
@@ -91,10 +91,20 @@ function liveKey(workspaceId: string, sessionId: string): string {
   return real ? recKey(workspaceId, real) : direct
 }
 
-export function getCodexRunningSessions(): { workspaceId: string; sessionId: string }[] {
-  const out: { workspaceId: string; sessionId: string }[] = []
+export function getCodexActiveSessions(): {
+  workspaceId: string
+  sessionId: string
+  activity: SessionActivity
+}[] {
+  const out: { workspaceId: string; sessionId: string; activity: SessionActivity }[] = []
   for (const s of sessions.values()) {
-    if (s.processing) out.push({ workspaceId: s.workspaceId, sessionId: s.sessionId })
+    // Codex never surfaces `requires-action`: approvals are designed out
+    // (APPROVAL_POLICY 'never' + transport auto-accept in client.ts). If that
+    // policy is ever relaxed, `*requestApproval` / `elicitation` server
+    // requests are the signals to map to it.
+    if (s.processing) {
+      out.push({ workspaceId: s.workspaceId, sessionId: s.sessionId, activity: 'running' })
+    }
   }
   return out
 }
@@ -103,7 +113,11 @@ function setProcessing(rec: SessionRecord, processing: boolean, turnId: string |
   rec.activeTurnId = turnId
   if (rec.processing === processing) return
   rec.processing = processing
-  broadcast(rec.workspaceId, { type: 'status', sessionId: rec.sessionId, processing })
+  broadcast(rec.workspaceId, {
+    type: 'status',
+    sessionId: rec.sessionId,
+    activity: processing ? 'running' : 'idle'
+  })
 }
 
 function emitTurnEvent(rec: SessionRecord, ev: StreamEvent) {
@@ -290,6 +304,11 @@ function handleNotification(rec: SessionRecord, method: string, params: Record<s
           content: turn.error.message
         })
       }
+      // An externally-interrupted turn otherwise ends silently, identical to a
+      // clean completion — surface the stop so the client can render it.
+      if (turn?.status === 'interrupted') {
+        broadcast(rec.workspaceId, { kind: 'stopped', sessionId: rec.sessionId })
+      }
       return
     }
     case 'error': {
@@ -298,6 +317,9 @@ function handleNotification(rec: SessionRecord, method: string, params: Record<s
       if (message) {
         broadcast(rec.workspaceId, { kind: 'error', sessionId: rec.sessionId, content: message })
       }
+      // A top-level error without a following turn/completed would otherwise
+      // leave the session busy forever — the error is terminal for the turn.
+      setProcessing(rec, false, null)
       return
     }
     // Codex hooks (~/.codex/hooks.json) — surface as hook notices, parity

--- a/server/harness/openclaw/index.ts
+++ b/server/harness/openclaw/index.ts
@@ -15,7 +15,7 @@ import {
   abortOpenClawRun,
   ensureOpenClawSessionLive,
   getLiveOpenClawEvents,
-  getOpenClawRunningSessions,
+  getOpenClawActiveSessions,
   sendOpenClawMessage
 } from './session'
 
@@ -36,7 +36,7 @@ export const openclawHarness: Harness = {
     return sendOpenClawMessage({ ...input, agentId: input.agentId })
   },
   interrupt: (workspaceId, sessionId) => abortOpenClawRun({ workspaceId, sessionId }),
-  runningSessions: () => getOpenClawRunningSessions(),
+  activeSessions: () => getOpenClawActiveSessions(),
 
   listSessions: async ws => {
     const rows = await getOpenClawSessions(ws.path, ws.agentId)
@@ -87,10 +87,10 @@ export const openclawHarness: Harness = {
   skillsDir: workspaceRoot => `${workspaceRoot}/skills`,
 
   statusLines: () => {
-    const running = getOpenClawRunningSessions()
+    const active = getOpenClawActiveSessions()
     return [
-      `live OpenClaw runs  ${running.length}`,
-      ...running.map(r => `  ▶ busy  ws=${r.workspaceId}  session=${r.sessionId}`)
+      `live OpenClaw runs  ${active.length}`,
+      ...active.map(r => `  ▶ busy  ws=${r.workspaceId}  session=${r.sessionId}`)
     ]
   }
 }

--- a/server/harness/openclaw/session.ts
+++ b/server/harness/openclaw/session.ts
@@ -14,7 +14,7 @@
 import { appendAttachmentNote } from '@/lib/attachment-note'
 import { stripViewBuilderMeta } from '@/lib/view-builder-meta'
 import { applyEvent, emptyViewState } from '@/lib/format'
-import type { StreamEvent, ViewState } from '@/lib/types'
+import type { SessionActivity, StreamEvent, ViewState } from '@/lib/types'
 
 import {
   type OpenClawMessage,
@@ -82,20 +82,46 @@ onGatewayReconnected(async () => {
       console.error('[openclaw-session] reconcile-on-reconnect failed', err)
     }
   }
+  // Lifecycle frames emitted during the disconnect window are gone for good —
+  // a run that ended while we were away would leave its session busy forever.
+  // Re-derive every busy flag from the gateway's own `sessions.list` status.
+  try {
+    const busy = [...sessions.values()].filter(rec =>
+      isOpenClawProcessing(rec.workspaceId, rec.sessionId)
+    )
+    if (busy.length === 0) return
+    const gw = await getGateway()
+    const res = await gw.rpc<{ sessions: { key: string; status?: string }[] }>('sessions.list', {
+      includeGlobal: true
+    })
+    const running = new Set(
+      (res?.sessions ?? []).filter(row => row.status === 'running').map(row => row.key)
+    )
+    for (const rec of busy) {
+      if (!running.has(rec.sessionKey)) setProcessing(rec, false, null)
+    }
+  } catch (err) {
+    console.error('[openclaw-session] busy-flag reconcile failed', err)
+  }
 })
 
 function recKey(workspaceId: string, sessionId: string): string {
   return `${workspaceId}:${sessionId}`
 }
 
-// All running OpenClaw sessions across every workspace, for the connect-time
-// status snapshot. Key is `${workspaceId}:${sessionId}` (both are colon-free).
-export function getOpenClawRunningSessions(): { workspaceId: string; sessionId: string }[] {
-  const out: { workspaceId: string; sessionId: string }[] = []
+// All non-idle OpenClaw sessions across every workspace, for the status
+// snapshot. Key is `${workspaceId}:${sessionId}` (both are colon-free). The
+// protocol has no "waiting for user input" concept, so activity is binary.
+export function getOpenClawActiveSessions(): {
+  workspaceId: string
+  sessionId: string
+  activity: SessionActivity
+}[] {
+  const out: { workspaceId: string; sessionId: string; activity: SessionActivity }[] = []
   for (const [k, v] of openclawAgents) {
     if (!v.processing) continue
     const i = k.indexOf(':')
-    out.push({ workspaceId: k.slice(0, i), sessionId: k.slice(i + 1) })
+    out.push({ workspaceId: k.slice(0, i), sessionId: k.slice(i + 1), activity: 'running' })
   }
   return out
 }
@@ -113,7 +139,11 @@ function setProcessing(rec: SessionRecord, processing: boolean, runId: string | 
     activeRunId: runId
   })
   if (existing?.processing === processing) return
-  broadcast(rec.workspaceId, { type: 'status', sessionId: rec.sessionId, processing })
+  broadcast(rec.workspaceId, {
+    type: 'status',
+    sessionId: rec.sessionId,
+    activity: processing ? 'running' : 'idle'
+  })
   if (processing) {
     void markViewBuilderBuildingBySession(rec.workspaceId, rec.workspacePath, rec.sessionId)
   } else {
@@ -522,6 +552,9 @@ export async function abortOpenClawRun(input: {
       sessionId: rec.sessionId,
       content: err instanceof Error ? err.message : 'abort failed'
     })
+    // Stop is the user's escape hatch from a stuck spinner — clear the busy
+    // flag even when the abort RPC fails (the run may already be gone).
+    setProcessing(rec, false, null)
   }
 }
 

--- a/server/harness/types.ts
+++ b/server/harness/types.ts
@@ -6,6 +6,7 @@ import type {
   DiscoveredWorkspace,
   McpServer,
   Model,
+  SessionActivity,
   SessionInfo,
   StreamEvent,
   WorkspaceEntry,
@@ -62,9 +63,10 @@ export type Harness = {
   // -- chat lifecycle ---------------------------------------------------------
   sendMessage(input: SendMessageInput): Promise<void>
   interrupt(workspaceId: string, sessionId: string): Promise<void>
-  // Sessions currently processing a turn, across all workspaces (drives the
-  // connect-time status snapshot and view-builder reconciliation).
-  runningSessions(): { workspaceId: string; sessionId: string }[]
+  // Every session whose activity is not `idle`, across all workspaces (drives
+  // the status snapshot and view-builder reconciliation). Activity is mirrored
+  // from the backend's native lifecycle signal, never derived by counting.
+  activeSessions(): { workspaceId: string; sessionId: string; activity: SessionActivity }[]
 
   // -- discovery / metadata ---------------------------------------------------
   listSessions(ws: WorkspaceEntry): Promise<SessionInfo[]>

--- a/server/test/stream-e2e.ts
+++ b/server/test/stream-e2e.ts
@@ -150,8 +150,8 @@ function check(name: string, ok: boolean, detail = '') {
 const isPreview = (f: Frame) => f.type === 'preview'
 const isAssistantTurn = (f: Frame) =>
   f.kind === 'turn' && (f.turn as { role?: string } | undefined)?.role === 'assistant'
-const isStatusFalse = (f: Frame) => f.type === 'status' && f.processing === false
-const isStatusTrue = (f: Frame) => f.type === 'status' && f.processing === true
+const isStatusFalse = (f: Frame) => f.type === 'status' && f.activity === 'idle'
+const isStatusTrue = (f: Frame) => f.type === 'status' && f.activity === 'running'
 
 function previewText(f: Frame): string {
   const blocks = (f.blocks ?? []) as { text?: string }[]
@@ -269,7 +269,7 @@ async function scenarioReconnectMidStream() {
   const c2 = new Client(URL)
   await c2.open()
   const snapshot = c2.frames.find(f => f.type === 'status_snapshot')
-  const runningNow = (snapshot?.running as unknown[] | undefined) ?? []
+  const runningNow = (snapshot?.sessions as unknown[] | undefined) ?? []
   if (runningNow.length >= 1) {
     // The common case: the long run is still going. The new client must receive
     // the tail and the terminal status — proving delivery survives a mid-stream

--- a/server/test/stream-e2e.ts
+++ b/server/test/stream-e2e.ts
@@ -24,7 +24,7 @@ import type { ClientMessage } from '@/lib/types'
 process.env.IS_SANDBOX ??= '1'
 
 import {
-  getCCRunningSessions,
+  getCCActiveSessions,
   interruptCCSession,
   killAllCCSessions,
   sendCCMessage
@@ -52,7 +52,7 @@ const server = Bun.serve({
   websocket: {
     open(ws) {
       addClient(ws)
-      ws.send(JSON.stringify({ type: 'status_snapshot', running: getCCRunningSessions() }))
+      ws.send(JSON.stringify({ type: 'status_snapshot', sessions: getCCActiveSessions() }))
     },
     async message(ws, message) {
       const data = JSON.parse(String(message)) as ClientMessage

--- a/server/web.ts
+++ b/server/web.ts
@@ -1,4 +1,4 @@
-import type { ClientMessage } from '@/lib/types'
+import type { ClientMessage, StatusSnapshotMessage } from '@/lib/types'
 
 import index from '../client/index.html'
 import { api } from './api'
@@ -10,7 +10,7 @@ import { startScratchpadSweeper } from './scratchpad'
 import { resolveScratchOp } from './scratchpad-relay'
 import { allHarnesses, harnessFor } from './harness/registry'
 import { getWorkspace } from './registry'
-import { addClient, removeClient, sendToClient } from './state'
+import { addClient, broadcastAll, getClientCount, removeClient, sendToClient } from './state'
 import { distShell, prebuilt } from './static'
 import { renderStatus } from './status'
 import { serveVendorEmojibase, serveVendorReact } from './vendor'
@@ -54,6 +54,13 @@ function isClientMessage(value: unknown): value is ClientMessage {
 // live-bundled HTML import in dev (Bun.serve's bundler + HMR). The HTML import
 // stays here, in the routes table, so Bun's dev bundler keys off it.
 const shell = prebuilt ? distShell : index
+
+// Authoritative activity snapshot across all harnesses. Sent on chat-socket
+// connect and re-broadcast periodically (below) so a spinner whose terminal
+// status frame was lost self-heals without a reconnect.
+function statusSnapshot(): StatusSnapshotMessage {
+  return { type: 'status_snapshot', sessions: allHarnesses().flatMap(h => h.activeSessions()) }
+}
 
 type Upgradable = { upgrade(req: Request, opts: { data: WsData }): boolean }
 
@@ -111,11 +118,10 @@ export const app = Bun.serve<WsData>({
     open(ws) {
       if (ws.data.channel === 'chat') {
         addClient(ws)
-        // Authoritative snapshot of every running session across all harnesses
-        // so the client can light/clear spinners correctly even for runs whose
-        // status transitions it missed while disconnected.
-        const running = allHarnesses().flatMap(h => h.runningSessions())
-        sendToClient(ws, { type: 'status_snapshot', running })
+        // Authoritative snapshot of every non-idle session across all
+        // harnesses so the client can light/clear spinners correctly even for
+        // runs whose status transitions it missed while disconnected.
+        sendToClient(ws, statusSnapshot())
       } else {
         ws.subscribe(EVENTS_TOPIC)
       }
@@ -172,6 +178,13 @@ export const app = Bun.serve<WsData>({
 // that it exists. Kept in ./events so control.ts and ./api can publish without
 // importing web.ts (which binds ports on load).
 setEventServer(app)
+
+// The snapshot heartbeat: the client's reconcile fully replaces its activity
+// map from each snapshot, so any stale spinner clears within one interval.
+const SNAPSHOT_INTERVAL_MS = 30_000
+setInterval(() => {
+  if (getClientCount() > 0) broadcastAll(statusSnapshot())
+}, SNAPSHOT_INTERVAL_MS)
 
 // Periodically reclaim scratchpad asset files nothing references anymore —
 // deleting an image in the browser (or an upload whose tab died) otherwise


### PR DESCRIPTION
## Why

Tester feedback surfaced a stuck chat loader: the turn completes but the spinner never clears, and only Stop + new chat recovers. Reproduced live — the Claude Code harness derived busy/idle by counting (`pendingTurns++` on send, `--` on SDK `result`), but a message queued mid-turn gets merged by the CLI into one model turn: one `result` for two sends leaves the counter stuck at 1. No terminal status frame, the session never idle-evicts, and a page reload re-lights the spinner from the connect snapshot (the server honestly believes it's running).

The same investigation confirmed a second bug: idle eviction (5 min TTL) kills the `claude` subprocess together with its background Bash tasks — a tester's video render died at exactly turn-end +5 min, three times.

## What

One `SessionActivity` enum (`idle | running | requires-action`) on the wire and in the harness contract (`activeSessions()`), mirrored from each backend's **native** lifecycle signal instead of derived by counting:

- **Claude Code** — mirror `session_state_changed`, with `result` as the everyday turn-over fallback (verified: current CLIs don't emit state events in streaming-input mode) and a running re-assert on stream activity (covers queued turns run separately and SDK-initiated turns, e.g. background-task notifications). Optimistic `running` on send. `interrupt()` races a 5 s timeout and tears down the wedged subprocess — Stop now always escapes a stuck state (before: `await q.interrupt()` hung forever on a frozen subprocess). Teardown broadcasts terminal `idle` itself. Background tasks are tracked via typed `task_started` / `task_notification` / `task_updated` events (`local_bash`, `local_workflow`); sessions with live tasks re-arm the idle timer instead of tearing down.
- **Codex** — top-level `error` notification now clears the busy state (used to stay stuck); `interrupted` turns emit `stopped` instead of ending silently like a success.
- **OpenClaw** — busy flags re-derived from `sessions.list` on gateway reconnect (terminal lifecycle frames lost in the disconnect window used to wedge the spinner forever); abort RPC failure clears the flag.
- **Server** — `status_snapshot` re-broadcast every 30 s to all chat clients; the client rebuilds its whole activity map from it, so any lost terminal frame self-heals without a reconnect.
- **Client** — `activity` map in the live store; `error` frames clear the spinner; `requires-action` (agent blocked on user input — permission prompt / MCP elicitation) is tracked on the wire but deliberately renders with **no loader and no Stop** until it gets real UI.

## Verification

Driven live against the dev server with a WS frame logger (all four previously reproduced failure modes):

1. **Merged queue** — message B sent mid-turn, one merged `result` → terminal `activity: idle` arrives, fresh-connect snapshot empty. (Before: no terminal frame, snapshot listed the session running forever.)
2. **Stop escape hatch** — `kill -STOP` the SDK subprocess mid-turn, press Stop → `stopped` + `idle` in ~5 s. (Before: zero frames, hung until SIGCONT.)
3. **Background-task keep-alive** — at the TTL tick the log shows `idle-keepalive bgTasks=1` and the task's probe file is still being written that same second; the task ran all 200 iterations; the session wound down one TTL after it finished. (Before: task killed at exactly +5 min.)
4. **Snapshot heartbeat** — `status_snapshot` every 30 s on the dot.

`bun test`: 481 pass (7 new in `chat-activity.test.ts`); oxlint, `typecheck:client`, oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)