### PR TITLE
Filter linked git worktrees from workspace discovery

### DIFF
--- a/docs/git-worktrees.md
+++ b/docs/git-worktrees.md
@@ -1,0 +1,54 @@
+# Limitation: git worktrees aren't supported as workspaces
+
+**Status:** known limitation · discovery filtering added 2026-07-21
+
+moi does **not** currently support being used as a workspace inside a linked
+git worktree (a checkout created by `git worktree add`). Treat a worktree
+directory as unsupported for now — open the primary working tree instead.
+
+## What changed
+
+Workspace discovery (the "Import from this computer" list on the home page)
+scans Claude Code's session history and suggests every directory an agent has
+ever run in (`server/harness/claude-code/index.ts` → `discoverWorkspaces`).
+Agents frequently run inside throwaway worktree checkouts (e.g. worktree-isolated
+runs), so those directories were showing up as if they were real workspaces.
+
+Discovery now detects linked git worktrees and drops them from the suggestion
+list, so they no longer get added by accident. This is a filter on **discovery
+only** — it does not make moi work correctly inside a worktree.
+
+## How the detection works
+
+A linked worktree stores its `.git` as a **file** (not a directory) whose one
+line points into the primary repo's git dir:
+
+```
+gitdir: /path/to/repo/.git/worktrees/<id>
+```
+
+`isLinkedGitWorktree` (`server/harness/claude-code/git-worktree.ts`) reads that
+file and matches the `.git/worktrees/` segment. See
+`git-worktree.test.ts` for the covered cases.
+
+## Reliability
+
+- **Standard worktrees** created by `git worktree add` are detected reliably —
+  the `gitdir:` gitfile pointing into `.git/worktrees/<id>` is git's documented,
+  stable layout (`man gitrepository-layout`).
+- **The main working tree is never filtered** — its `.git` is a directory, so
+  the read fails and the check returns `false`. A real repo can't be hidden.
+- **Submodules are left alone** — their `.git` file points into `.git/modules/`,
+  not `.git/worktrees/`, so it doesn't match.
+- **Fails open** — any read error is treated as "not a worktree", so a transient
+  filesystem hiccup never hides a legitimate workspace. The trade-off is that a
+  worktree could occasionally slip through rather than a real workspace vanishing.
+- **Known gap:** if a repo's common git dir isn't literally named `.git` (a bare
+  repo used as the common dir, or a custom `$GIT_DIR`), the pointer won't contain
+  `.git/worktrees/` and the worktree won't be filtered. This is uncommon.
+
+## If you already added a worktree
+
+The filter only affects future suggestions. A worktree you already imported is a
+registered workspace and stays until you remove it — remove it from the
+workspace list manually.

--- a/server/harness/claude-code/git-worktree.test.ts
+++ b/server/harness/claude-code/git-worktree.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from 'bun:test'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { isLinkedGitWorktree, pointsIntoWorktrees } from './git-worktree'
+
+test('pointsIntoWorktrees matches a linked worktree .git file', () => {
+  expect(pointsIntoWorktrees('gitdir: /home/user/moi/.git/worktrees/feature-x')).toBe(true)
+})
+
+test('pointsIntoWorktrees tolerates a trailing newline and extra whitespace', () => {
+  expect(pointsIntoWorktrees('gitdir:   /repo/.git/worktrees/wt\n')).toBe(true)
+})
+
+test('pointsIntoWorktrees matches Windows-style paths', () => {
+  expect(pointsIntoWorktrees('gitdir: C:\\repo\\.git\\worktrees\\wt')).toBe(true)
+})
+
+test('pointsIntoWorktrees ignores submodules pointing into .git/modules', () => {
+  expect(pointsIntoWorktrees('gitdir: ../.git/modules/vendor/lib')).toBe(false)
+})
+
+test('pointsIntoWorktrees ignores unrelated or malformed contents', () => {
+  expect(pointsIntoWorktrees('')).toBe(false)
+  expect(pointsIntoWorktrees('not a git file')).toBe(false)
+  expect(pointsIntoWorktrees('ref: refs/heads/main')).toBe(false)
+})
+
+test('isLinkedGitWorktree returns true for a worktree .git file on disk', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'moi-wt-'))
+  const dir = join(base, 'checkout')
+  await mkdir(dir)
+  await writeFile(join(dir, '.git'), 'gitdir: /repo/.git/worktrees/checkout\n')
+  expect(await isLinkedGitWorktree(dir)).toBe(true)
+})
+
+test('isLinkedGitWorktree returns false for a normal repo (.git directory)', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'moi-repo-'))
+  await mkdir(join(base, '.git'))
+  expect(await isLinkedGitWorktree(base)).toBe(false)
+})
+
+test('isLinkedGitWorktree returns false when there is no .git at all', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'moi-plain-'))
+  expect(await isLinkedGitWorktree(base)).toBe(false)
+})

