### PR TITLE
Add intents: tab focus with params and applet actions into chat

### DIFF
--- a/client/features/applets/useApplet.ts
+++ b/client/features/applets/useApplet.ts
@@ -14,9 +14,17 @@ import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { type WorkspaceEvent, useWorkspaceEvent } from '@/client/runtime/useWorkspaceEvents'
 import type { AppletKind } from '@/lib/types'
 
+// Props the host passes to a mounted applet component. `params` is the active
+// view's current focus-param values (client/features/workspace/intents.ts);
+// widgets are mounted without it. Optional so param-less applets stay plain
+// `ComponentType`s.
+export type AppletComponentProps = {
+  params?: Record<string, unknown>
+}
+
 type AppletState =
   | { status: 'loading'; version: number }
-  | { status: 'ready'; Component: ComponentType; version: number }
+  | { status: 'ready'; Component: ComponentType<AppletComponentProps>; version: number }
   | { status: 'error'; error: string; version: number }
 
 // An applet kind (widget / view) differs only in its URL path segment and which
@@ -47,9 +55,9 @@ function loadApplet(
   segment: AppletSegment,
   workspaceId: string,
   name: string
-): Promise<ComponentType> {
+): Promise<ComponentType<AppletComponentProps>> {
   const key = appletKey(segment, workspaceId, name)
-  const existing = getCachedApplet(key) as Promise<ComponentType> | undefined
+  const existing = getCachedApplet(key) as Promise<ComponentType<AppletComponentProps>> | undefined
   if (existing) return existing
 
   // Import the bundle dir's `index.js` at its current `?v`; the version is bumped
@@ -57,7 +65,7 @@ function loadApplet(
   // while this applet is unmounted — so a backgrounded tab never serves stale.
   const promise = import(/* @vite-ignore */ appletUrl(segment, workspaceId, name)).then(mod => {
     if (!mod.default) throw new Error(`"${name}" has no default export`)
-    return mod.default as ComponentType
+    return mod.default as ComponentType<AppletComponentProps>
   })
 
   setCachedApplet(key, promise)

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -12,6 +12,7 @@ import { resolveChatRunOptions, startOptimisticTurn } from '@/client/features/ch
 import { buildPreviewTurn } from '@/client/features/chat/preview-turn'
 import { draftKey, liveStore, selectPreviews, useLive } from '@/client/features/chat/chat-store'
 import { emptyViewState } from '@/lib/format'
+import type { MoiIntent } from '@/lib/moi-context'
 import type { Part, ViewState } from '@/lib/types'
 
 const EMPTY: ViewState = emptyViewState()
@@ -58,9 +59,11 @@ export function useChat() {
 
   // The composer owns the draft (in the live store) and hands the text in, so a
   // keystroke re-renders only the composer — not this hook's host (WorkspaceView)
-  // and its whole subtree. See `ChatInput`.
+  // and its whole subtree. See `ChatInput`. `intent` marks an applet-fired
+  // action message (docs/intents.md): it rides the context envelope, so the
+  // visible text stays the action's label.
   const send = useCallback(
-    (draft: string) => {
+    (draft: string, intent?: MoiIntent) => {
       const text = draft.trim()
       // Attachments for the active thread, keyed exactly like the draft. Only
       // fully-uploaded ones are sent; the composer disables send while any are
@@ -118,7 +121,7 @@ export function useChat() {
         model,
         effort,
         stream,
-        context: buildMoiContext(),
+        context: { ...buildMoiContext(), ...(intent ? { intent } : {}) },
         ...(ready.length > 0 ? { attachments: ready.map(a => a.upload!.id) } : {})
       })
       if (isNew) {

--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -34,6 +34,8 @@ import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayo
 import { resolveAppIcon } from '@/client/lib/app-icon-registry'
 import { cn } from '@/client/lib/cn'
 import { liveStore } from '@/client/features/chat/chat-store'
+import { bindWorkspaceIntents, focusTab, useTabParams } from '@/client/features/workspace/intents'
+import { useWorkspaceEvent } from '@/client/runtime/useWorkspaceEvents'
 import {
   type CreateWorkspaceTabItem,
   type WorkspaceTabItem,
@@ -99,10 +101,13 @@ type ViewAppProps = {
 
 // A view — an agent-defined app — mounted full-area. The bundle owns its own
 // layout + scroll, so we give it a plain filled box and fade it in (mirroring
-// WidgetShell, but full-area instead of a grid cell).
+// WidgetShell, but full-area instead of a grid cell). `params` hands the view
+// its current focus-param values (docs/intents.md), `{}` until a focus intent
+// sets them.
 function ViewApp({ view }: ViewAppProps) {
   const workspaceId = useWorkspaceId()
   const bundle = useView(view.id)
+  const params = useTabParams(workspaceId, viewTabId(view.id))
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
@@ -128,7 +133,7 @@ function ViewApp({ view }: ViewAppProps) {
                 workspaceId={workspaceId}
                 resetKey={bundle.version}
               >
-                <bundle.Component />
+                <bundle.Component params={params} />
               </WidgetErrorBoundary>
             </motion.div>
           </AppletMount>
@@ -453,6 +458,45 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
     }
     setChatFocusRequest(request => request + 1)
   }
+
+  // An applet action (docs/intents.md). Idle chat: send now — the label is the
+  // visible text, the structured payload rides the envelope's `intent` field.
+  // Busy chat: never interrupt or drop — park the label as the composer draft
+  // (the structured context is lost on this path; acceptable for now). Both
+  // paths surface the chat so the user sees what happened.
+  const runAppletAction = (label: string, context?: Record<string, unknown>, source?: string) => {
+    const text = label.trim()
+    if (!text) return
+    if (processing) {
+      openChat(text)
+      return
+    }
+    send(text, { source: source ?? activeTab, ...(context ? { context } : {}) })
+    openChat()
+  }
+
+  // Bind this screen to the intent system: register the tab switcher +
+  // action sender, and install the `window.moi` applet bridge. Bound once per
+  // workspace; the ref keeps the callbacks current across renders.
+  const intentScreenRef = useRef({ openTab, runAppletAction })
+  intentScreenRef.current = { openTab, runAppletAction }
+  useEffect(
+    () =>
+      bindWorkspaceIntents(workspaceId, {
+        openTab: tab => intentScreenRef.current.openTab(tab),
+        sendAction: (label, context, source) =>
+          intentScreenRef.current.runAppletAction(label, context, source)
+      }),
+    [workspaceId]
+  )
+
+  // Agent-initiated focus (`moi focus` → `intent:focus` event): same dispatch
+  // as an applet's `focus()` call.
+  useWorkspaceEvent(event => {
+    if (event.type === 'intent:focus' && event.workspaceId === workspaceId) {
+      focusTab(workspaceId, event.tab, event.params)
+    }
+  })
 
   const createItems: CreateWorkspaceTabItem[] = [
     ...(!dockedSplit && !openSet.has('agent')

--- a/client/features/workspace/intents.test.ts
+++ b/client/features/workspace/intents.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+
+import { bindWorkspaceIntents, focusTab, getTabParams, intentsStore } from './intents'
+import type { WorkspaceTabId } from '@/lib/types'
+
+describe('intents store', () => {
+  test('tab params default to a stable empty object', () => {
+    expect(getTabParams('ws-1', 'view:none')).toEqual({})
+    expect(getTabParams('ws-1', 'view:none')).toBe(getTabParams('ws-2', 'view:other'))
+  })
+
+  test('setTabParams keys per workspace and tab, replacing wholesale', () => {
+    intentsStore.getState().setTabParams('ws-1', 'view:shop', { product: 'scarf' })
+    intentsStore.getState().setTabParams('ws-2', 'view:shop', { product: 'hat' })
+    expect(getTabParams('ws-1', 'view:shop')).toEqual({ product: 'scarf' })
+    expect(getTabParams('ws-2', 'view:shop')).toEqual({ product: 'hat' })
+    intentsStore.getState().setTabParams('ws-1', 'view:shop', { tab: 'reviews' })
+    expect(getTabParams('ws-1', 'view:shop')).toEqual({ tab: 'reviews' })
+  })
+
+  test('focusTab stores params and opens the tab through the bound screen', () => {
+    const opened: WorkspaceTabId[] = []
+    const unbind = bindWorkspaceIntents('ws-f', {
+      openTab: tab => opened.push(tab),
+      sendAction: () => {}
+    })
+    focusTab('ws-f', 'view:shop', { product: 'scarf' })
+    expect(opened).toEqual(['view:shop'])
+    expect(getTabParams('ws-f', 'view:shop')).toEqual({ product: 'scarf' })
+    // A bare focus keeps the tab's existing params.
+    focusTab('ws-f', 'view:shop')
+    expect(opened).toEqual(['view:shop', 'view:shop'])
+    expect(getTabParams('ws-f', 'view:shop')).toEqual({ product: 'scarf' })
+    unbind()
+  })
+
+  test('focusTab with no bound screen still records params, never throws', () => {
+    focusTab('ws-unbound', 'view:crm', { account: 'acme' })
+    expect(getTabParams('ws-unbound', 'view:crm')).toEqual({ account: 'acme' })
+  })
+
+  test('unbinding stops dispatch to the old screen; a rebind wins', () => {
+    const first: string[] = []
+    const second: string[] = []
+    const unbindFirst = bindWorkspaceIntents('ws-r', {
+      openTab: tab => first.push(tab),
+      sendAction: label => first.push(`action:${label}`)
+    })
+    const unbindSecond = bindWorkspaceIntents('ws-r', {
+      openTab: tab => second.push(tab),
+      sendAction: label => second.push(`action:${label}`)
+    })
+    // The stale first cleanup must not remove the second binding.
+    unbindFirst()
+    focusTab('ws-r', 'widgets')
+    expect(first).toEqual([])
+    expect(second).toEqual(['widgets'])
+    unbindSecond()
+    focusTab('ws-r', 'widgets')
+    expect(second).toEqual(['widgets'])
+  })
+})

--- a/client/features/workspace/intents.ts
+++ b/client/features/workspace/intents.ts
@@ -1,0 +1,95 @@
+// Client-local intent state and dispatch (docs/intents.md). Two things live
+// here, both module-level so applet code and non-React callers can reach them:
+//
+//   - Ephemeral per-tab params: the values the last focus intent handed a tab.
+//     In-memory only — deliberately NOT persisted into WorkspaceLayout, so a
+//     reload starts every view without params.
+//   - `focusTab(workspaceId, tab, params?)`: store the params and switch the
+//     active tab through the mounted WorkspaceScreen's own tab mechanism.
+//
+// The screen registers its handlers via `bindWorkspaceIntents` while mounted;
+// that same binding installs the typed `window.moi` bridge the applet-bundle
+// `moi` module stubs delegate to (server/bundler/build-applet.ts).
+import { useStore } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+
+import type { MoiAppletRuntime, WorkspaceTabId } from '@/lib/types'
+
+declare global {
+  interface Window {
+    moi?: MoiAppletRuntime
+  }
+}
+
+// Entries are keyed `${workspaceId}:${tab}` — same convention as liveStore.
+function key(workspaceId: string, tab: WorkspaceTabId): string {
+  return `${workspaceId}:${tab}`
+}
+
+type IntentsStore = {
+  paramsByTab: Record<string, Record<string, unknown>>
+  setTabParams: (workspaceId: string, tab: WorkspaceTabId, params: Record<string, unknown>) => void
+}
+
+export const intentsStore = createStore<IntentsStore>()(set => ({
+  paramsByTab: {},
+
+  setTabParams: (workspaceId, tab, params) =>
+    set(s => ({ paramsByTab: { ...s.paramsByTab, [key(workspaceId, tab)]: params } }))
+}))
+
+// Stable empty default so an unset tab never re-renders its subscribers.
+const EMPTY_PARAMS: Record<string, unknown> = {}
+
+export function getTabParams(workspaceId: string, tab: WorkspaceTabId): Record<string, unknown> {
+  return intentsStore.getState().paramsByTab[key(workspaceId, tab)] ?? EMPTY_PARAMS
+}
+
+// Reactive read of one tab's current params — feeds the mounted view's
+// `params` prop.
+export function useTabParams(workspaceId: string, tab: WorkspaceTabId): Record<string, unknown> {
+  return useStore(intentsStore, s => s.paramsByTab[key(workspaceId, tab)]) ?? EMPTY_PARAMS
+}
+
+// What a mounted WorkspaceScreen contributes: its tab switcher and the chat
+// side of `sendAction` (send-or-park, see WorkspaceScreen).
+type WorkspaceIntentHandlers = {
+  openTab: (tab: WorkspaceTabId) => void
+  sendAction: (label: string, context?: Record<string, unknown>, source?: string) => void
+}
+
+const handlers = new Map<string, WorkspaceIntentHandlers>()
+
+// Dispatch a focus intent: remember the params for the target tab (when given —
+// a bare focus keeps whatever the tab already holds), then activate it. Callers:
+// the `intent:focus` workspace event (agent-initiated `moi focus`) and applet
+// `focus()` calls via the `window.moi` bridge.
+export function focusTab(
+  workspaceId: string,
+  tab: WorkspaceTabId,
+  params?: Record<string, unknown>
+): void {
+  if (params) intentsStore.getState().setTabParams(workspaceId, tab, params)
+  handlers.get(workspaceId)?.openTab(tab)
+}
+
+// Bind a mounted WorkspaceScreen to the intent system and install the
+// `window.moi` applet bridge for its workspace. Returns the unbind cleanup.
+// One workspace is on screen at a time, so a plain overwrite is safe; the
+// cleanup only removes what it installed (a remount that already re-bound wins).
+export function bindWorkspaceIntents(
+  workspaceId: string,
+  screen: WorkspaceIntentHandlers
+): () => void {
+  handlers.set(workspaceId, screen)
+  const runtime: MoiAppletRuntime = {
+    focus: (tab, params) => focusTab(workspaceId, tab, params),
+    sendAction: (label, context, source) =>
+      handlers.get(workspaceId)?.sendAction(label, context, source)
+  }
+  if (typeof window !== 'undefined') window.moi = runtime
+  return () => {
+    if (handlers.get(workspaceId) === screen) handlers.delete(workspaceId)
+    if (typeof window !== 'undefined' && window.moi === runtime) delete window.moi
+  }
+}

--- a/client/features/workspace/moi-context.ts
+++ b/client/features/workspace/moi-context.ts
@@ -22,6 +22,7 @@ import { useCallback } from 'react'
 
 import { useViewBuilders } from '@/client/features/views/api'
 import { useWorkspaceViews } from '@/client/features/workspace/api'
+import { getTabParams } from '@/client/features/workspace/intents'
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
 import type { MoiContext } from '@/lib/moi-context'
@@ -76,9 +77,16 @@ export function useMoiUserMessageContext(): () => MoiContext {
   const activeTab = layout.tabs.active
   return useCallback(() => {
     const directives = drainChatDirectives(workspaceId)
+    // Current focus-param values of the active view (a live read from the
+    // intents store, so the snapshot is send-time fresh) — how the agent knows
+    // "this" means product "scarf". Views only; other tabs hold no params.
+    const tabParams = activeTab.startsWith('view:')
+      ? getTabParams(workspaceId, activeTab)
+      : undefined
     return {
       activeTab,
       tabTitle: activeTabTitle(activeTab, views, builders),
+      ...(tabParams && Object.keys(tabParams).length > 0 ? { tabParams } : {}),
       ...(directives.length > 0 ? { directives } : {})
     }
   }, [workspaceId, activeTab, views, builders])

--- a/client/runtime/useWorkspaceEvents.ts
+++ b/client/runtime/useWorkspaceEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { wsUrl } from '@/client/lib/ws-url'
-import type { ViewBuilder, ViewInfo, WidgetInfo } from '@/lib/types'
+import type { ViewBuilder, ViewInfo, WidgetInfo, WorkspaceTabId } from '@/lib/types'
 
 export type WorkspaceEvent =
   | { type: 'widget:updated'; name: string }
@@ -21,6 +21,14 @@ export type WorkspaceEvent =
   // The Scratchpad canvas for `workspaceId` was saved — open tabs reload from
   // disk. `origin` is the tab that wrote it, so that tab can skip its own echo.
   | { type: 'scratchpad:updated'; workspaceId: string; origin?: string }
+  // An agent-initiated focus intent (`moi focus`): tabs showing `workspaceId`
+  // switch to `tab`, handing it `params` (see client/features/workspace/intents.ts).
+  | {
+      type: 'intent:focus'
+      workspaceId: string
+      tab: WorkspaceTabId
+      params?: Record<string, unknown>
+    }
 
 type WorkspaceEventHandler = (event: WorkspaceEvent) => void
 

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -1,0 +1,64 @@
+# Intents
+
+Intents are how the three surfaces of a workspace — chat, widgets, and views — talk to each
+other. This is the address-based v1: an intent targets a **tab id** (`agent`, `widgets`,
+`scratchpad`, `view:<id>`), and views declare a **params** contract that focus intents fill.
+
+## The params contract
+
+A view declares its addressable state in its config (`lib/types.ts` → `ViewConfig.params`):
+
+```ts
+export const config = {
+  title: 'Shop',
+  params: { product: 'Product slug shown in the detail pane' }
+} as const
+```
+
+The map (name → one-line description) is parsed at bundle time
+(`server/bundler/build-applet.ts`), stored in the view manifest, and surfaced by `moi tabs` so an
+agent can discover what each view accepts. Current param _values_ are ephemeral client state
+(`client/features/workspace/intents.ts` — in-memory, never persisted into the layout) and reach
+the mounted view as a single `params` prop, `{}` until a focus intent sets them.
+
+## The three flows
+
+- **Chat/agent → view** — the agent runs `moi focus view:shop --params '{"product":"scarf"}'`.
+  The CLI sends a control message (`server/control.ts`), which validates the tab id (unknown ids
+  fail with the valid list) and publishes an `intent:focus` workspace event. Every open tab of
+  that workspace switches to the target and hands it the params.
+- **Applet → chat** — applet code calls `sendAction(label, context?)` (from the `moi` module).
+  Idle chat: the message goes out immediately — `label` is the visible text, while
+  `{ source, context }` rides the hidden `<moi-context>` envelope as its `intent` field
+  (`lib/moi-context.ts`), rendered as an `# Applet action` section. Busy chat: the label is
+  parked as the composer draft and the chat is surfaced, so the run is never interrupted and the
+  action is never dropped (the structured `context` is lost on this path — an accepted MVP gap).
+- **Applet → view** — applet code calls `focus(tab, params?)` (also from `moi`). Same dispatch as
+  the agent flow, minus the server round-trip: params are stored and the tab is activated
+  client-side.
+
+Both `focus` and `sendAction` are stubs baked into every applet bundle that delegate to the
+host-installed `window.moi` bridge (`MoiAppletRuntime` in `lib/types.ts`); outside the moi host
+they no-op. `sendAction` self-attributes with the applet's own `<kind>:<name>` id.
+
+## Envelope symmetry
+
+While a view with params is active, ordinary user messages include the current values as
+`tabParams` in the envelope's active-tab section — so "make this cheaper" tells the agent it is
+about product `scarf` without the user saying so.
+
+## Discovery
+
+`moi tabs` prints the manifest — static tabs plus each view with its declared params — assembled
+server-side from the view list (`server/views.ts` → `assembleWorkspaceTabs`).
+
+## Deliberately deferred
+
+- **Queueing on a busy chat** — a busy `sendAction` parks the label as a draft instead of
+  queueing the full structured action.
+- **Per-client focus scoping** — `intent:focus` reaches every open tab of the workspace, not the
+  one the user is looking at.
+- **Widget-level addressing** — intents target tabs; individual widgets are not addressable.
+- **URL persistence of params** — params don't survive a reload and can't be deep-linked.
+- **Capability-based routing** — targets are concrete tab ids; there is no "whatever can show a
+  product" indirection.

--- a/lib/moi-context.ts
+++ b/lib/moi-context.ts
@@ -32,6 +32,16 @@ const MOI_CONTEXT_MARKER = 'You are running in a `moi` workspace'
 const SYSTEM_REMINDER_OPEN = '<system-reminder>'
 const SYSTEM_REMINDER_CLOSE = '</system-reminder>'
 
+// An applet-fired action riding a chat message (`sendAction` — see
+// docs/intents.md). The visible message text is the action's label; the
+// structured payload lives here, never in the text.
+export type MoiIntent = {
+  // The applet the action originated from, e.g. `view:shop` or `widget:orders`.
+  source: string
+  // Structured state the applet attached (the selected row, current filters, …).
+  context?: Record<string, unknown>
+}
+
 // The structured form built at send time — by the client for chat sends, by
 // the server for programmatic sends (the view builder). Extend this (and
 // `renderMoiContext`) when new ambient fields land.
@@ -44,6 +54,12 @@ export type MoiContext = {
   // view builder's claimed title while the build runs. The tab bar falls
   // back to the id when unset; so does the envelope.
   tabTitle?: string
+  // Current param values of the active view tab (set by the last focus
+  // intent), so the agent knows exactly what the user is looking at when
+  // they say "make this cheaper".
+  tabParams?: Record<string, unknown>
+  // Set when this message was fired by an applet action instead of typed.
+  intent?: MoiIntent
   // One-shot imperative lines for this message only (e.g. the view-builder
   // bootstrap instructions from lib/view-builder-directives.ts).
   directives?: string[]
@@ -71,6 +87,12 @@ function describeTab(tab: WorkspaceTabId, title?: string): string {
   return `The user is on the "${tab}" tab.`
 }
 
+// A compact fenced JSON block for structured envelope payloads (view params,
+// applet action context). Single-line — these objects are meant to stay small.
+function fencedJson(value: Record<string, unknown>): string {
+  return '```json\n' + JSON.stringify(value) + '\n```'
+}
+
 // Format (modeled on Claude Code's system-reminder context blocks): a short
 // orientation preamble with the skill pointer, `# Section` headers with
 // complete sentences under them, and an IMPORTANT footer with handling rules.
@@ -82,7 +104,20 @@ export function renderMoiContextBody(ctx: MoiContext): string {
     `${MOI_CONTEXT_MARKER} — a shared UI the user chats with you from, which you can extend and customize.`,
     'Read the **`moi-workspace` skill** before responding — even to a simple question — unless you already read it in this chat.'
   ].join('\n')
-  const sections = [`# Active tab\n${describeTab(ctx.activeTab, ctx.tabTitle)}`]
+  const activeTabLines = [describeTab(ctx.activeTab, ctx.tabTitle)]
+  if (ctx.tabParams && Object.keys(ctx.tabParams).length > 0) {
+    activeTabLines.push('The view currently shows these param values:', fencedJson(ctx.tabParams))
+  }
+  const sections = [`# Active tab\n${activeTabLines.join('\n')}`]
+  if (ctx.intent) {
+    const intentLines = [
+      `The user fired this message with an action in "${ctx.intent.source}" — the message text is the action's label, not typed by the user.`
+    ]
+    if (ctx.intent.context && Object.keys(ctx.intent.context).length > 0) {
+      intentLines.push('The applet attached this context:', fencedJson(ctx.intent.context))
+    }
+    sections.push(`# Applet action\n${intentLines.join('\n')}`)
+  }
   if (ctx.directives?.length) {
     sections.push(`# This message only\n${ctx.directives.join('\n')}`)
   }
@@ -97,13 +132,30 @@ export function renderMoiContext(ctx: MoiContext): string {
   return `${MOI_CONTEXT_OPEN}\n${renderMoiContextBody(ctx)}\n${MOI_CONTEXT_CLOSE}`
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 // Wire-shape guard for the chat frame's `context` field (see web.ts).
 export function isMoiContext(value: unknown): value is MoiContext {
-  if (typeof value !== 'object' || value === null) return false
-  const v = value as { activeTab?: unknown; tabTitle?: unknown; directives?: unknown }
+  if (!isRecord(value)) return false
+  const v = value as {
+    activeTab?: unknown
+    tabTitle?: unknown
+    tabParams?: unknown
+    intent?: unknown
+    directives?: unknown
+  }
+  const intentOk =
+    v.intent === undefined ||
+    (isRecord(v.intent) &&
+      typeof v.intent.source === 'string' &&
+      (v.intent.context === undefined || isRecord(v.intent.context)))
   return (
     typeof v.activeTab === 'string' &&
     (v.tabTitle === undefined || typeof v.tabTitle === 'string') &&
+    (v.tabParams === undefined || isRecord(v.tabParams)) &&
+    intentOk &&
     (v.directives === undefined ||
       (Array.isArray(v.directives) && v.directives.every(d => typeof d === 'string')))
   )

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,11 @@ export type ViewConfig = {
   icon?: string
   // Advisory env hints, same semantics as WidgetConfig.requiredEnv.
   requiredEnv?: string[]
+  // Declared focus-param contract: param name → one-line description. Advisory
+  // metadata surfaced by `moi tabs` so an agent knows what a `moi focus
+  // view:<id> --params` call can pass. Never enforced — the mounted view
+  // receives whatever the focus intent carried (see docs/intents.md).
+  params?: Record<string, string>
 }
 
 export type ViewInfo = {
@@ -450,6 +455,25 @@ export type WorkspaceTabId =
 export type WorkspaceTabsState = {
   open: WorkspaceTabId[]
   active: WorkspaceTabId
+}
+
+// One row of the `moi tabs` manifest: a static tab or a built view, with the
+// view's declared focus params (name → description) when it has any.
+export type WorkspaceTabInfo = {
+  id: WorkspaceTabId
+  title: string
+  params?: Record<string, string>
+}
+
+// The host-installed applet runtime bridge (`window.moi`). Applet code reaches
+// it through the `focus`/`sendAction` stubs of the `moi` module baked into
+// every bundle (server/bundler/build-applet.ts); the host binds it to the
+// mounted workspace (client/features/workspace/intents.ts). `source` names the
+// applet an action originated from (e.g. `view:shop`) — the module stub fills
+// it in, so applet authors never pass it.
+export type MoiAppletRuntime = {
+  focus: (tab: WorkspaceTabId, params?: Record<string, unknown>) => void
+  sendAction: (label: string, context?: Record<string, unknown>, source?: string) => void
 }
 
 export type { FontTheme, ColorTheme } from './themes'

--- a/server/bundler/build-applet.ts
+++ b/server/bundler/build-applet.ts
@@ -99,6 +99,33 @@ function findConfigProperties(source: string) {
   return init.properties
 }
 
+// `params`: a view's declared focus-param contract — an object literal of
+// param name → one-line description, both strings. Advisory only — surfaced by
+// `moi tabs`, never enforced at focus time.
+function readParamsMap(propValue: unknown): Record<string, string> | undefined {
+  const value = propValue as { type?: string; properties?: unknown[] }
+  if (value?.type !== 'ObjectExpression') return undefined
+  const out: Record<string, string> = {}
+  for (const raw of value.properties ?? []) {
+    const prop = raw as {
+      type?: string
+      key?: { type?: string; name?: string; value?: unknown }
+      value?: { type?: string; value?: unknown }
+    }
+    if (prop?.type !== 'Property') continue
+    const key =
+      prop.key?.type === 'Identifier'
+        ? prop.key.name
+        : prop.key?.type === 'Literal' && typeof prop.key.value === 'string'
+          ? prop.key.value
+          : undefined
+    if (!key) continue
+    if (prop.value?.type !== 'Literal' || typeof prop.value.value !== 'string') continue
+    out[key] = prop.value.value
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
 // `requiredEnv`: an array of string literals naming env vars the bundle needs.
 // Advisory only — surfaced in the env UI, never enforced at build/load.
 function readRequiredEnv(propValue: unknown): string[] | undefined {
@@ -147,8 +174,9 @@ export async function extractWidgetConfig(srcPath: string): Promise<WidgetConfig
   return { ...DEFAULT_CONFIG, ...result }
 }
 
-// A view's config: `title` + app icon registry id + advisory `requiredEnv`.
-// No sizing — views are full-screen. Returns null when no `config` export is present.
+// A view's config: `title` + app icon registry id + advisory `requiredEnv` +
+// declared focus `params`. No sizing — views are full-screen. Returns null
+// when no `config` export is present.
 export async function extractViewConfig(srcPath: string): Promise<ViewConfig | null> {
   const source = await Bun.file(srcPath).text()
 
@@ -165,6 +193,11 @@ export async function extractViewConfig(srcPath: string): Promise<ViewConfig | n
       if (prop.value?.type === 'Literal' && typeof prop.value.value === 'string') {
         result[key] = prop.value.value
       }
+      continue
+    }
+    if (key === 'params') {
+      const params = readParamsMap(prop.value)
+      if (params) result.params = params
       continue
     }
     if (key === 'requiredEnv') {
@@ -231,19 +264,35 @@ export function rpc(module, name) {
 }
 `
 
-// The `moi` virtual module — the applet-facing runtime API. Today just
-// `fileUrl(path)`, which maps a workspace-relative path to its streaming URL
-// (`/api/workspaces/<id>/fs/<path>`). Same sentinel base as RPC; the path is
-// per-segment URL-encoded so spaces / unicode in filenames survive. A leading
-// slash is stripped so both `clips/a.mp4` and `/clips/a.mp4` work.
-const MOI_MODULE_SOURCE = `
+// The `moi` virtual module — the applet-facing runtime API:
+//   • `fileUrl(path)` maps a workspace-relative path to its streaming URL
+//     (`/api/workspaces/<id>/fs/<path>`). Same sentinel base as RPC; the path
+//     is per-segment URL-encoded so spaces / unicode in filenames survive. A
+//     leading slash is stripped so both `clips/a.mp4` and `/clips/a.mp4` work.
+//   • `focus(tab, params?)` / `sendAction(label, context?)` delegate to the
+//     host-installed intent bridge (`window.moi`, see MoiAppletRuntime in
+//     lib/types.ts) and no-op outside the moi host. `SOURCE` is this applet's
+//     own `<kind>:<name>` id, baked in so actions self-attribute without the
+//     author passing anything.
+function moiModuleSource(source: string): string {
+  return `
 const BASE = ${JSON.stringify(APPLET_API_BASE_SENTINEL)};
+const SOURCE = ${JSON.stringify(source)};
 
 export function fileUrl(path) {
   const clean = String(path).replace(/^\\/+/, "");
   return BASE + "/fs/" + clean.split("/").map(encodeURIComponent).join("/");
 }
+
+export function focus(tab, params) {
+  window.moi?.focus(tab, params);
+}
+
+export function sendAction(label, context) {
+  window.moi?.sendAction(label, context, SOURCE);
+}
 `
+}
 
 // Server modules are keyed by their path relative to the moi root
 // (`.moi/widgets/hello.server.ts` → `"widgets/hello"`), posix-normalized so
@@ -272,13 +321,15 @@ function serverModuleKey(serverPath: string, moiRoot: string): string {
 
 // The applet runtime plugin wires the three I/O transports into the bundle:
 //   • `.server` imports → RPC stubs (via the `mei:rpc` virtual module)
-//   • `moi` import      → the `fileUrl` runtime
+//   • `moi` import      → the `fileUrl` + intent (`focus`/`sendAction`) runtime
 //   • asset imports     → content-hashed sibling files, referenced by URL
 // It returns the collected server modules (for hot-reload + env aggregation)
-// and the asset files the caller must emit next to `index.js`.
+// and the asset files the caller must emit next to `index.js`. `appletSource`
+// is the applet's `<kind>:<name>` id, baked into `sendAction` for attribution.
 function appletRuntimePlugin(
   sourceDir: string,
-  moiRoot: string
+  moiRoot: string,
+  appletSource: string
 ): {
   plugin: BunPlugin
   serverModules: ServerModule[]
@@ -313,10 +364,11 @@ function appletRuntimePlugin(
         path: Bun.resolveSync('devalue', import.meta.dir)
       }))
 
-      // The `moi` runtime module (fileUrl). A bare specifier, so match it exactly.
+      // The `moi` runtime module (fileUrl + intents). A bare specifier, so
+      // match it exactly.
       build.onResolve({ filter: /^moi$/ }, () => ({ path: 'moi', namespace: 'moi-runtime' }))
       build.onLoad({ filter: /.*/, namespace: 'moi-runtime' }, () => ({
-        contents: MOI_MODULE_SOURCE,
+        contents: moiModuleSource(appletSource),
         loader: 'js'
       }))
 
@@ -529,7 +581,11 @@ export async function buildApplet(
 
   await prevalidateServerFiles(entrypoint)
 
-  const { plugin: runtime, serverModules, assets } = appletRuntimePlugin(sourceDir, moiRoot)
+  const {
+    plugin: runtime,
+    serverModules,
+    assets
+  } = appletRuntimePlugin(sourceDir, moiRoot, `${kind}:${widgetName}`)
   const syntheticCssPath = await writeSyntheticTailwindCss(entrypoint, moiRoot, kind)
 
   let result: Awaited<ReturnType<typeof Bun.build>>

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -18,7 +18,8 @@ import type {
   ScratchOp,
   ScratchSize,
   ScratchStyle,
-  WorkspaceEntry
+  WorkspaceEntry,
+  WorkspaceTabInfo
 } from '@/lib/types'
 
 import {
@@ -598,6 +599,100 @@ const refresh = defineCommand({
       console.error('Could not connect to control server. Is the main process running?')
       process.exit(1)
     }
+  }
+})
+
+// ---- intents (docs/intents.md) ----------------------------------------------
+
+const tabs = defineCommand({
+  meta: {
+    name: 'tabs',
+    description: 'List workspace tabs — static tabs and views with their declared params'
+  },
+  args: {
+    dir: {
+      type: 'positional',
+      default: '.',
+      description: 'Workspace directory (default: current)'
+    }
+  },
+  run({ args }) {
+    const path = resolve(args.dir)
+    sendControl(path, { type: 'tabs', path }, res => {
+      const tabList = (Array.isArray(res.tabs) ? res.tabs : []) as WorkspaceTabInfo[]
+      console.log('\n' + pc.bold('moi tabs') + pc.dim(` — ${tabList.length} tabs`) + '\n')
+      // One row per tab; a view's declared params continue on indented rows so
+      // the table stays scannable for an agent.
+      const rows: string[][] = []
+      for (const tab of tabList) {
+        const params = Object.entries(tab.params ?? {})
+        rows.push([pc.cyan(tab.id), tab.title, params.length ? paramCell(params[0]) : ''])
+        for (const param of params.slice(1)) rows.push(['', '', paramCell(param)])
+      }
+      console.log(
+        columns(
+          ['tab', 'title', 'params'].map(h => pc.dim(h)),
+          rows
+        )
+      )
+      console.log(
+        '\n' + pc.dim('  Focus one with `moi focus <tab-id> [--params \'{"k":"v"}\']`.') + '\n'
+      )
+    })
+  }
+})
+
+function paramCell([name, description]: [string, string]): string {
+  return `${name} ${pc.dim('— ' + description)}`
+}
+
+const focus = defineCommand({
+  meta: {
+    name: 'focus',
+    description: 'Focus a workspace tab in open browser tabs, optionally passing view params'
+  },
+  args: {
+    tab: {
+      type: 'positional',
+      required: true,
+      description: 'Tab id from `moi tabs`, e.g. view:shop or scratchpad'
+    },
+    params: {
+      type: 'string',
+      description: 'Param values as one JSON object, e.g. \'{"product":"scarf"}\''
+    },
+    dir: {
+      type: 'string',
+      default: '.',
+      description: 'Workspace directory (default: current)'
+    }
+  },
+  run({ args }) {
+    const path = resolve(args.dir)
+    let params: Record<string, unknown> | undefined
+    if (args.params) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(args.params)
+      } catch (err) {
+        console.error(
+          '\n' +
+            pc.red('✗') +
+            ` --params is not valid JSON: ${err instanceof Error ? err.message : String(err)}\n`
+        )
+        process.exit(1)
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        console.error(
+          '\n' + pc.red('✗') + ' --params must be one JSON object, e.g. \'{"product":"scarf"}\'\n'
+        )
+        process.exit(1)
+      }
+      params = parsed as Record<string, unknown>
+    }
+    sendControl(path, { type: 'intent:focus', path, tab: args.tab, params }, res => {
+      console.log('\n' + pc.green('✓') + ' Focused ' + pc.bold(String(res.tab)) + '\n')
+    })
   }
 })
 
@@ -1960,6 +2055,8 @@ const main = defineCommand({
     bundle,
     builder,
     refresh,
+    tabs,
+    focus,
     'call-server-fn': callServerFn,
     debug,
     theme,

--- a/server/control.ts
+++ b/server/control.ts
@@ -18,7 +18,7 @@ import { relayScratchOp } from './scratchpad-relay'
 import { broadcastAll } from './state'
 import { applyThemeUpdate, matchColorTheme } from './theme'
 import { handleBundle } from './widgets'
-import { getViewList, handleBundleViews, hasViewId } from './views'
+import { assembleWorkspaceTabs, getViewList, handleBundleViews, hasViewId } from './views'
 import {
   ViewBuilderError,
   listViewBuilders,
@@ -260,6 +260,50 @@ export const control = Bun.serve({
               })
             )
           }
+          return
+        }
+
+        // `moi tabs` — the workspace tab manifest (static tabs + built views
+        // with their declared focus params). See docs/intents.md.
+        if (data.type === 'tabs') {
+          const match = await resolveWorkspace(ws, data.path)
+          if (!match) return
+          ws.send(
+            JSON.stringify({ ok: true, tabs: assembleWorkspaceTabs(await getViewList(match.path)) })
+          )
+          return
+        }
+
+        // `moi focus <tab-id>` — a focus intent: broadcast to the workspace's
+        // open tabs, which switch to `tab` and hand it `params`. The tab is
+        // validated here (cheap) so an agent typo gets a corrective error
+        // instead of a silent no-op in the browser.
+        if (data.type === 'intent:focus') {
+          const match = await resolveWorkspace(ws, data.path)
+          if (!match) return
+          const tab = String(data.tab ?? '')
+          const params =
+            data.params && typeof data.params === 'object' && !Array.isArray(data.params)
+              ? (data.params as Record<string, unknown>)
+              : undefined
+          const isStatic = tab === 'agent' || tab === 'widgets' || tab === 'scratchpad'
+          const isView = tab.startsWith('view:')
+          if (!isStatic && (!isView || !(await hasViewId(match.path, tab.slice('view:'.length))))) {
+            const known = assembleWorkspaceTabs(await getViewList(match.path)).map(t => t.id)
+            ws.send(
+              JSON.stringify({
+                error: `Unknown tab "${tab}". Valid tabs: ${known.join(', ')}. Run \`moi tabs\` for details.`
+              })
+            )
+            return
+          }
+          publishEvent({
+            type: 'intent:focus',
+            workspaceId: match.id,
+            tab,
+            ...(params ? { params } : {})
+          })
+          ws.send(JSON.stringify({ ok: true, tab }))
           return
         }
 

--- a/server/test/__fixtures__/with-intents.tsx
+++ b/server/test/__fixtures__/with-intents.tsx
@@ -1,0 +1,10 @@
+import { focus, sendAction } from 'moi'
+
+export default function WithIntents() {
+  return (
+    <div>
+      <button onClick={() => focus('view:shop', { product: 'scarf' })}>Open</button>
+      <button onClick={() => sendAction('Reorder milk', { sku: 'milk-1l' })}>Reorder</button>
+    </div>
+  )
+}

--- a/server/test/__fixtures__/with-view-params.tsx
+++ b/server/test/__fixtures__/with-view-params.tsx
@@ -1,0 +1,12 @@
+export const config = {
+  title: 'Shop',
+  icon: 'cart',
+  params: {
+    product: 'Product slug shown in the detail pane',
+    'detail-tab': 'Which detail tab is open: overview or reviews'
+  }
+} as const
+
+export default function Shop() {
+  return <div>shop</div>
+}

--- a/server/test/build-applet.test.ts
+++ b/server/test/build-applet.test.ts
@@ -273,6 +273,24 @@ describe('extractViewConfig', () => {
     // with-config.tsx exports { rowSpan, colSpan } — none of which a view honors.
     expect(await extractViewConfig(join(FIXTURES, 'with-config.tsx'))).toEqual({})
   })
+
+  test('extracts the declared params map (identifier and string-literal keys)', async () => {
+    const config = await extractViewConfig(join(FIXTURES, 'with-view-params.tsx'))
+    expect(config).toEqual({
+      title: 'Shop',
+      icon: 'cart',
+      params: {
+        product: 'Product slug shown in the detail pane',
+        'detail-tab': 'Which detail tab is open: overview or reviews'
+      }
+    })
+  })
+
+  test('omits params when the map is empty or not string → string', async () => {
+    // with-view-config.tsx declares no params at all.
+    const config = await extractViewConfig(join(FIXTURES, 'with-view-config.tsx'))
+    expect(config?.params).toBeUndefined()
+  })
 })
 
 describe("buildApplet kind='view'", () => {
@@ -321,6 +339,17 @@ describe('moi fileUrl module', () => {
     expect(result.js).toContain('function fileUrl')
     expect(result.js).toContain('%%MOI_APPLET_API_BASE%%')
     expect(result.js).toContain('"/fs/"')
+  })
+})
+
+describe('moi intent stubs', () => {
+  test('focus/sendAction delegate to window.moi with the applet source baked in', async () => {
+    const result = await buildApplet(join(FIXTURES, 'with-intents.tsx'), undefined, 'view')
+    // Both stubs go through the host bridge and never throw outside the host.
+    expect(result.js).toContain('window.moi?.focus')
+    expect(result.js).toContain('window.moi?.sendAction')
+    // sendAction self-attributes with this applet's `<kind>:<name>` id.
+    expect(result.js).toContain('"view:with-intents"')
   })
 })
 

--- a/server/test/moi-context.test.ts
+++ b/server/test/moi-context.test.ts
@@ -68,6 +68,37 @@ describe('moi context envelope', () => {
     expect(stripMoiContext(pasted)).toBe('Look at this:\n\nweird right?')
   })
 
+  test('renders active-view params as a sentence + fenced JSON', () => {
+    const rendered = renderMoiContext({
+      activeTab: 'view:shop',
+      tabTitle: 'Shop',
+      tabParams: { product: 'scarf' }
+    })
+    expect(rendered).toContain('The user is on the "Shop" view tab (.moi/views/shop.tsx).')
+    expect(rendered).toContain(
+      'The view currently shows these param values:\n```json\n{"product":"scarf"}\n```'
+    )
+    // Empty params render nothing extra.
+    expect(renderMoiContext({ activeTab: 'view:shop', tabParams: {} })).not.toContain(
+      'param values'
+    )
+  })
+
+  test('renders an applet action as its own section with fenced context', () => {
+    const rendered = renderMoiContext({
+      activeTab: 'view:shop',
+      intent: { source: 'view:shop', context: { sku: 'milk-1l' } }
+    })
+    expect(rendered).toContain(
+      '# Applet action\nThe user fired this message with an action in "view:shop" — the message text is the action\'s label, not typed by the user.'
+    )
+    expect(rendered).toContain('The applet attached this context:\n```json\n{"sku":"milk-1l"}\n```')
+    // A context-less action still gets the attribution sentence, minus the JSON.
+    const bare = renderMoiContext({ activeTab: 'widgets', intent: { source: 'widget:orders' } })
+    expect(bare).toContain('an action in "widget:orders"')
+    expect(bare).not.toContain('attached this context')
+  })
+
   test('renders directives under a this-message-only section', () => {
     const rendered = renderMoiContext({
       activeTab: 'view-builder:builder-1',
@@ -97,6 +128,23 @@ describe('moi context envelope', () => {
     expect(isMoiContext('rendered text')).toBe(false)
     expect(isMoiContext({ tabTitle: 'CRM' })).toBe(false)
     expect(isMoiContext({ activeTab: 'agent', directives: [1] })).toBe(false)
+  })
+
+  test('wire guard validates tabParams and intent shapes', () => {
+    expect(isMoiContext({ activeTab: 'view:shop', tabParams: { product: 'scarf' } })).toBe(true)
+    expect(
+      isMoiContext({
+        activeTab: 'view:shop',
+        intent: { source: 'view:shop', context: { sku: 1 } }
+      })
+    ).toBe(true)
+    expect(isMoiContext({ activeTab: 'view:shop', intent: { source: 'view:shop' } })).toBe(true)
+    expect(isMoiContext({ activeTab: 'view:shop', tabParams: ['scarf'] })).toBe(false)
+    expect(isMoiContext({ activeTab: 'view:shop', intent: { context: {} } })).toBe(false)
+    expect(isMoiContext({ activeTab: 'view:shop', intent: { source: 1 } })).toBe(false)
+    expect(isMoiContext({ activeTab: 'view:shop', intent: { source: 'x', context: 'y' } })).toBe(
+      false
+    )
   })
 
   test('loose strip handles truncated envelopes in previews', () => {

--- a/server/test/workspace-tabs.test.ts
+++ b/server/test/workspace-tabs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ViewInfo } from '@/lib/types'
+
+import { assembleWorkspaceTabs } from '../views'
+
+describe('assembleWorkspaceTabs', () => {
+  test('static tabs alone when the workspace has no views', () => {
+    expect(assembleWorkspaceTabs([])).toEqual([
+      { id: 'agent', title: 'Agent' },
+      { id: 'widgets', title: 'Widgets' },
+      { id: 'scratchpad', title: 'Scratchpad' }
+    ])
+  })
+
+  test('appends views in list order with titles and declared params', () => {
+    const views: ViewInfo[] = [
+      {
+        id: 'shop',
+        config: { title: 'Shop', params: { product: 'Product slug shown in the detail pane' } }
+      },
+      { id: 'crm', config: { title: '' } }
+    ]
+    const tabList = assembleWorkspaceTabs(views)
+    expect(tabList.slice(3)).toEqual([
+      {
+        id: 'view:shop',
+        title: 'Shop',
+        params: { product: 'Product slug shown in the detail pane' }
+      },
+      // No title falls back to the id; no params key when none are declared.
+      { id: 'view:crm', title: 'crm' }
+    ])
+  })
+})

--- a/server/views.ts
+++ b/server/views.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 
-import type { ViewConfig, ViewInfo } from '@/lib/types'
+import type { ViewConfig, ViewInfo, WorkspaceTabInfo } from '@/lib/types'
 
 import { syncAppletLogAfterBuild } from './applet-log'
 import { buildApplets, getAppletPaths, listBuilt, scanSources, serveApplet } from './applets'
@@ -106,15 +106,36 @@ export async function getViewList(workspacePath: string): Promise<ViewInfo[]> {
     const raw = manifest.config[id] ?? {}
     const icon = typeof raw.icon === 'string' && raw.icon ? raw.icon : undefined
     const requiredEnv = Array.isArray(raw.requiredEnv) ? raw.requiredEnv : undefined
+    const params =
+      raw.params && typeof raw.params === 'object' && Object.keys(raw.params).length > 0
+        ? raw.params
+        : undefined
     return {
       id,
       config: {
         title: raw.title || id,
         ...(icon ? { icon } : {}),
-        ...(requiredEnv ? { requiredEnv } : {})
+        ...(requiredEnv ? { requiredEnv } : {}),
+        ...(params ? { params } : {})
       }
     }
   })
+}
+
+// The `moi tabs` manifest: the static tabs plus one row per built view (nav
+// order), each view carrying its declared focus params. Pure assembly from a
+// view list so it unit-tests without a workspace on disk.
+export function assembleWorkspaceTabs(views: ViewInfo[]): WorkspaceTabInfo[] {
+  return [
+    { id: 'agent', title: 'Agent' },
+    { id: 'widgets', title: 'Widgets' },
+    { id: 'scratchpad', title: 'Scratchpad' },
+    ...views.map<WorkspaceTabInfo>(view => ({
+      id: `view:${view.id}`,
+      title: view.config.title || view.id,
+      ...(view.config.params ? { params: view.config.params } : {})
+    }))
+  ]
 }
 
 export async function hasViewId(workspacePath: string, viewId: string): Promise<boolean> {

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -112,6 +112,8 @@ never from inside `.moi/` itself. You don't pass paths; moi resolves the workspa
 - `moi bundle --force` — rebuild all applets (use after changing `config`)
 - `moi refresh` — re-fetch widget/view data without rebuilding (use after you mutated data the
   widgets read — DB rows, files, external API records — so the displayed values catch up)
+- `moi tabs` — list the workspace tabs: static tabs plus every view with its declared params
+- `moi focus <tab-id> [--params '<json>']` — switch the user's UI to a tab (see Intents)
 - `moi call-server-fn <module>/<fn> '[args]'` — invoke a `.server.ts` function directly (smoke test)
 - `moi debug logs` — applet runtime errors on record (experimental)
 - `moi theme --font=<key>` — change font theme (omit `--font` to list options)
@@ -316,6 +318,59 @@ export const config = {
 The inverse of a widget: a view **owns its whole page** — its own `h-full w-full` layout, scrolling
 (`overflow-auto`), padding, and chrome. Build it to read like an app screen. See `VIEW-DESIGN.md`.
 
+# Intents — connecting chat, widgets, and views
+
+Tabs are addressable by id: `agent`, `widgets`, `scratchpad`, `view:<id>`. Run `moi tabs` to list
+them with each view's declared params. Keep a current picture of what exists in the workspace —
+check `moi tabs` before wiring anything to a tab id.
+
+## View params
+
+Declare `params` in a view's config when the view has addressable state (a selected record, an
+active filter, a sub-page). Param name → one-line description, both strings:
+
+```ts
+export const config = {
+  title: 'Shop',
+  icon: 'cart',
+  params: { product: 'Product slug shown in the detail pane' }
+} as const
+```
+
+The mounted view receives the current values as a `params` prop — `Record<string, unknown>`, `{}`
+until a focus intent sets them, reset on page reload — so always handle the empty case:
+
+```tsx
+export default function Shop({ params = {} }: { params?: Record<string, unknown> }) {
+  const product = typeof params.product === 'string' ? params.product : null
+  // product === null → render the index; otherwise the detail pane
+}
+```
+
+`params` is config, so run `moi bundle --force` after changing the declaration.
+
+## Navigate: `moi focus` (you) and `focus` (applet code)
+
+- `moi focus view:shop --params '{"product":"scarf"}'` — switch the user's open workspace UI to
+  that tab and hand the view its params. Use it to show the user what you're talking about. An
+  unknown tab id fails with the list of valid ids.
+- In applet code: `import { focus } from 'moi'`, then `focus(tab, params?)` — e.g. a widget row
+  opening its detail view: `focus('view:shop', { product: row.slug })`.
+- Before wiring a widget button that focuses a view, check the target view's declared params with
+  `moi tabs`; if the param you need is missing, edit the view to accept and declare it **first**.
+
+## Applet → chat: `sendAction`
+
+`import { sendAction } from 'moi'`, then `sendAction(label, context?)` sends a chat message from
+applet UI. The user sees `label` as their own message; `context` reaches you inside the hidden
+`<moi-context>` envelope under `# Applet action`, together with which applet fired it. Keep the
+label a short user-readable action ("Reorder milk") and put ids/state in `context`, never in the
+label. If a run is already in progress the label is parked in the composer as a draft instead (its
+`context` is dropped), so don't rely on an action arriving instantly.
+
+The envelope is symmetric: while a view with params is active, the user's own messages carry the
+current param values — "make this cheaper" arrives with `{"product":"scarf"}` attached.
+
 # Keeping this skill current
 
 This skill is installed with moi (via the CLI or the UI) and can fall behind when the moi CLI updates.
@@ -328,4 +383,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.7.0" />
+<moi-skill version="0.8.0" />


### PR DESCRIPTION
Implements the address-based intent system from the Jul 22 design discussion, MVP scope: chat/agent, widgets, and views can now communicate. The agent (or an applet) can focus any tab with params (`moi focus view:shop --params '{"product":"scarf"}'`), views declare a `params` contract in their config and receive live values as a `params` prop, and applet buttons can fire a prompt into the chat (`sendAction`) whose structured payload rides the `moi-context` envelope instead of the visible text. Every chat send now also reports the active view's current param values back to the agent, and `moi tabs` prints the workspace's tab + params manifest.

Sample of what the agent sees after an applet action (inside the `<moi-context>` envelope):

```
# Active tab
The user is on the "Shop" view tab (.moi/views/shop.tsx).
The view currently shows these param values:
{"product":"scarf"}

# Applet action
The user fired this message with an action in "view:shop" — the message text is the action's label, not typed by the user.
The applet attached this context:
{"sku":"scarf-red","price":4900}
```

Applet API: `focus(tab, params?)` and `sendAction(label, context?)` from the `moi` module (bundler stubs delegate to a host-installed `window.moi` bridge). Busy chat parks the action label as a composer draft instead of interrupting or dropping. Design notes and deliberate deferrals (queueing, per-client focus scoping, URL persistence) in `docs/intents.md`; alternative capability-based design in a sibling PR for comparison.

Reviewer focus:
- `bindWorkspaceIntents` lifecycle (`client/features/workspace/intents.ts` + WorkspaceScreen effect): `window.moi` install/cleanup ordering under StrictMode double-mount and workspace switches.
- Busy-path draft parking overwrites any half-typed draft and drops the structured context — accepted MVP roughness.
- `moi` module stubs in `build-applet.ts` reference `window`; existing bundles keep working but only expose the new functions after a rebuild.

Verified: `bun test` 566 pass / 0 fail (62 files), `typecheck:client`, `lint`, and `format:check` all clean. No dev-server run (unit-level verification only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do2RQTJD9HtNQqLP8Lr2Bt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Do2RQTJD9HtNQqLP8Lr2Bt)_