### PR TITLE
Add harness executable paths to status output

### DIFF
--- a/server/harness/claude-code/index.ts
+++ b/server/harness/claude-code/index.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import type { McpServer } from '@/lib/types'
 
 import type { DiscoveredWorkspaceCandidate, Harness } from '../types'
-import { pathHarnessAvailability } from '../executable'
+import { findHarnessExecutable, pathHarnessAvailability } from '../executable'
 import { isLinkedGitWorktree } from './git-worktree'
 import { getMcpStatus } from './mcp'
 import { getClaudeModels } from './models'
@@ -100,6 +100,7 @@ export const claudeCodeHarness: Harness = {
     const cc = getCCDebugSnapshot()
     const busy = cc.sessions.filter(s => s.activity !== 'idle').length
     const lines = [
+      `claude executable  ${findHarnessExecutable('claude-code') ?? '(not found)'}`,
       `live CC sessions  ${cc.sessions.length}/${SESSION_LIMITS.maxLive}  ` +
         `(${busy} busy, ${cc.sessions.length - busy} idle, ${cc.aliases} alias${cc.aliases === 1 ? '' : 'es'}, ` +
         `idle TTL ${fmtDuration(SESSION_LIMITS.idleTtlMs)})`

--- a/server/harness/codex/index.ts
+++ b/server/harness/codex/index.ts
@@ -1,7 +1,7 @@
 // Codex as a Harness. Thin wiring over this folder's modules — see
 // ../types.ts for the contract and ../README.md for the architecture.
 import type { Harness } from '../types'
-import { pathHarnessAvailability } from '../executable'
+import { findHarnessExecutable, pathHarnessAvailability } from '../executable'
 import {
   getCodexMcpStatus,
   getCodexModels,
@@ -68,6 +68,7 @@ export const codexHarness: Harness = {
   statusLines: () => {
     const active = getCodexActiveSessions()
     return [
+      `codex executable  ${findHarnessExecutable('codex') ?? '(not found)'}`,
       `live Codex runs  ${active.length}`,
       ...active.map(r => `  ▶ busy  ws=${r.workspaceId}  session=${r.sessionId}`)
     ]


### PR DESCRIPTION
Display the resolved executable paths for Claude Code and Codex harnesses in their respective status line outputs.

**Changes:**
- Import `findHarnessExecutable` in both `claude-code` and `codex` harness modules
- Add executable path status line to `claudeCodeHarness.statusLines()` showing the resolved `claude-code` executable or "(not found)"
- Add executable path status line to `codexHarness.statusLines()` showing the resolved `codex` executable or "(not found)"

This provides visibility into which harness executables are available and their resolved paths, useful for debugging harness availability issues.

https://claude.ai/code/session_01UyW1QM9o76o7X3yiNh3UBL