--- a/server/harness/claude-code/git-worktree.ts
+++ b/server/harness/claude-code/git-worktree.ts
@@ -1,0 +1,31 @@
+// Detecting linked git worktrees so workspace discovery can skip them.
+//
+// Claude Code accumulates session history in every directory an agent ever ran
+// in, including the throwaway checkouts created for worktree-isolated runs.
+// Those derived directories shouldn't surface as importable workspaces in the
+// discovery list, so we filter them out.
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+// A linked git worktree stores its `.git` as a *file* (not a directory) whose
+// single line points into the primary repo: `gitdir: /repo/.git/worktrees/<id>`.
+// Return true only for that shape. Submodules also use a `.git` file, but they
+// point into `.git/modules/…`, so keying on the `worktrees` segment leaves
+// submodule checkouts alone.
+export function pointsIntoWorktrees(gitFileContents: string): boolean {
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(gitFileContents)
+  if (!match) return false
+  return /(?:^|[/\\])\.git[/\\]worktrees[/\\]/.test(match[1])
+}
+
+// Whether `dir` is a linked git worktree checkout. A normal repo keeps `.git`
+// as a directory (so `readFile` fails with EISDIR → false); a non-repo has no
+// `.git` at all (ENOENT → false). Any read error is treated as "not a
+// worktree" so discovery fails open rather than hiding real workspaces.
+export async function isLinkedGitWorktree(dir: string): Promise<boolean> {
+  try {
+    return pointsIntoWorktrees(await readFile(join(dir, '.git'), 'utf8'))
+  } catch {
+    return false
+  }
+}

--- a/server/harness/claude-code/git-worktree.ts
+++ b/server/harness/claude-code/git-worktree.ts
@@ -3,7 +3,8 @@
 // Claude Code accumulates session history in every directory an agent ever ran
 // in, including the throwaway checkouts created for worktree-isolated runs.
 // Those derived directories shouldn't surface as importable workspaces in the
-// discovery list, so we filter them out.
+// discovery list, so we filter them out. moi doesn't support running inside a
+// worktree yet — see docs/git-worktrees.md.
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 

--- a/server/harness/claude-code/index.ts
+++ b/server/harness/claude-code/index.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { DiscoveredWorkspace, McpServer } from '@/lib/types'
 
 import type { Harness } from '../types'
+import { isLinkedGitWorktree } from './git-worktree'
 import { getMcpStatus } from './mcp'
 import { getClaudeModels } from './models'
 import {
@@ -51,7 +52,13 @@ async function discoverWorkspaces(registeredPaths: Set<string>): Promise<Discove
         if (info.isDirectory()) paths.add(s.cwd)
       } catch {}
     }
-    return [...paths].map(path => ({ path, type: 'claude-code' as const }))
+    // Drop linked git worktrees — throwaway checkouts (e.g. worktree-isolated
+    // runs) that shouldn't surface as importable workspaces.
+    const candidates = [...paths]
+    const worktree = await Promise.all(candidates.map(isLinkedGitWorktree))
+    return candidates
+      .filter((_, i) => !worktree[i])
+      .map(path => ({ path, type: 'claude-code' as const }))
   } catch {
     return []
   }


### PR DESCRIPTION
## Summary

Workspace discovery now detects and excludes linked git worktrees (checkouts created by `git worktree add`) from the "Import from this computer" suggestion list. This prevents throwaway worktree directories used in worktree-isolated agent runs from surfacing as importable workspaces.

## Changes

- **New module `server/harness/claude-code/git-worktree.ts`**: Implements worktree detection by reading the `.git` file (which is a file, not a directory, in linked worktrees) and checking if it points into `.git/worktrees/`. Includes `pointsIntoWorktrees()` for parsing the gitfile contents and `isLinkedGitWorktree()` for checking a directory.
- **New test file `server/harness/claude-code/git-worktree.test.ts`**: Comprehensive test coverage for both functions, including standard worktrees, submodules (which should not be filtered), Windows paths, and edge cases.
- **Updated `server/harness/claude-code/index.ts`**: Modified `discoverWorkspaces()` to filter out detected worktrees before returning the discovery list.
- **New documentation `docs/git-worktrees.md`**: Explains the limitation, detection mechanism, reliability guarantees, and known gaps.

## Implementation Details

The detection is reliable and fails open:
- **Standard worktrees** are detected reliably via git's documented `.git/worktrees/<id>` layout
- **Main working tree is never filtered** — its `.git` is a directory, so the read fails and returns `false`
- **Submodules are left alone** — they point into `.git/modules/`, not `.git/worktrees/`
- **Fails open** — any read error is treated as "not a worktree", so transient filesystem issues never hide legitimate workspaces
- **Known gap**: Custom git directories (bare repos, `$GIT_DIR`) won't be filtered, but this is uncommon

Note: This is a discovery-only filter. moi does not yet support running inside a worktree; users should open the primary working tree instead.

https://claude.ai/code/session_01CuiGGQygGQjjPu9MtFjaEX