### PR TITLE
Add capability-based intents: views declare, applets dispatch by name

### DIFF
--- a/client/features/applets/useApplet.ts
+++ b/client/features/applets/useApplet.ts
@@ -12,11 +12,14 @@ import {
 import { reportAppletError } from '@/client/features/applets/applet-log'
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { type WorkspaceEvent, useWorkspaceEvent } from '@/client/runtime/useWorkspaceEvents'
-import type { AppletKind } from '@/lib/types'
+import type { AppletKind, ViewIntentProps } from '@/lib/types'
 
+// Applet components take the (all-optional) intent-delivery props — views
+// receive them when a dispatch routes to them (docs/intents.md); widgets are
+// simply mounted without any.
 type AppletState =
   | { status: 'loading'; version: number }
-  | { status: 'ready'; Component: ComponentType; version: number }
+  | { status: 'ready'; Component: ComponentType<ViewIntentProps>; version: number }
   | { status: 'error'; error: string; version: number }
 
 // An applet kind (widget / view) differs only in its URL path segment and which
@@ -47,9 +50,9 @@ function loadApplet(
   segment: AppletSegment,
   workspaceId: string,
   name: string
-): Promise<ComponentType> {
+): Promise<ComponentType<ViewIntentProps>> {
   const key = appletKey(segment, workspaceId, name)
-  const existing = getCachedApplet(key) as Promise<ComponentType> | undefined
+  const existing = getCachedApplet(key) as Promise<ComponentType<ViewIntentProps>> | undefined
   if (existing) return existing
 
   // Import the bundle dir's `index.js` at its current `?v`; the version is bumped
@@ -57,7 +60,7 @@ function loadApplet(
   // while this applet is unmounted — so a backgrounded tab never serves stale.
   const promise = import(/* @vite-ignore */ appletUrl(segment, workspaceId, name)).then(mod => {
     if (!mod.default) throw new Error(`"${name}" has no default export`)
-    return mod.default as ComponentType
+    return mod.default as ComponentType<ViewIntentProps>
   })
 
   setCachedApplet(key, promise)

--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -31,9 +31,17 @@ import { useWorkspaceAvailability } from '@/client/features/workspace/api'
 import { useWorkspaceTheme } from '@/client/features/workspace/useWorkspaceTheme'
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
+import {
+  routeIntentDispatch,
+  useDeliveredIntent,
+  useMoiAppletRuntime
+} from '@/client/features/workspace/intents'
+import { pushIntentAction } from '@/client/features/workspace/moi-context'
 import { resolveAppIcon } from '@/client/lib/app-icon-registry'
 import { cn } from '@/client/lib/cn'
 import { liveStore } from '@/client/features/chat/chat-store'
+import { useWorkspaceEvent } from '@/client/runtime/useWorkspaceEvents'
+import type { IntentDispatch } from '@/lib/intents'
 import {
   type CreateWorkspaceTabItem,
   type WorkspaceTabItem,
@@ -99,10 +107,12 @@ type ViewAppProps = {
 
 // A view — an agent-defined app — mounted full-area. The bundle owns its own
 // layout + scroll, so we give it a plain filled box and fade it in (mirroring
-// WidgetShell, but full-area instead of a grid cell).
+// WidgetShell, but full-area instead of a grid cell). A routed intent reaches
+// the component as `intent`/`params` props (docs/intents.md).
 function ViewApp({ view }: ViewAppProps) {
   const workspaceId = useWorkspaceId()
   const bundle = useView(view.id)
+  const delivered = useDeliveredIntent(workspaceId, view.id)
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
@@ -128,7 +138,9 @@ function ViewApp({ view }: ViewAppProps) {
                 workspaceId={workspaceId}
                 resetKey={bundle.version}
               >
-                <bundle.Component />
+                <bundle.Component
+                  {...(delivered ? { intent: delivered.intent, params: delivered.params } : {})}
+                />
               </WidgetErrorBoundary>
             </motion.div>
           </AppletMount>
@@ -453,6 +465,43 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
     }
     setChatFocusRequest(request => request + 1)
   }
+
+  // Intent routing (docs/intents.md): CLI dispatches arrive as workspace
+  // events; applet dispatches come through the `window.moi` runtime installed
+  // below. Both resolve against the loaded view configs and land on the
+  // declaring view's tab.
+  const routeDispatch = (dispatch: IntentDispatch) =>
+    routeIntentDispatch({ workspaceId, views, openTab }, dispatch)
+
+  useWorkspaceEvent(event => {
+    if (event.type === 'intent:dispatch' && event.workspaceId === workspaceId) {
+      routeDispatch({
+        name: event.name,
+        ...(event.params ? { params: event.params } : {}),
+        source: event.source
+      })
+    }
+  })
+
+  useMoiAppletRuntime({
+    dispatch: routeDispatch,
+    sendAction: (label, context, source) => {
+      const text = label.trim()
+      if (!text) return
+      if (processing) {
+        // A run is in flight: don't interrupt, don't drop — park the label as
+        // the composer draft and surface the chat. The structured context is
+        // lost on this path (an MVP tradeoff; see docs/intents.md).
+        openChat(text)
+        return
+      }
+      // Idle: send now. The label is the visible message text; the structured
+      // payload rides the next envelope via the one-shot intent-action queue.
+      pushIntentAction(workspaceId, { source, ...(context ? { context } : {}) })
+      send(text)
+      openChat()
+    }
+  })
 
   const createItems: CreateWorkspaceTabItem[] = [
     ...(!dockedSplit && !openSet.has('agent')

--- a/client/features/workspace/intents.test.ts
+++ b/client/features/workspace/intents.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+
+import { appletFromSource, intentStore, routeIntentDispatch } from './intents'
+import type { ViewInfo, WorkspaceTabId } from '@/lib/types'
+
+const views: ViewInfo[] = [
+  { id: 'crm', config: { title: 'CRM', intents: [{ name: 'open-customer' }] } },
+  { id: 'orders', config: { title: 'Orders', intents: [{ name: 'open-order' }] } }
+]
+
+describe('routeIntentDispatch', () => {
+  test('routes to the declaring view: delivers the payload and opens its tab', () => {
+    const opened: WorkspaceTabId[] = []
+    const resolved = routeIntentDispatch(
+      { workspaceId: 'ws-1', views, openTab: tab => opened.push(tab) },
+      { name: 'open-order', params: { id: 'o-7' }, source: 'widget:products' }
+    )
+    expect(resolved).toBe(true)
+    expect(opened).toEqual(['view:orders'])
+    expect(intentStore.getState().delivered['ws-1:orders']).toEqual({
+      intent: 'open-order',
+      params: { id: 'o-7' }
+    })
+  })
+
+  test('params default to an empty object', () => {
+    routeIntentDispatch(
+      { workspaceId: 'ws-1', views, openTab: () => {} },
+      { name: 'open-customer', source: 'cli' }
+    )
+    expect(intentStore.getState().delivered['ws-1:crm']).toEqual({
+      intent: 'open-customer',
+      params: {}
+    })
+  })
+
+  test('a later dispatch to the same view replaces the delivered intent', () => {
+    const ctx = { workspaceId: 'ws-2', views, openTab: () => {} }
+    routeIntentDispatch(ctx, { name: 'open-order', params: { id: 'a' }, source: 'cli' })
+    routeIntentDispatch(ctx, { name: 'open-order', params: { id: 'b' }, source: 'cli' })
+    expect(intentStore.getState().delivered['ws-2:orders']).toEqual({
+      intent: 'open-order',
+      params: { id: 'b' }
+    })
+  })
+
+  test('an unresolved dispatch delivers nothing and switches no tab', () => {
+    const opened: WorkspaceTabId[] = []
+    const before = intentStore.getState().delivered
+    const resolved = routeIntentDispatch(
+      { workspaceId: 'ws-3', views, openTab: tab => opened.push(tab) },
+      { name: 'close-ticket', source: 'widget:products' }
+    )
+    // The journal report is fire-and-forget (POST /applet-log); observable
+    // behavior here is: no resolution, no tab switch, no delivery.
+    expect(resolved).toBe(false)
+    expect(opened).toEqual([])
+    expect(intentStore.getState().delivered).toEqual(before)
+  })
+})
+
+describe('appletFromSource', () => {
+  test('parses applet sources for journal attribution', () => {
+    expect(appletFromSource('widget:products')).toEqual({ kind: 'widget', name: 'products' })
+    expect(appletFromSource('view:crm')).toEqual({ kind: 'view', name: 'crm' })
+  })
+
+  test('non-applet sources attribute to nothing', () => {
+    expect(appletFromSource('cli')).toBeNull()
+    expect(appletFromSource('applet')).toBeNull()
+    expect(appletFromSource('widget:')).toBeNull()
+    expect(appletFromSource('widget:bad name')).toBeNull()
+  })
+})

--- a/client/features/workspace/intents.ts
+++ b/client/features/workspace/intents.ts
@@ -1,0 +1,124 @@
+// Client half of the intent system (docs/intents.md): resolve a dispatch to
+// the first view declaring its name, switch the active tab, and hand the
+// payload to the mounted view component as props. Delivered state is
+// ephemeral in-memory — never persisted into the workspace layout — so a
+// reload clears it. The `window.moi` runtime installed here is what applet
+// bundles reach through the `moi` virtual module's `intent`/`sendAction`.
+import { useEffect, useRef } from 'react'
+
+import { useStore } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+
+import { matchBundleUrl, reportAppletError } from '@/client/features/applets/applet-log'
+import { resolveIntentView } from '@/lib/intents'
+import type { IntentDispatch } from '@/lib/intents'
+import type { AppletKind, MoiAppletRuntime, ViewInfo, WorkspaceTabId } from '@/lib/types'
+
+declare global {
+  interface Window {
+    moi?: MoiAppletRuntime
+  }
+}
+
+// The last delivered intent per view, keyed `${workspaceId}:${viewId}`. Kept
+// (not one-shot) so a rebuild remount re-receives the same props; replaced by
+// the next dispatch to the same view.
+export type DeliveredIntent = { intent: string; params: Record<string, unknown> }
+
+type IntentStore = {
+  delivered: Record<string, DeliveredIntent>
+  deliver: (workspaceId: string, viewId: string, delivery: DeliveredIntent) => void
+}
+
+export const intentStore = createStore<IntentStore>()(set => ({
+  delivered: {},
+  deliver: (workspaceId, viewId, delivery) =>
+    set(s => ({ delivered: { ...s.delivered, [`${workspaceId}:${viewId}`]: delivery } }))
+}))
+
+// Reactive read for the mounted view (see ViewApp in WorkspaceScreen).
+export function useDeliveredIntent(
+  workspaceId: string,
+  viewId: string
+): DeliveredIntent | undefined {
+  return useStore(intentStore, s => s.delivered[`${workspaceId}:${viewId}`])
+}
+
+// `widget:products` → { kind: 'widget', name: 'products' } for journal
+// attribution; null for non-applet sources (`cli`). Exported for tests.
+export function appletFromSource(source: string): { kind: AppletKind; name: string } | null {
+  const m = source.match(/^(widget|view):([a-zA-Z0-9_-]+)$/)
+  if (!m) return null
+  return { kind: m[1] === 'widget' ? 'widget' : 'view', name: m[2] }
+}
+
+export type IntentRouteCtx = {
+  workspaceId: string
+  views: ViewInfo[]
+  openTab: (tab: WorkspaceTabId) => void
+}
+
+// Route one dispatch (from the CLI event or an applet's `moi.intent` call):
+// first declaring view wins. An unresolved dispatch is recorded in the applet
+// error journal so the authoring agent sees it in `moi debug logs` instead of
+// it vanishing. Returns whether the dispatch resolved.
+export function routeIntentDispatch(ctx: IntentRouteCtx, dispatch: IntentDispatch): boolean {
+  const view = resolveIntentView(ctx.views, dispatch.name)
+  if (!view) {
+    reportAppletError(ctx.workspaceId, {
+      source: 'intent',
+      ...(appletFromSource(dispatch.source) ?? {}),
+      message: `no view declares intent "${dispatch.name}" (dispatched by ${dispatch.source})`
+    })
+    return false
+  }
+  intentStore
+    .getState()
+    .deliver(ctx.workspaceId, view.id, { intent: dispatch.name, params: dispatch.params ?? {} })
+  ctx.openTab(`view:${view.id}`)
+  return true
+}
+
+// The originating applet of a `window.moi` call, recovered from the stack:
+// applet bundles load from `/api/workspaces/<id>/(widgets|views)/<name>/`, so
+// the topmost matching frame names the caller (same trick the error journal
+// uses for window errors). Non-applet callers fall back to 'applet'.
+function callerApplet(): string {
+  const ref = matchBundleUrl(new Error().stack)
+  return ref ? `${ref.kind}:${ref.name}` : 'applet'
+}
+
+export type MoiRuntimeHost = {
+  dispatch: (dispatch: IntentDispatch) => void
+  sendAction: (label: string, context: Record<string, unknown> | undefined, source: string) => void
+}
+
+// Install the applet-facing runtime at `window.moi` for the mounted
+// workspace. The host callbacks are read through a ref so the installed
+// object survives re-renders while always seeing fresh state.
+export function useMoiAppletRuntime(host: MoiRuntimeHost): void {
+  const hostRef = useRef(host)
+  hostRef.current = host
+  useEffect(() => {
+    const runtime: MoiAppletRuntime = {
+      intent: (name, params) => {
+        hostRef.current.dispatch({
+          name: String(name),
+          ...(params && typeof params === 'object' ? { params } : {}),
+          source: callerApplet()
+        })
+      },
+      sendAction: (label, context) => {
+        hostRef.current.sendAction(
+          String(label),
+          context && typeof context === 'object' ? context : undefined,
+          callerApplet()
+        )
+      }
+    }
+    window.moi = runtime
+    return () => {
+      if (window.moi === runtime) delete window.moi
+    }
+  }, [])
+}

--- a/client/features/workspace/moi-context.test.ts
+++ b/client/features/workspace/moi-context.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
-import { activeTabTitle, drainChatDirectives, pushChatDirective } from './moi-context'
+import {
+  activeTabTitle,
+  drainChatDirectives,
+  drainIntentAction,
+  pushChatDirective,
+  pushIntentAction
+} from './moi-context'
 import type { ViewBuilder, ViewInfo } from '@/lib/types'
 
 describe('moi context assembly', () => {
@@ -11,6 +17,18 @@ describe('moi context assembly', () => {
     expect(drainChatDirectives('ws-1')).toEqual(['First.', 'Second.'])
     expect(drainChatDirectives('ws-1')).toEqual([])
     expect(drainChatDirectives('ws-2')).toEqual(['Other workspace.'])
+  })
+
+  test('intent actions queue per workspace, last write wins, drain once', () => {
+    pushIntentAction('ws-1', { source: 'widget:products', context: { sku: 'old' } })
+    pushIntentAction('ws-1', { source: 'widget:products', context: { sku: 'a-1' } })
+    pushIntentAction('ws-2', { source: 'view:crm' })
+    expect(drainIntentAction('ws-1')).toEqual({
+      source: 'widget:products',
+      context: { sku: 'a-1' }
+    })
+    expect(drainIntentAction('ws-1')).toBeUndefined()
+    expect(drainIntentAction('ws-2')).toEqual({ source: 'view:crm' })
   })
 
   test('activeTabTitle resolves view titles and claimed builder titles', () => {

--- a/client/features/workspace/moi-context.ts
+++ b/client/features/workspace/moi-context.ts
@@ -24,6 +24,7 @@ import { useViewBuilders } from '@/client/features/views/api'
 import { useWorkspaceViews } from '@/client/features/workspace/api'
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
+import { intentNames } from '@/lib/intents'
 import type { MoiContext } from '@/lib/moi-context'
 import type { ViewBuilder, ViewInfo, WorkspaceTabId } from '@/lib/types'
 
@@ -46,6 +47,24 @@ export function drainChatDirectives(workspaceId: string): string[] {
   const queue = directiveQueues.get(workspaceId) ?? []
   directiveQueues.delete(workspaceId)
   return queue
+}
+
+// One-shot applet-action payload per workspace (docs/intents.md): `sendAction`
+// stores the originating applet + structured context here and the NEXT chat
+// message's envelope carries it as `MoiContext.intent`. Last write wins — one
+// action produces one message, so there is never more than one in flight.
+type IntentAction = NonNullable<MoiContext['intent']>
+const intentActions = new Map<string, IntentAction>()
+
+export function pushIntentAction(workspaceId: string, intent: IntentAction): void {
+  intentActions.set(workspaceId, intent)
+}
+
+// Exported for unit tests; production code drains only via `useMoiUserMessageContext`.
+export function drainIntentAction(workspaceId: string): IntentAction | undefined {
+  const intent = intentActions.get(workspaceId)
+  intentActions.delete(workspaceId)
+  return intent
 }
 
 // The UI label of the active tab when it has one beyond its id: a view's
@@ -76,9 +95,15 @@ export function useMoiUserMessageContext(): () => MoiContext {
   const activeTab = layout.tabs.active
   return useCallback(() => {
     const directives = drainChatDirectives(workspaceId)
+    const intent = drainIntentAction(workspaceId)
+    // The workspace's declared capability surface — names only (the envelope
+    // stays terse; `moi intents` has the details).
+    const availableIntents = intentNames(views ?? [])
     return {
       activeTab,
       tabTitle: activeTabTitle(activeTab, views, builders),
+      ...(intent ? { intent } : {}),
+      ...(availableIntents.length > 0 ? { availableIntents } : {}),
       ...(directives.length > 0 ? { directives } : {})
     }
   }, [workspaceId, activeTab, views, builders])

--- a/client/runtime/useWorkspaceEvents.ts
+++ b/client/runtime/useWorkspaceEvents.ts
@@ -21,6 +21,16 @@ export type WorkspaceEvent =
   // The Scratchpad canvas for `workspaceId` was saved — open tabs reload from
   // disk. `origin` is the tab that wrote it, so that tab can skip its own echo.
   | { type: 'scratchpad:updated'; workspaceId: string; origin?: string }
+  // An agent-initiated intent dispatch (`moi intent <name>`, docs/intents.md).
+  // Tabs showing `workspaceId` route it through the client resolver
+  // (client/features/workspace/intents.ts) to the view declaring the name.
+  | {
+      type: 'intent:dispatch'
+      workspaceId: string
+      name: string
+      params?: Record<string, unknown>
+      source: string
+    }
 
 type WorkspaceEventHandler = (event: WorkspaceEvent) => void
 

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -1,0 +1,59 @@
+# Intents
+
+**Key idea:** applets, the CLI, and chat need to talk to each other — but wiring them by tab id or
+prop name breaks the moment the agent renames or rebuilds a view. Instead, views **declare** named
+intents they handle (`intents` in their config), and emitters dispatch by intent name. The system
+routes each dispatch to whichever view declares it — like Android intents, capability-based rather
+than address-based.
+
+Why declared names instead of tab ids:
+
+- **Rename-safe links** — a widget dispatching `open-product` keeps working when the products view
+  is renamed, retitled, or rewritten, as long as _some_ view still declares the intent.
+- **Queryable surface** — `moi intents` lists every declared intent (name, description, params,
+  declaring view): the workspace's "what can it do" API, readable by the agent before wiring.
+- **Future chooser** — when two views declare the same intent, routing today picks the first (nav
+  order); the declaration model leaves room for a user-facing chooser later.
+
+## Declaring
+
+```ts
+export const config = {
+  title: 'Products',
+  intents: [{ name: 'open-product', description: 'Open one product', params: { id: 'product id' } }]
+} as const
+```
+
+Names are kebab-case verbs; malformed declarations are skipped at extract time (build-applet.ts),
+never failing the build. Declarations land in the views manifest and ride the `/views` list, so
+both the client resolver and the CLI see the same set.
+
+## Flows
+
+- **CLI dispatch** — `moi intent open-product --params '{"id":"p-42"}'` → control server resolves
+  against the built views (a name nothing declares fails in the CLI, listing what is declared) →
+  `intent:dispatch` workspace event → the client resolver switches to the declaring view's tab and
+  passes `intent`/`params` props to its component. Delivered state is in-memory only.
+- **Applet dispatch** — `import { intent } from 'moi'`; `intent('open-product', { id })` from any
+  widget or view. Delegates to the host-installed `window.moi` runtime; the originating applet is
+  recovered from the call stack (bundle URLs), so the dispatch carries a `source` like
+  `widget:products`. A dispatch no view declares is recorded in the applet error journal
+  (`moi debug logs`): `no view declares intent "open-product" (dispatched by widget:products)`.
+- **Applet → chat action** — `sendAction('Reorder low stock', { sku })` sends a chat message: the
+  label is the visible text, the structured context rides the `<moi-context>` envelope
+  (`MoiContext.intent`). If a run is in progress the label parks as the composer draft instead —
+  never interrupting, never dropping.
+
+Every chat message's envelope also carries `availableIntents` (declared names only), so the agent
+always knows the workspace's capability surface and where to look for details (`moi intents`).
+
+## Deliberate deferrals (MVP)
+
+- **Queueing on a busy chat** — `sendAction` during a run parks only the label as a draft; the
+  structured context is dropped rather than queued.
+- **Per-client scoping** — a CLI dispatch broadcasts to every tab showing the workspace; there is
+  no targeting of one browser tab.
+- **Multiple-handler chooser** — duplicate declarations resolve to the first view in nav order; no
+  disambiguation UI.
+- **URL persistence** — delivered intents are ephemeral in-memory state; a reload clears them and
+  they are never written into the workspace layout.

--- a/lib/intents.ts
+++ b/lib/intents.ts
@@ -1,0 +1,59 @@
+// Capability-based intent routing (docs/intents.md): views DECLARE named
+// intents in their config, and emitters dispatch by intent name — the system
+// routes to whichever view declares it. Nobody addresses a tab id directly,
+// so renames and rebuilds never break a link. These helpers are shared by the
+// client resolver and the server's CLI dispatch/manifest, so both sides agree
+// on what resolves.
+import type { ViewInfo } from './types'
+
+// Intent names are kebab-case verbs (`open-product`). Shared by the config
+// extractor (skip malformed declarations) and the CLI dispatch validation.
+export const INTENT_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/
+
+// One dispatch: an intent name, optional params, and the originating emitter
+// (`widget:products`, `view:crm`, or `cli`).
+export type IntentDispatch = {
+  name: string
+  params?: Record<string, unknown>
+  source: string
+}
+
+// One declared intent with the view that declares it — a row of the workspace
+// capability manifest (`moi intents`).
+export type WorkspaceIntent = {
+  name: string
+  description?: string
+  params?: Record<string, string>
+  viewId: string
+}
+
+// Every declared intent across the workspace's views, in view (nav) order.
+// Duplicate names keep every row — dispatch resolves to the first declarer
+// (a chooser for multiple handlers is deliberately deferred).
+export function collectIntents(views: ViewInfo[]): WorkspaceIntent[] {
+  const out: WorkspaceIntent[] = []
+  for (const view of views) {
+    for (const intent of view.config.intents ?? []) {
+      out.push({
+        name: intent.name,
+        ...(intent.description ? { description: intent.description } : {}),
+        ...(intent.params ? { params: intent.params } : {}),
+        viewId: view.id
+      })
+    }
+  }
+  return out
+}
+
+// Declared intent names, deduped, in declaration order — the terse list the
+// moi-context envelope carries as `availableIntents`.
+export function intentNames(views: ViewInfo[]): string[] {
+  return [...new Set(collectIntents(views).map(intent => intent.name))]
+}
+
+// The routing rule: the first view whose config declares `name`, or null when
+// nothing does (an unresolved dispatch — journaled client-side, refused by
+// the CLI server-side).
+export function resolveIntentView(views: ViewInfo[], name: string): ViewInfo | null {
+  return views.find(view => (view.config.intents ?? []).some(i => i.name === name)) ?? null
+}

--- a/lib/moi-context.ts
+++ b/lib/moi-context.ts
@@ -44,6 +44,14 @@ export type MoiContext = {
   // view builder's claimed title while the build runs. The tab bar falls
   // back to the id when unset; so does the envelope.
   tabTitle?: string
+  // Set when this message was sent by an applet action (`sendAction`,
+  // docs/intents.md): the originating applet and its structured context. The
+  // visible message text is the action's label; the payload rides here only.
+  intent?: { source: string; context?: Record<string, unknown> }
+  // Names of every intent the workspace's views declare — the workspace's
+  // capability surface, so the agent knows what it can dispatch. Names only
+  // to stay terse; `moi intents` has descriptions and params.
+  availableIntents?: string[]
   // One-shot imperative lines for this message only (e.g. the view-builder
   // bootstrap instructions from lib/view-builder-directives.ts).
   directives?: string[]
@@ -83,6 +91,27 @@ export function renderMoiContextBody(ctx: MoiContext): string {
     'Read the **`moi-workspace` skill** before responding — even to a simple question — unless you already read it in this chat.'
   ].join('\n')
   const sections = [`# Active tab\n${describeTab(ctx.activeTab, ctx.tabTitle)}`]
+  if (ctx.intent) {
+    const lines = [
+      `The user sent this message with an applet action from "${ctx.intent.source}" — the message text is the action's label.`
+    ]
+    if (ctx.intent.context) {
+      lines.push(
+        'The applet attached this structured context:',
+        '```json',
+        JSON.stringify(ctx.intent.context, null, 2),
+        '```'
+      )
+    }
+    sections.push(`# Applet action\n${lines.join('\n')}`)
+  }
+  if (ctx.availableIntents?.length) {
+    sections.push(
+      `# Workspace intents\nThe workspace's views declare these intents: ${ctx.availableIntents
+        .map(name => `\`${name}\``)
+        .join(', ')}. Run \`moi intents\` for details and \`moi intent <name>\` to dispatch one.`
+    )
+  }
   if (ctx.directives?.length) {
     sections.push(`# This message only\n${ctx.directives.join('\n')}`)
   }
@@ -97,13 +126,31 @@ export function renderMoiContext(ctx: MoiContext): string {
   return `${MOI_CONTEXT_OPEN}\n${renderMoiContextBody(ctx)}\n${MOI_CONTEXT_CLOSE}`
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 // Wire-shape guard for the chat frame's `context` field (see web.ts).
 export function isMoiContext(value: unknown): value is MoiContext {
   if (typeof value !== 'object' || value === null) return false
-  const v = value as { activeTab?: unknown; tabTitle?: unknown; directives?: unknown }
+  const v = value as {
+    activeTab?: unknown
+    tabTitle?: unknown
+    intent?: unknown
+    availableIntents?: unknown
+    directives?: unknown
+  }
+  const intent = v.intent as { source?: unknown; context?: unknown } | undefined
   return (
     typeof v.activeTab === 'string' &&
     (v.tabTitle === undefined || typeof v.tabTitle === 'string') &&
+    (v.intent === undefined ||
+      (isPlainObject(v.intent) &&
+        typeof intent?.source === 'string' &&
+        (intent.context === undefined || isPlainObject(intent.context)))) &&
+    (v.availableIntents === undefined ||
+      (Array.isArray(v.availableIntents) &&
+        v.availableIntents.every(n => typeof n === 'string'))) &&
     (v.directives === undefined ||
       (Array.isArray(v.directives) && v.directives.every(d => typeof d === 'string')))
   )

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,16 @@ export type WidgetInfo = {
   tag?: string
 }
 
+// One intent a view declares it handles (docs/intents.md). `name` is a
+// kebab-case verb like `open-product`; `params` maps each param name to a
+// one-line description. Emitters dispatch by name — the system routes to
+// whichever view declares it, so links survive renames and rebuilds.
+export type ViewIntent = {
+  name: string
+  description?: string
+  params?: Record<string, string>
+}
+
 // A view is a full-screen, agent-authored "app" (`.moi/views/<name>.tsx`),
 // shown one-at-a-time in the workspace nav. Same build/RPC machinery as a
 // widget, minus the grid: no sizing, the view owns its own layout and scroll.
@@ -29,6 +39,24 @@ export type ViewConfig = {
   icon?: string
   // Advisory env hints, same semantics as WidgetConfig.requiredEnv.
   requiredEnv?: string[]
+  // Intents this view handles (docs/intents.md).
+  intents?: ViewIntent[]
+}
+
+// Props the host passes a mounted view component after routing an intent to
+// it (client/features/workspace/intents.ts). Absent until a dispatch lands;
+// ephemeral in-memory state, never persisted into the workspace layout.
+export type ViewIntentProps = {
+  intent?: string
+  params?: Record<string, unknown>
+}
+
+// The applet-facing runtime the host installs at `window.moi` (re-exported to
+// bundles by the `moi` virtual module): dispatch a declared intent, or send a
+// chat action whose label becomes the visible message text. See docs/intents.md.
+export type MoiAppletRuntime = {
+  intent: (name: string, params?: Record<string, unknown>) => void
+  sendAction: (label: string, context?: Record<string, unknown>) => void
 }
 
 export type ViewInfo = {
@@ -68,9 +96,10 @@ export type ViewBuilder = {
 // ---- Applet error journal (see docs/self-correction.md) ------------------
 
 // Where an applet error was observed. `build` and `rpc` are recorded
-// server-side (bundle pipeline, RPC route); `load`/`render`/`window` are
-// browser-side and reach the journal via POST /api/workspaces/:id/applet-log.
-export type AppletLogSource = 'build' | 'load' | 'render' | 'window' | 'rpc'
+// server-side (bundle pipeline, RPC route); `load`/`render`/`window`/`intent`
+// are browser-side and reach the journal via POST /api/workspaces/:id/applet-log.
+// `intent` marks a dispatch no view declared (docs/intents.md).
+export type AppletLogSource = 'build' | 'load' | 'render' | 'window' | 'rpc' | 'intent'
 
 // One journal entry, as returned to `moi debug logs`. `kind`/`name` attribute
 // the applet when known; `module`/`fn` pin down the server function for `rpc`
@@ -89,12 +118,14 @@ export type AppletLogEntry = {
 }
 
 // The browser-reported subset (the server-side sources can't be spoofed by a
-// tab — the POST route rejects them).
-export type AppletClientErrorSource = 'load' | 'render' | 'window'
+// tab — the POST route rejects them). `kind`/`name` attribute the applet; they
+// are optional only for `intent` entries, whose dispatcher may not be an
+// applet (`cli`) — the POST route still requires them for the other sources.
+export type AppletClientErrorSource = 'load' | 'render' | 'window' | 'intent'
 export type AppletClientError = {
   source: AppletClientErrorSource
-  kind: AppletKind
-  name: string
+  kind?: AppletKind
+  name?: string
   message: string
   stack?: string
 }

--- a/server/api.ts
+++ b/server/api.ts
@@ -339,14 +339,29 @@ one.post('/applet-log', async c => {
       message?: unknown
       stack?: unknown
     }
-    if (e.source !== 'load' && e.source !== 'render' && e.source !== 'window') continue
-    if (e.kind !== 'widget' && e.kind !== 'view') continue
-    if (typeof e.name !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(e.name)) continue
+    if (
+      e.source !== 'load' &&
+      e.source !== 'render' &&
+      e.source !== 'window' &&
+      e.source !== 'intent'
+    ) {
+      continue
+    }
+    const kind = e.kind === 'widget' || e.kind === 'view' ? e.kind : undefined
+    const name = typeof e.name === 'string' && /^[a-zA-Z0-9_-]+$/.test(e.name) ? e.name : undefined
+    // `intent` entries (a dispatch no view declares — docs/intents.md) may be
+    // unattributed: a `cli`-sourced dispatch has no applet behind it. Every
+    // other source must name its applet.
+    if (e.source === 'intent') {
+      if ((e.kind !== undefined && !kind) || (e.name !== undefined && !name)) continue
+    } else if (!kind || !name) {
+      continue
+    }
     if (typeof e.message !== 'string' || !e.message) continue
     recordAppletError(c.get('ws').path, {
       source: e.source,
-      kind: e.kind,
-      name: e.name,
+      ...(kind ? { kind } : {}),
+      ...(name ? { name } : {}),
       message: e.message,
       ...(typeof e.stack === 'string' ? { stack: e.stack } : {})
     })

--- a/server/bundler/build-applet.ts
+++ b/server/bundler/build-applet.ts
@@ -8,7 +8,8 @@ import tailwind from 'bun-plugin-tailwind'
 import { realpathSync } from 'node:fs'
 import { basename, dirname, join, relative, sep } from 'path'
 
-import type { AppletKind, ViewConfig, WidgetConfig } from '@/lib/types'
+import { INTENT_NAME_RE } from '@/lib/intents'
+import type { AppletKind, ViewConfig, ViewIntent, WidgetConfig } from '@/lib/types'
 
 import { scopeAppletCss } from './applet-css'
 
@@ -114,6 +115,74 @@ function readRequiredEnv(propValue: unknown): string[] | undefined {
   return names.length ? names : undefined
 }
 
+// A string-literal AST node's value, or undefined for anything else.
+function literalString(node: unknown): string | undefined {
+  const n = node as { type?: string; value?: unknown }
+  return n?.type === 'Literal' && typeof n.value === 'string' ? n.value : undefined
+}
+
+// A property's key name: `name: …` (Identifier) or `'name': …` (string Literal).
+function propertyKey(prop: { key?: unknown }): string | undefined {
+  const key = prop.key as { type?: string; name?: string; value?: unknown } | undefined
+  if (key?.type === 'Identifier') return key.name
+  return literalString(key)
+}
+
+// `params`: an object literal mapping param name → one-line description.
+// Non-string values are dropped.
+function readIntentParams(propValue: unknown): Record<string, string> | undefined {
+  const value = propValue as { type?: string; properties?: unknown[] }
+  if (value?.type !== 'ObjectExpression') return undefined
+  const out: Record<string, string> = {}
+  for (const raw of value.properties ?? []) {
+    const prop = raw as { type?: string; key?: unknown; value?: unknown }
+    if (prop?.type !== 'Property') continue
+    const key = propertyKey(prop)
+    const desc = literalString(prop.value)
+    if (key && desc !== undefined) out[key] = desc
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
+// `intents`: declarations of the named intents a view handles
+// (docs/intents.md). Minimal validation — an entry must be an object literal
+// with a kebab-case string `name`; malformed entries are skipped with a warn,
+// never failing the build.
+function readIntents(propValue: unknown, viewName: string): ViewIntent[] | undefined {
+  const value = propValue as { type?: string; elements?: unknown[] }
+  if (value?.type !== 'ArrayExpression') return undefined
+  const intents: ViewIntent[] = []
+  for (const el of value.elements ?? []) {
+    const obj = el as { type?: string; properties?: unknown[] }
+    if (obj?.type !== 'ObjectExpression') continue
+    let name: string | undefined
+    let description: string | undefined
+    let params: Record<string, string> | undefined
+    for (const raw of obj.properties ?? []) {
+      const prop = raw as { type?: string; key?: unknown; value?: unknown }
+      if (prop?.type !== 'Property') continue
+      const key = propertyKey(prop)
+      if (key === 'name') name = literalString(prop.value)
+      else if (key === 'description') description = literalString(prop.value)
+      else if (key === 'params') params = readIntentParams(prop.value)
+    }
+    if (!name || !INTENT_NAME_RE.test(name)) {
+      console.warn(
+        `[moi] "${viewName}": skipping malformed intent declaration` +
+          (name ? ` "${name}"` : '') +
+          ' (name must be a kebab-case string like "open-product")'
+      )
+      continue
+    }
+    intents.push({
+      name,
+      ...(description ? { description } : {}),
+      ...(params ? { params } : {})
+    })
+  }
+  return intents.length ? intents : undefined
+}
+
 export async function extractWidgetConfig(srcPath: string): Promise<WidgetConfig | null> {
   const source = await Bun.file(srcPath).text()
   const widgetName = basename(srcPath).replace(/\.tsx?$/, '')
@@ -147,10 +216,12 @@ export async function extractWidgetConfig(srcPath: string): Promise<WidgetConfig
   return { ...DEFAULT_CONFIG, ...result }
 }
 
-// A view's config: `title` + app icon registry id + advisory `requiredEnv`.
-// No sizing — views are full-screen. Returns null when no `config` export is present.
+// A view's config: `title` + app icon registry id + advisory `requiredEnv` +
+// declared `intents`. No sizing — views are full-screen. Returns null when no
+// `config` export is present.
 export async function extractViewConfig(srcPath: string): Promise<ViewConfig | null> {
   const source = await Bun.file(srcPath).text()
+  const viewName = basename(srcPath).replace(/\.tsx?$/, '')
 
   const properties = findConfigProperties(source)
   if (!properties) return null
@@ -170,6 +241,11 @@ export async function extractViewConfig(srcPath: string): Promise<ViewConfig | n
     if (key === 'requiredEnv') {
       const names = readRequiredEnv(prop.value)
       if (names) result.requiredEnv = names
+      continue
+    }
+    if (key === 'intents') {
+      const intents = readIntents(prop.value, viewName)
+      if (intents) result.intents = intents
     }
   }
 
@@ -231,17 +307,29 @@ export function rpc(module, name) {
 }
 `
 
-// The `moi` virtual module — the applet-facing runtime API. Today just
-// `fileUrl(path)`, which maps a workspace-relative path to its streaming URL
-// (`/api/workspaces/<id>/fs/<path>`). Same sentinel base as RPC; the path is
-// per-segment URL-encoded so spaces / unicode in filenames survive. A leading
-// slash is stripped so both `clips/a.mp4` and `/clips/a.mp4` work.
+// The `moi` virtual module — the applet-facing runtime API:
+//   • `fileUrl(path)` maps a workspace-relative path to its streaming URL
+//     (`/api/workspaces/<id>/fs/<path>`). Same sentinel base as RPC; the path
+//     is per-segment URL-encoded so spaces / unicode in filenames survive. A
+//     leading slash is stripped so both `clips/a.mp4` and `/clips/a.mp4` work.
+//   • `intent(name, params?)` / `sendAction(label, context?)` delegate to the
+//     host-installed `window.moi` runtime (docs/intents.md; typed as
+//     `MoiAppletRuntime` in lib/types). Thin delegation keeps the on-disk
+//     bundle host-agnostic; a bundle loaded outside the host is a no-op.
 const MOI_MODULE_SOURCE = `
 const BASE = ${JSON.stringify(APPLET_API_BASE_SENTINEL)};
 
 export function fileUrl(path) {
   const clean = String(path).replace(/^\\/+/, "");
   return BASE + "/fs/" + clean.split("/").map(encodeURIComponent).join("/");
+}
+
+export function intent(name, params) {
+  window.moi?.intent(name, params);
+}
+
+export function sendAction(label, context) {
+  window.moi?.sendAction(label, context);
 }
 `
 

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'path'
 import pc from './cli-pc'
 
+import type { WorkspaceIntent } from '@/lib/intents'
 import { COLOR_THEMES, FONT_THEMES } from '@/lib/themes'
 import type { ColorTheme, FontTheme } from '@/lib/themes'
 import type {
@@ -1699,6 +1700,112 @@ const scratch = defineCommand({
   }
 })
 
+// ---- intents (capability manifest + dispatch — docs/intents.md) --------------
+
+const intentsCmd = defineCommand({
+  meta: {
+    name: 'intents',
+    description: 'List the intents declared by the workspace views (the capability manifest)'
+  },
+  args: {
+    dir: dirArg,
+    json: { type: 'boolean', default: false, description: 'Machine-readable output' }
+  },
+  run({ args }) {
+    const path = resolve(args.dir)
+    sendControl(path, { type: 'intent:list', path }, res => {
+      const list = (Array.isArray(res.intents) ? res.intents : []) as WorkspaceIntent[]
+      if (args.json) {
+        console.log(JSON.stringify(list, null, 2))
+        return
+      }
+      if (list.length === 0) {
+        console.log(
+          '\n' +
+            pc.bold('moi intents') +
+            pc.dim(' — no intents declared') +
+            '\n\n' +
+            pc.dim(
+              '  Views declare intents in their config: `intents: [{ name, description, params }]`.'
+            ) +
+            '\n'
+        )
+        return
+      }
+      console.log('\n' + pc.bold('moi intents') + pc.dim(` — ${list.length} declared`) + '\n')
+      for (const intent of list) {
+        console.log(
+          `  ${pc.bold(intent.name)} ${pc.dim(`→ view ${intent.viewId}`)}` +
+            (intent.description ? ` — ${intent.description}` : '')
+        )
+        for (const [param, desc] of Object.entries(intent.params ?? {})) {
+          console.log(pc.dim(`      ${param}: ${desc}`))
+        }
+      }
+      console.log(
+        '\n' +
+          pc.dim('  Dispatch with ') +
+          pc.bold("moi intent <name> --params '<json>'") +
+          pc.dim(' — params are one JSON object.') +
+          '\n'
+      )
+    })
+  }
+})
+
+const intentCmd = defineCommand({
+  meta: {
+    name: 'intent',
+    description: 'Dispatch an intent — the view that declares it opens and receives the params'
+  },
+  args: {
+    name: {
+      type: 'positional',
+      required: true,
+      description: 'Intent name (see `moi intents`)'
+    },
+    params: {
+      type: 'string',
+      description: 'Params as one JSON object, e.g. \'{"id": "p-42"}\''
+    },
+    dir: dirArg
+  },
+  run({ args }) {
+    const path = resolve(args.dir)
+    let params: Record<string, unknown> | undefined
+    if (args.params !== undefined) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(args.params)
+      } catch {
+        parsed = null
+      }
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        console.error(
+          '\n' + pc.red('✗') + ' --params must be one JSON object, e.g. \'{"id": "p-42"}\'\n'
+        )
+        process.exit(1)
+      }
+      params = parsed as Record<string, unknown>
+    }
+    sendControl(
+      path,
+      { type: 'intent:dispatch', path, name: args.name, ...(params ? { params } : {}) },
+      res => {
+        console.log(
+          '\n' +
+            pc.green('✓') +
+            ' dispatched ' +
+            pc.bold(args.name) +
+            ' → view ' +
+            pc.bold(String(res.viewId)) +
+            '\n'
+        )
+      }
+    )
+  }
+})
+
 // ---- self-correction commands (docs/self-correction.md) ---------------------
 
 const callServerFn = defineCommand({
@@ -1960,6 +2067,8 @@ const main = defineCommand({
     bundle,
     builder,
     refresh,
+    intent: intentCmd,
+    intents: intentsCmd,
     'call-server-fn': callServerFn,
     debug,
     theme,

--- a/server/control.ts
+++ b/server/control.ts
@@ -1,6 +1,7 @@
 import { stringify as devalueStringify } from 'devalue'
 import { resolve } from 'path'
 
+import { collectIntents, resolveIntentView } from '@/lib/intents'
 import type { WorkspaceEntry } from '@/lib/types'
 
 import { clearAppletLog, getAppletLog, getAppletLogCount } from './applet-log'
@@ -132,6 +133,54 @@ export const control = Bun.serve({
               logCount: getAppletLogCount(workspacePath)
             })
           )
+          return
+        }
+
+        // The intent capability manifest — `moi intents` (docs/intents.md):
+        // every intent the workspace's built views declare, in nav order.
+        if (data.type === 'intent:list') {
+          const match = await resolveWorkspace(ws, data.path)
+          if (!match) return
+          ws.send(
+            JSON.stringify({ ok: true, intents: collectIntents(await getViewList(match.path)) })
+          )
+          return
+        }
+
+        // Agent-initiated dispatch — `moi intent <name>`. Resolved against the
+        // BUILT views before publishing, so a name nothing declares fails
+        // loudly in the CLI (listing what is declared) instead of dissolving
+        // into a browser event no view handles.
+        if (data.type === 'intent:dispatch') {
+          const match = await resolveWorkspace(ws, data.path)
+          if (!match) return
+          const name = typeof data.name === 'string' ? data.name.trim() : ''
+          if (!name) {
+            ws.send(JSON.stringify({ error: 'An intent name is required' }))
+            return
+          }
+          const params =
+            typeof data.params === 'object' && data.params !== null && !Array.isArray(data.params)
+              ? (data.params as Record<string, unknown>)
+              : undefined
+          const views = await getViewList(match.path)
+          const target = resolveIntentView(views, name)
+          if (!target) {
+            const declared = collectIntents(views)
+            const hint = declared.length
+              ? `Declared intents: ${declared.map(i => `${i.name} (view ${i.viewId})`).join(', ')}`
+              : 'No intents are declared in this workspace — add an `intents` entry to a view config and run `moi bundle`.'
+            ws.send(JSON.stringify({ error: `No view declares intent "${name}". ${hint}` }))
+            return
+          }
+          publishEvent({
+            type: 'intent:dispatch',
+            workspaceId: match.id,
+            name,
+            ...(params ? { params } : {}),
+            source: 'cli'
+          })
+          ws.send(JSON.stringify({ ok: true, viewId: target.id }))
           return
         }
 

--- a/server/moi-scaffold.ts
+++ b/server/moi-scaffold.ts
@@ -60,12 +60,28 @@ declare module 'moi' {
   // Absolute URL to a workspace file, streamed by the server. Pass a
   // workspace-relative path (e.g. 'clips/001.mp4'). Media/asset files only.
   export function fileUrl(path: string): string
+  // Dispatch a declared intent — the view declaring \`name\` opens and receives
+  // the params as props. Run \`moi intents\` to see what's declared.
+  export function intent(name: string, params?: Record<string, unknown>): void
+  // Send a chat message to the agent: \`label\` is the visible text, \`context\`
+  // rides the hidden envelope. Parks as a composer draft while a run is active.
+  export function sendAction(label: string, context?: Record<string, unknown>): void
+  export type ViewIntent = {
+    name: string
+    description?: string
+    params?: Record<string, string>
+  }
   export type WidgetConfig = {
     rowSpan: 1 | 2 | 3 | 4
     colSpan: 1 | 2 | 3 | 4
     requiredEnv?: string[]
   }
-  export type ViewConfig = { title?: string; requiredEnv?: string[] }
+  export type ViewConfig = {
+    title?: string
+    icon?: string
+    requiredEnv?: string[]
+    intents?: ViewIntent[]
+  }
 }
 
 // Bundled asset imports (\`import logo from './logo.png'\`) resolve to a URL string.

--- a/server/test/__fixtures__/with-intent-call.tsx
+++ b/server/test/__fixtures__/with-intent-call.tsx
@@ -1,0 +1,19 @@
+import { intent, sendAction } from 'moi'
+
+export const config = {
+  title: 'Emitter',
+  intents: [{ name: 'noop' }]
+} as const
+
+export default function Emitter() {
+  return (
+    <button
+      onClick={() => {
+        intent('open-product', { id: 'p-1' })
+        sendAction('Reorder low stock', { sku: 'a-1' })
+      }}
+    >
+      go
+    </button>
+  )
+}

--- a/server/test/__fixtures__/with-intents.tsx
+++ b/server/test/__fixtures__/with-intents.tsx
@@ -1,0 +1,14 @@
+export const config = {
+  title: 'Products',
+  intents: [
+    { name: 'open-product', description: 'Open one product', params: { id: 'product id' } },
+    { name: 'list-products' },
+    { name: 'Bad Name' }, // skipped: not kebab-case
+    { description: 'no name' }, // skipped: missing name
+    { name: 'mixed-params', params: { kept: 'a string', 'kebab-key': 'quoted key', dropped: 42 } }
+  ]
+} as const
+
+export default function Products() {
+  return <div className="h-full w-full" />
+}

--- a/server/test/build-applet.test.ts
+++ b/server/test/build-applet.test.ts
@@ -273,6 +273,22 @@ describe('extractViewConfig', () => {
     // with-config.tsx exports { rowSpan, colSpan } — none of which a view honors.
     expect(await extractViewConfig(join(FIXTURES, 'with-config.tsx'))).toEqual({})
   })
+
+  test('extracts intent declarations, skipping malformed entries', async () => {
+    const config = await extractViewConfig(join(FIXTURES, 'with-intents.tsx'))
+    // Non-kebab-case and nameless entries are skipped; non-string param
+    // descriptions are dropped; quoted (kebab-case) param keys survive.
+    expect(config?.intents).toEqual([
+      { name: 'open-product', description: 'Open one product', params: { id: 'product id' } },
+      { name: 'list-products' },
+      { name: 'mixed-params', params: { kept: 'a string', 'kebab-key': 'quoted key' } }
+    ])
+  })
+
+  test('omits intents when the config declares none', async () => {
+    const config = await extractViewConfig(join(FIXTURES, 'with-view-config.tsx'))
+    expect(config?.intents).toBeUndefined()
+  })
 })
 
 describe("buildApplet kind='view'", () => {
@@ -291,6 +307,16 @@ describe("buildApplet kind='view'", () => {
     const result = await buildApplet(join(FIXTURES, 'hello.tsx'), undefined, 'widget')
     expect(result.js).toContain('widget:hello')
     expect(result.js).not.toContain('view:hello')
+  })
+
+  test('the moi module exposes intent/sendAction as window.moi delegates', async () => {
+    const result = await buildApplet(join(FIXTURES, 'with-intent-call.tsx'), undefined, 'view')
+    // The bundle carries thin stubs — the host installs the real runtime at
+    // window.moi (client/features/workspace/intents.ts), so an on-disk bundle
+    // stays host-agnostic.
+    expect(result.js).toContain('window.moi?.intent')
+    expect(result.js).toContain('window.moi?.sendAction')
+    expect(result.config).toEqual({ title: 'Emitter', intents: [{ name: 'noop' }] })
   })
 })
 

--- a/server/test/intents.test.ts
+++ b/server/test/intents.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+
+import { INTENT_NAME_RE, collectIntents, intentNames, resolveIntentView } from '@/lib/intents'
+import type { ViewInfo } from '@/lib/types'
+
+const views: ViewInfo[] = [
+  {
+    id: 'crm',
+    config: {
+      title: 'CRM',
+      intents: [
+        { name: 'open-customer', description: 'Open one customer', params: { id: 'customer id' } },
+        { name: 'search' }
+      ]
+    }
+  },
+  { id: 'notes', config: { title: 'Notes' } },
+  {
+    id: 'orders',
+    config: {
+      title: 'Orders',
+      // `search` is also declared by crm — dispatch resolves to crm (first).
+      intents: [{ name: 'search' }, { name: 'open-order' }]
+    }
+  }
+]
+
+describe('collectIntents (the capability manifest)', () => {
+  test('flattens every declaration in view order, tagged with its view', () => {
+    expect(collectIntents(views)).toEqual([
+      {
+        name: 'open-customer',
+        description: 'Open one customer',
+        params: { id: 'customer id' },
+        viewId: 'crm'
+      },
+      { name: 'search', viewId: 'crm' },
+      { name: 'search', viewId: 'orders' },
+      { name: 'open-order', viewId: 'orders' }
+    ])
+  })
+
+  test('empty when no view declares anything', () => {
+    expect(collectIntents([{ id: 'plain', config: {} }])).toEqual([])
+  })
+})
+
+describe('intentNames (envelope surface)', () => {
+  test('dedupes names in declaration order', () => {
+    expect(intentNames(views)).toEqual(['open-customer', 'search', 'open-order'])
+  })
+})
+
+describe('resolveIntentView (routing)', () => {
+  test('resolves to the first view declaring the name', () => {
+    expect(resolveIntentView(views, 'open-order')?.id).toBe('orders')
+    expect(resolveIntentView(views, 'search')?.id).toBe('crm')
+  })
+
+  test('unresolved names return null', () => {
+    expect(resolveIntentView(views, 'close-ticket')).toBeNull()
+    expect(resolveIntentView([], 'open-customer')).toBeNull()
+  })
+})
+
+describe('INTENT_NAME_RE', () => {
+  test('accepts kebab-case verbs, rejects everything else', () => {
+    expect(INTENT_NAME_RE.test('open-product')).toBe(true)
+    expect(INTENT_NAME_RE.test('sync')).toBe(true)
+    expect(INTENT_NAME_RE.test('v2-sync-all')).toBe(true)
+    expect(INTENT_NAME_RE.test('Open-Product')).toBe(false)
+    expect(INTENT_NAME_RE.test('open_product')).toBe(false)
+    expect(INTENT_NAME_RE.test('open product')).toBe(false)
+    expect(INTENT_NAME_RE.test('-open')).toBe(false)
+    expect(INTENT_NAME_RE.test('')).toBe(false)
+  })
+})

--- a/server/test/moi-context.test.ts
+++ b/server/test/moi-context.test.ts
@@ -99,6 +99,47 @@ describe('moi context envelope', () => {
     expect(isMoiContext({ activeTab: 'agent', directives: [1] })).toBe(false)
   })
 
+  test('renders an applet action section with fenced context JSON', () => {
+    const rendered = renderMoiContext({
+      activeTab: 'view:crm',
+      intent: { source: 'widget:products', context: { sku: 'a-1' } }
+    })
+    expect(rendered).toContain(
+      '# Applet action\nThe user sent this message with an applet action from "widget:products" — the message text is the action\'s label.'
+    )
+    expect(rendered).toContain('```json\n{\n  "sku": "a-1"\n}\n```')
+    // Context-less action: the sentence stands alone, no fence.
+    const bare = renderMoiContext({ activeTab: 'agent', intent: { source: 'view:crm' } })
+    expect(bare).toContain('# Applet action')
+    expect(bare).not.toContain('```json')
+  })
+
+  test('renders the workspace intents sentence with the CLI pointer', () => {
+    const rendered = renderMoiContext({
+      activeTab: 'widgets',
+      availableIntents: ['open-product', 'add-order']
+    })
+    expect(rendered).toContain(
+      "# Workspace intents\nThe workspace's views declare these intents: `open-product`, `add-order`. Run `moi intents` for details and `moi intent <name>` to dispatch one."
+    )
+    // Absent list, absent section.
+    expect(renderMoiContext({ activeTab: 'widgets' })).not.toContain('# Workspace intents')
+  })
+
+  test('wire guard covers intent and availableIntents', () => {
+    expect(isMoiContext({ activeTab: 'agent', intent: { source: 'widget:products' } })).toBe(true)
+    expect(
+      isMoiContext({
+        activeTab: 'agent',
+        intent: { source: 'cli', context: { id: 1 } },
+        availableIntents: ['open-product']
+      })
+    ).toBe(true)
+    expect(isMoiContext({ activeTab: 'agent', intent: { context: {} } })).toBe(false)
+    expect(isMoiContext({ activeTab: 'agent', intent: { source: 'x', context: [] } })).toBe(false)
+    expect(isMoiContext({ activeTab: 'agent', availableIntents: [1] })).toBe(false)
+  })
+
   test('loose strip handles truncated envelopes in previews', () => {
     const sent = appendMoiContext('Fix the header', context)
     expect(stripMoiContextLoose(sent)).toBe('Fix the header')

--- a/server/test/views.test.ts
+++ b/server/test/views.test.ts
@@ -88,6 +88,24 @@ describe('listViews', () => {
     expect((await views())[0].config).toEqual({ title: 'CRM', icon: 'briefcase' })
   })
 
+  test('passes through intent declarations (docs/intents.md)', async () => {
+    seed(['crm'], {
+      config: {
+        crm: {
+          title: 'CRM',
+          intents: [{ name: 'open-customer', description: 'Open one', params: { id: 'row id' } }]
+        }
+      },
+      order: ['crm']
+    })
+    const res = await listViews(WS)
+    const body = (await res.json()) as { views: { config: Record<string, unknown> }[] }
+    expect(body.views[0].config).toEqual({
+      title: 'CRM',
+      intents: [{ name: 'open-customer', description: 'Open one', params: { id: 'row id' } }]
+    })
+  })
+
   test('appends a built view missing from order', async () => {
     seed(['a', 'b'], { config: {}, order: ['b'] })
     expect((await views()).map(v => v.id)).toEqual(['b', 'a'])

--- a/server/views.ts
+++ b/server/views.ts
@@ -106,12 +106,16 @@ export async function getViewList(workspacePath: string): Promise<ViewInfo[]> {
     const raw = manifest.config[id] ?? {}
     const icon = typeof raw.icon === 'string' && raw.icon ? raw.icon : undefined
     const requiredEnv = Array.isArray(raw.requiredEnv) ? raw.requiredEnv : undefined
+    // Declared intents pass through as extracted (the bundler already
+    // validated the declarations — see readIntents in build-applet.ts).
+    const intents = Array.isArray(raw.intents) && raw.intents.length ? raw.intents : undefined
     return {
       id,
       config: {
         title: raw.title || id,
         ...(icon ? { icon } : {}),
-        ...(requiredEnv ? { requiredEnv } : {})
+        ...(requiredEnv ? { requiredEnv } : {}),
+        ...(intents ? { intents } : {})
       }
     }
   })
@@ -169,7 +173,11 @@ export async function handleBundleViews(
     r =>
       r.status === 'built' &&
       ((before.config[r.name]?.title ?? '') !== (r.config?.title ?? '') ||
-        (before.config[r.name]?.icon ?? '') !== (r.config?.icon ?? ''))
+        (before.config[r.name]?.icon ?? '') !== (r.config?.icon ?? '') ||
+        // Intent declarations ride the client's views query — a changed set
+        // must refetch it or the client resolver routes on stale capabilities.
+        JSON.stringify(before.config[r.name]?.intents ?? []) !==
+          JSON.stringify(r.config?.intents ?? []))
   )
   const orderChanged = before.order.join('\0') !== after.order.join('\0')
   const membershipChanged =

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -113,6 +113,8 @@ never from inside `.moi/` itself. You don't pass paths; moi resolves the workspa
 - `moi refresh` — re-fetch widget/view data without rebuilding (use after you mutated data the
   widgets read — DB rows, files, external API records — so the displayed values catch up)
 - `moi call-server-fn <module>/<fn> '[args]'` — invoke a `.server.ts` function directly (smoke test)
+- `moi intents` — list the intents declared by the workspace views (see Intents)
+- `moi intent <name> --params '<json>'` — dispatch an intent; the declaring view opens with the params
 - `moi debug logs` — applet runtime errors on record (experimental)
 - `moi theme --font=<key>` — change font theme (omit `--font` to list options)
 - `moi theme --color=<key>` — change color preset (omit `--color` to list options)
@@ -316,6 +318,42 @@ export const config = {
 The inverse of a widget: a view **owns its whole page** — its own `h-full w-full` layout, scrolling
 (`overflow-auto`), padding, and chrome. Build it to read like an app screen. See `VIEW-DESIGN.md`.
 
+# Intents
+
+Views declare **intents** — named capabilities that other applets and you (via the CLI) can
+trigger. Dispatching an intent switches the workspace to the view that declares it and hands it the
+params. Always route by declared name, never hardcode a tab or prop wiring between applets — named
+routing survives renames and rebuilds.
+
+- Declare an intent in the view's config for anything other applets or you should be able to
+  trigger. Names are kebab-case verbs; `params` maps each param name to a one-line description:
+
+  ```ts
+  export const config = {
+    title: 'Products',
+    intents: [
+      { name: 'open-product', description: 'Open one product detail pane', params: { id: 'product id' } }
+    ]
+  } as const
+  ```
+
+- The view receives a dispatch as props — re-render, don't refetch the world:
+
+  ```tsx
+  export default function Products({ intent, params }: { intent?: string; params?: Record<string, unknown> }) { … }
+  ```
+
+- Dispatch from applet code via the `moi` module:
+  `import { intent, sendAction } from 'moi'` → `intent('open-product', { id: 'p-42' })`.
+- `sendAction(label, context?)` sends a chat message to **you**: `label` becomes the visible
+  message text and `context` rides the hidden envelope. Use it for "ask the agent" buttons. If a
+  run is already in progress the label lands in the composer draft instead (context is dropped).
+- Run `moi intents` **before wiring an emitter**. If the target intent is missing, add the
+  declaration to the target view first and `moi bundle` — only then wire the emitter.
+- Dispatch yourself with `moi intent open-product --params '{"id":"p-42"}'` (params: one JSON object).
+- A dispatch no view declares does not error in the UI — it lands in `moi debug logs`, so check
+  there when a link seems dead.
+
 # Keeping this skill current
 
 This skill is installed with moi (via the CLI or the UI) and can fall behind when the moi CLI updates.
@@ -328,4 +366,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.7.0" />
+<moi-skill version="0.8.0" />


### PR DESCRIPTION
Alternative take on the intent system (compare with #52): instead of addressing tabs by id, views declare named intents in their config (`intents: [{ name: 'open-product', params: { id: 'product id' } }]`) and emitters dispatch by name — `intent('open-product', { id })` from applet code or `moi intent open-product --params '<json>'` from the CLI. The system routes to whichever view declared the name, so renames and rebuilds don't break widget→view links, and the workspace grows a queryable capability surface: `moi intents` lists every declared intent, and every chat send tells the agent what the workspace can do via the `moi-context` envelope:

```
# Workspace intents
The workspace's views declare these intents: `open-product`, `add-order`. Run `moi intents` for details and `moi intent <name>` to dispatch one.
```

Unresolved dispatches are observable, not silent: `no view declares intent "open-product" (dispatched by widget:products)` lands in the applet journal so the authoring agent sees it in `moi debug logs` and self-corrects. Shared with #52: `sendAction(label, context?)` fires a prompt into chat with the structured payload riding the envelope (busy chat parks the label as a composer draft), views receive `intent`/`params` props, and the skill + `docs/intents.md` teach the authoring workflow. Routing semantics live in `lib/intents.ts`, shared by server dispatch validation and client resolution so they can't drift.

Reviewer focus:
- Stack-based caller attribution (`callerApplet` in `client/features/workspace/intents.ts`) recovers the emitting applet from the error stack via `matchBundleUrl` — degrades to a generic `'applet'` source if the stack shape changes.
- `sendAction` idle-vs-busy race in `WorkspaceScreen.tsx`: a click landing between send and the running-status frame takes the idle path; busy path intentionally drops structured context (documented).
- `/applet-log` route loosening in `server/api.ts`: `'intent'` entries may omit kind/name on an unauthenticated route — check server-recorded sources (`build`/`rpc`) remain unspoofable.

Verified: `bun test` 573 pass / 0 fail (62 files, baseline 551 pass), `typecheck:client`, `lint`, and `format:check` all clean. CLI smoke-tested (`moi intents`, `moi intent`, `--params` validation); no dev-server run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do2RQTJD9HtNQqLP8Lr2Bt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Do2RQTJD9HtNQqLP8Lr2Bt)_