### PR TITLE
Add onboarding welcome chat with guided build prompts

### DIFF
--- a/client/app/routes/WorkspaceRoute.tsx
+++ b/client/app/routes/WorkspaceRoute.tsx
@@ -87,11 +87,13 @@ type SeedActiveSessionProps = {
 function SeedActiveSession({ workspaceId, sessions }: SeedActiveSessionProps) {
   useEffect(() => {
     if (!sessions) return
-    const active = liveStore.getState().activeByWorkspace[workspaceId] ?? null
-    const stillValid = active && sessions.some(session => session.sessionId === active)
-    if (!stillValid) {
-      liveStore.getState().setActive(workspaceId, sessions[0]?.sessionId ?? null)
-    }
+    const activeByWorkspace = liveStore.getState().activeByWorkspace
+    const hasActiveSelection = Object.prototype.hasOwnProperty.call(activeByWorkspace, workspaceId)
+    const activeSessionId = activeByWorkspace[workspaceId]
+    const activeStillValid =
+      activeSessionId === null || sessions.some(session => session.sessionId === activeSessionId)
+    if (hasActiveSelection && activeStillValid) return
+    liveStore.getState().setActive(workspaceId, sessions[0]?.sessionId ?? null)
   }, [workspaceId, sessions])
   return null
 }

--- a/client/components/shared/Composer.tsx
+++ b/client/components/shared/Composer.tsx
@@ -23,8 +23,11 @@ export function Composer({
       onMouseDown={event => {
         onMouseDown?.(event)
         if (event.defaultPrevented) return
-        if (event.target instanceof HTMLElement && event.target.closest('button')) return
-        event.preventDefault()
+        if (
+          event.target instanceof Element &&
+          event.target.closest('button, input, textarea, select, a, [contenteditable="true"]')
+        )
+          return
         composerRef.current?.focus()
       }}
       className={cn(

--- a/client/components/shared/Composer.tsx
+++ b/client/components/shared/Composer.tsx
@@ -31,7 +31,7 @@ export function Composer({
         composerRef.current?.focus()
       }}
       className={cn(
-        'flex w-full max-w-(--chat-max-container) cursor-text flex-col gap-1 rounded-lg bg-card p-2 text-card-foreground shadow-xs transition-[color,box-shadow] outline-none focus-within:shadow-sm',
+        'flex w-full cursor-text flex-col gap-1 rounded-lg bg-card p-2 text-card-foreground shadow-xs transition-[color,box-shadow] outline-none focus-within:shadow-sm',
         className
       )}
     >

--- a/client/features/chat/ChatEmptyState.test.tsx
+++ b/client/features/chat/ChatEmptyState.test.tsx
@@ -1,0 +1,56 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  ChatEmptyState,
+  type ChatEmptyStateKind,
+  resolveChatEmptyState
+} from '@/client/features/chat/ChatEmptyState'
+
+function renderState(kind: ChatEmptyStateKind): string {
+  return renderToStaticMarkup(
+    createElement(ChatEmptyState, {
+      kind,
+      onSelectPrompt: () => undefined
+    })
+  )
+}
+
+describe('resolveChatEmptyState', () => {
+  test('gives the global chat welcome first priority', () => {
+    expect(
+      resolveChatEmptyState({
+        hasSentMessageFromMoi: false,
+        isWorkspacePendingAnalysis: true
+      })
+    ).toBe('chat-welcome')
+  })
+
+  test('shows the workspace welcome for a pending imported workspace', () => {
+    expect(
+      resolveChatEmptyState({
+        hasSentMessageFromMoi: true,
+        isWorkspacePendingAnalysis: true
+      })
+    ).toBe('workspace-welcome')
+  })
+
+  test('uses the simple empty state without pending analysis', () => {
+    expect(
+      resolveChatEmptyState({
+        hasSentMessageFromMoi: true,
+        isWorkspacePendingAnalysis: false
+      })
+    ).toBe('empty')
+  })
+})
+
+describe('ChatEmptyState', () => {
+  test('renders the selected empty state', () => {
+    expect(renderState('chat-welcome')).toContain('moi is the visual workspace')
+    expect(renderState('workspace-welcome')).toContain('What could you build?')
+    expect(renderState('empty')).toContain('Chat with your agent')
+  })
+})

--- a/client/features/chat/ChatEmptyState.test.tsx
+++ b/client/features/chat/ChatEmptyState.test.tsx
@@ -50,7 +50,7 @@ describe('resolveChatEmptyState', () => {
 describe('ChatEmptyState', () => {
   test('renders the selected empty state', () => {
     expect(renderState('chat-welcome')).toContain('moi is the visual workspace')
-    expect(renderState('workspace-welcome')).toContain('What could you build?')
+    expect(renderState('workspace-welcome')).toContain('Explore the workspace')
     expect(renderState('empty')).toContain('Chat with your agent')
   })
 })

--- a/client/features/chat/ChatEmptyState.tsx
+++ b/client/features/chat/ChatEmptyState.tsx
@@ -1,6 +1,7 @@
 import {
   IconArticle,
   IconBriefcase,
+  IconFileSearch,
   IconGhost,
   IconLayout2,
   IconPiano,
@@ -9,7 +10,12 @@ import {
   type TablerIcon
 } from '@tabler/icons-react'
 
-import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
+import {
+  ChatPromptBubble,
+  ChatPromptBubbles,
+  type ChatPromptBubble as ChatPrompt
+} from '@/client/features/chat/ChatPromptBubbles'
+import { cn } from '@/client/lib/cn'
 
 export const CHAT_WELCOME_PROMPTS = [
   {
@@ -53,16 +59,62 @@ export const CHAT_WELCOME_PROMPTS = [
     ],
     icon: IconBriefcase
   }
-] satisfies ChatPromptBubble[]
+] satisfies ChatPrompt[]
 
-type ChatWelcomeProps = {
-  disabled?: boolean
-  onSelectPrompt: (prompt: ChatPromptBubble) => void
+export const WORKSPACE_ANALYSIS_PROMPT = {
+  label: 'Explore the workspace',
+  prompt: 'Explore this workspace and suggest what moi can build based on its content',
+  context: [
+    'Explore the existing workspace files before making suggestions.',
+    'Briefly explain what the workspace appears to be for and which content informed your ideas.',
+    'Propose a focused set of useful widgets or views that fit the work already here.',
+    'Wait for me to choose before building anything.'
+  ],
+  icon: IconFileSearch
+} satisfies ChatPrompt
+
+export type ChatEmptyStateKind = 'chat-welcome' | 'workspace-welcome' | 'empty'
+
+type ResolveChatEmptyStateOptions = {
+  hasSentMessageFromMoi: boolean
+  isWorkspacePendingAnalysis: boolean
 }
 
-export function ChatWelcome({ disabled = false, onSelectPrompt }: ChatWelcomeProps) {
+export function resolveChatEmptyState({
+  hasSentMessageFromMoi,
+  isWorkspacePendingAnalysis
+}: ResolveChatEmptyStateOptions): ChatEmptyStateKind {
+  if (!hasSentMessageFromMoi) return 'chat-welcome'
+  if (isWorkspacePendingAnalysis) return 'workspace-welcome'
+  return 'empty'
+}
+
+const EMPTY_STATE_STYLES = cn('flex flex-1 flex-col items-center justify-center')
+
+type ChatEmptyStateProps = {
+  kind: ChatEmptyStateKind
+  disabled?: boolean
+  onSelectPrompt: (prompt: ChatPrompt) => void
+}
+
+export function ChatEmptyState({ kind, disabled = false, onSelectPrompt }: ChatEmptyStateProps) {
+  if (kind === 'chat-welcome') {
+    return <ChatWelcome disabled={disabled} onSelectPrompt={onSelectPrompt} />
+  }
+  if (kind === 'workspace-welcome') {
+    return <ChatWorkspaceWelcome disabled={disabled} onSelectPrompt={onSelectPrompt} />
+  }
+  return <EmptyState />
+}
+
+type WelcomeProps = {
+  disabled?: boolean
+  onSelectPrompt: (prompt: ChatPrompt) => void
+}
+
+export function ChatWelcome({ disabled = false, onSelectPrompt }: WelcomeProps) {
   return (
-    <div className="flex min-h-full max-w-md min-w-0 flex-col items-center justify-center self-center pb-2">
+    <div className={cn(EMPTY_STATE_STYLES, 'max-w-md min-w-0')}>
       <div className="prose prose-sm min-w-0 wrap-anywhere prose-inherit">
         <p>moi is the visual workspace for you and your agent.</p>
         <p>
@@ -84,6 +136,31 @@ export function ChatWelcome({ disabled = false, onSelectPrompt }: ChatWelcomePro
         disabled={disabled}
         onSelect={onSelectPrompt}
       />
+    </div>
+  )
+}
+
+export function ChatWorkspaceWelcome({ disabled = false, onSelectPrompt }: WelcomeProps) {
+  return (
+    <div className={cn(EMPTY_STATE_STYLES, 'gap-2')}>
+      <div className="prose prose-sm max-w-60 min-w-0 text-center wrap-anywhere text-muted-foreground prose-inherit">
+        <p>See what moi can build for you</p>
+      </div>
+      <ChatPromptBubble
+        prompt={WORKSPACE_ANALYSIS_PROMPT}
+        disabled={disabled}
+        onSelect={onSelectPrompt}
+      />
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className={cn(EMPTY_STATE_STYLES, 'gap-1 text-center')}>
+      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+        Chat with your agent, create widgets and views, and manage your workspace context from here
+      </p>
     </div>
   )
 }

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -32,13 +32,6 @@ type ChatPanelProps = {
   send: (text: string) => void
   stop: () => void
   onSwitchThread: (sessionId: string | null) => void
-  // Extra content for the header's left edge, rendered before the thread
-  // selector when the chat is the primary panel.
-  headerLeft?: ReactNode
-  // Extra controls for the header's right edge — the parent supplies whatever
-  // chrome belongs here in the current layout (e.g. the section reopen toggle
-  // plus MCP/settings menus when the chat is fullscreen).
-  headerRight?: ReactNode
   // Floating popup: render a close (X) button that dismisses the popup.
   onClose?: () => void
 }
@@ -57,8 +50,6 @@ export function ChatPanel({
   send,
   stop,
   onSwitchThread,
-  headerLeft,
-  headerRight,
   onClose
 }: ChatPanelProps) {
   const composerRef = useRef<HTMLTextAreaElement>(null)
@@ -102,19 +93,13 @@ export function ChatPanel({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col pt-2 pb-3">
-      <header className="flex items-center justify-between pr-2 pb-2 pl-2">
-        <div className="flex min-w-0 items-center gap-2.5">
-          {headerLeft}
-          <ChatSelector onSwitch={onSwitchThread} />
-        </div>
-        <div className="flex items-center gap-0.5">
-          {headerRight}
-          {onClose && (
-            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close chat">
-              <IconX stroke={1.5} />
-            </Button>
-          )}
-        </div>
+      <header className="mx-auto flex w-full max-w-[calc(var(--chat-max-container)+40px)] items-center justify-between pr-2 pb-2 pl-2">
+        <ChatSelector onSwitch={onSwitchThread} />
+        {onClose && (
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close chat">
+            <IconX stroke={1.5} />
+          </Button>
+        )}
       </header>
 
       <div className="relative flex min-h-0 flex-1 flex-col">
@@ -158,9 +143,9 @@ export function ChatPanel({
         )}
       </div>
 
-      <div className="mx-auto flex w-full flex-col items-center px-3">
+      <div className="mx-auto flex w-full max-w-[calc(var(--chat-max-container)+24px)] flex-col px-3">
         {error && (
-          <div className="mb-2 flex w-full max-w-(--chat-max-container) items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <div className="mb-2 flex w-full items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             <span className="flex-1 wrap-break-word">{error}</span>
             {onDismissError && (
               <Button

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 
 import { IconChevronDown, IconX } from '@tabler/icons-react'
 

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -12,9 +12,9 @@ import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import type { Turn, ViewState } from '@/lib/types'
 
 import { ChatComposer } from './ChatComposer'
+import { ChatEmptyState, resolveChatEmptyState } from './ChatEmptyState'
 import { ChatSelector } from './ChatSelector'
-import { ChatWelcome } from './ChatWelcome'
-import { EmptyState, ThinkingIndicator, TurnView } from './TurnView'
+import { ThinkingIndicator, TurnView } from './TurnView'
 import { Button } from '@/client/components/ui/button'
 import { useUiStore } from '@/client/store/ui'
 
@@ -62,6 +62,9 @@ export function ChatPanel({
   const scrollRef = useRef<HTMLDivElement>(null)
   const turns = view.turns
   const hasSentMessageFromMoi = useUiStore(state => state.hasSentMessageFromMoi)
+  const isWorkspacePendingAnalysis = useUiStore(state =>
+    (state.workspaceIdsPendingAnalysis ?? []).includes(workspaceId)
+  )
   const attachmentsUploading = useLive(state =>
     (state.attachments[draftKey(workspaceId, sessionId ?? null)] ?? []).some(
       attachment => attachment.status === 'uploading'
@@ -79,13 +82,17 @@ export function ChatPanel({
     [turns, previewTurn]
   )
   const showEmptyChat = chatLoaded && groupedTurns.length === 0 && !processing
+  const emptyStateKind = resolveChatEmptyState({
+    hasSentMessageFromMoi,
+    isWorkspacePendingAnalysis
+  })
 
   // Stick to the bottom while pinned; respect scroll-up; jump on thread switch.
   const { atBottom, scrollToBottom, scrollToTop } = useStickToBottom(scrollRef, sessionId)
 
   useLayoutEffect(() => {
-    if (showEmptyChat && !hasSentMessageFromMoi) scrollToTop()
-  }, [showEmptyChat, hasSentMessageFromMoi, scrollToTop])
+    if (showEmptyChat && emptyStateKind !== 'empty') scrollToTop()
+  }, [showEmptyChat, emptyStateKind, scrollToTop])
 
   // The active chat surface owns initial focus. A monotonically increasing
   // request also refocuses an already-visible composer after intent actions.
@@ -128,12 +135,13 @@ export function ChatPanel({
           className="flex scrollbar-thin flex-1 scroll-fade flex-col overflow-y-auto overscroll-contain px-5 pt-4 pb-12 [--scroll-fade-reveal:8px]"
         >
           <div className="mx-auto flex w-full max-w-(--chat-max-container) flex-1 flex-col gap-6">
-            {showEmptyChat &&
-              (hasSentMessageFromMoi ? (
-                <EmptyState />
-              ) : (
-                <ChatWelcome disabled={promptDisabled} onSelectPrompt={handlePromptSelect} />
-              ))}
+            {showEmptyChat && (
+              <ChatEmptyState
+                kind={emptyStateKind}
+                disabled={promptDisabled}
+                onSelectPrompt={handlePromptSelect}
+              />
+            )}
             {groupedTurns.map((turn, i) => (
               <TurnView
                 key={turn.id}

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 
 import { IconChevronDown, IconX } from '@tabler/icons-react'
 
@@ -8,12 +8,15 @@ import type { Turn, ViewState } from '@/lib/types'
 
 import { ChatComposer } from './ChatComposer'
 import { ChatSelector } from './ChatSelector'
+import { ChatWelcome } from './ChatWelcome'
 import { EmptyState, ThinkingIndicator, TurnView } from './TurnView'
 import { Button } from '@/client/components/ui/button'
+import { useUiStore } from '@/client/store/ui'
 
 type ChatPanelProps = {
   active?: boolean
   focusRequest?: number
+  chatReady: boolean
   view: ViewState
   // The live streaming preview as a synthetic assistant turn (or null). Merged
   // into the transcript through the same groupTurns pipeline so a thinking-only
@@ -43,6 +46,7 @@ type ChatPanelProps = {
 export function ChatPanel({
   active = true,
   focusRequest = 0,
+  chatReady,
   view,
   previewTurn,
   sessionId,
@@ -60,6 +64,7 @@ export function ChatPanel({
   const composerRef = useRef<HTMLTextAreaElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const turns = view.turns
+  const hasSentMessageFromMoi = useUiStore(state => state.hasSentMessageFromMoi)
   // Visual grouping: fold consecutive tool-only assistant turns into one
   // synthetic turn so OpenAI Codex–style traces (which serialize one
   // assistant message per agent step) don't render with the wider
@@ -70,9 +75,14 @@ export function ChatPanel({
     () => groupTurns(previewTurn ? [...turns, previewTurn] : turns),
     [turns, previewTurn]
   )
+  const showEmptyChat = chatReady && groupedTurns.length === 0 && !processing
 
   // Stick to the bottom while pinned; respect scroll-up; jump on thread switch.
-  const { atBottom, scrollToBottom } = useStickToBottom(scrollRef, sessionId)
+  const { atBottom, scrollToBottom, scrollToTop } = useStickToBottom(scrollRef, sessionId)
+
+  useLayoutEffect(() => {
+    if (showEmptyChat && !hasSentMessageFromMoi) scrollToTop()
+  }, [showEmptyChat, hasSentMessageFromMoi, scrollToTop])
 
   // The active chat surface owns initial focus. A monotonically increasing
   // request also refocuses an already-visible composer after intent actions.
@@ -113,7 +123,12 @@ export function ChatPanel({
           className="flex scrollbar-thin flex-1 scroll-fade flex-col overflow-y-auto overscroll-contain px-5 pt-4 pb-12 [--scroll-fade-reveal:8px]"
         >
           <div className="mx-auto flex w-full max-w-(--chat-max-container) flex-1 flex-col gap-6">
-            {turns.length === 0 && !processing && <EmptyState />}
+            {showEmptyChat &&
+              (hasSentMessageFromMoi ? (
+                <EmptyState />
+              ) : (
+                <ChatWelcome onSelectPrompt={handleSend} />
+              ))}
             {groupedTurns.map((turn, i) => (
               <TurnView
                 key={turn.id}

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -18,7 +18,7 @@ import { useUiStore } from '@/client/store/ui'
 type ChatPanelProps = {
   active?: boolean
   focusRequest?: number
-  chatReady: boolean
+  chatLoaded: boolean
   view: ViewState
   // The live streaming preview as a synthetic assistant turn (or null). Merged
   // into the transcript through the same groupTurns pipeline so a thinking-only
@@ -41,7 +41,7 @@ type ChatPanelProps = {
 export function ChatPanel({
   active = true,
   focusRequest = 0,
-  chatReady,
+  chatLoaded,
   view,
   previewTurn,
   sessionId,
@@ -68,7 +68,7 @@ export function ChatPanel({
     () => groupTurns(previewTurn ? [...turns, previewTurn] : turns),
     [turns, previewTurn]
   )
-  const showEmptyChat = chatReady && groupedTurns.length === 0 && !processing
+  const showEmptyChat = chatLoaded && groupedTurns.length === 0 && !processing
 
   // Stick to the bottom while pinned; respect scroll-up; jump on thread switch.
   const { atBottom, scrollToBottom, scrollToTop } = useStickToBottom(scrollRef, sessionId)

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -4,6 +4,8 @@ import { IconChevronDown, IconX } from '@tabler/icons-react'
 
 import { useStickToBottom } from '@/client/features/chat/useStickToBottom'
 import { groupTurns } from '@/client/features/chat/group-turns'
+import type { ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
+import type { ChatSendOptions } from '@/client/features/chat/chat-send'
 import type { Turn, ViewState } from '@/lib/types'
 
 import { ChatComposer } from './ChatComposer'
@@ -29,7 +31,7 @@ type ChatPanelProps = {
   error?: string | null
   onDismissError?: () => void
   unavailableReason: string | null | undefined
-  send: (text: string) => void
+  send: (text: string, options?: ChatSendOptions) => void
   stop: () => void
   onSwitchThread: (sessionId: string | null) => void
   // Floating popup: render a close (X) button that dismisses the popup.
@@ -84,11 +86,18 @@ export function ChatPanel({
   // Sending always returns the user to the bottom, even if they'd scrolled up —
   // they expect to see their message and the reply.
   const handleSend = useCallback(
-    (text: string) => {
-      send(text)
+    (text: string, options?: ChatSendOptions) => {
+      send(text, options)
       scrollToBottom()
     },
     [send, scrollToBottom]
+  )
+
+  const handlePromptSelect = useCallback(
+    (prompt: ChatPromptBubble) => {
+      handleSend(prompt.prompt, { directives: prompt.context })
+    },
+    [handleSend]
   )
 
   return (
@@ -112,7 +121,7 @@ export function ChatPanel({
               (hasSentMessageFromMoi ? (
                 <EmptyState />
               ) : (
-                <ChatWelcome onSelectPrompt={handleSend} />
+                <ChatWelcome onSelectPrompt={handlePromptSelect} />
               ))}
             {groupedTurns.map((turn, i) => (
               <TurnView

--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 
 import { IconChevronDown, IconX } from '@tabler/icons-react'
 
+import { canSubmitComposerAction } from '@/client/components/shared/Composer'
 import { useStickToBottom } from '@/client/features/chat/useStickToBottom'
 import { groupTurns } from '@/client/features/chat/group-turns'
+import { draftKey, useLive } from '@/client/features/chat/chat-store'
 import type { ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
 import type { ChatSendOptions } from '@/client/features/chat/chat-send'
+import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import type { Turn, ViewState } from '@/lib/types'
 
 import { ChatComposer } from './ChatComposer'
@@ -54,10 +57,17 @@ export function ChatPanel({
   onSwitchThread,
   onClose
 }: ChatPanelProps) {
+  const workspaceId = useWorkspaceId()
   const composerRef = useRef<HTMLTextAreaElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const turns = view.turns
   const hasSentMessageFromMoi = useUiStore(state => state.hasSentMessageFromMoi)
+  const attachmentsUploading = useLive(state =>
+    (state.attachments[draftKey(workspaceId, sessionId ?? null)] ?? []).some(
+      attachment => attachment.status === 'uploading'
+    )
+  )
+  const promptDisabled = !canSubmitComposerAction(true, attachmentsUploading, unavailableReason)
   // Visual grouping: fold consecutive tool-only assistant turns into one
   // synthetic turn so OpenAI Codex–style traces (which serialize one
   // assistant message per agent step) don't render with the wider
@@ -95,9 +105,10 @@ export function ChatPanel({
 
   const handlePromptSelect = useCallback(
     (prompt: ChatPromptBubble) => {
+      if (promptDisabled) return
       handleSend(prompt.prompt, { directives: prompt.context })
     },
-    [handleSend]
+    [handleSend, promptDisabled]
   )
 
   return (
@@ -121,7 +132,7 @@ export function ChatPanel({
               (hasSentMessageFromMoi ? (
                 <EmptyState />
               ) : (
-                <ChatWelcome onSelectPrompt={handlePromptSelect} />
+                <ChatWelcome disabled={promptDisabled} onSelectPrompt={handlePromptSelect} />
               ))}
             {groupedTurns.map((turn, i) => (
               <TurnView

--- a/client/features/chat/ChatPromptBubbles.test.tsx
+++ b/client/features/chat/ChatPromptBubbles.test.tsx
@@ -1,0 +1,29 @@
+import { Children, type ReactElement, type ReactNode } from 'react'
+
+import { IconPiano } from '@tabler/icons-react'
+import { describe, expect, mock, test } from 'bun:test'
+
+import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
+
+describe('ChatPromptBubbles', () => {
+  test('returns the complete prompt when selected', () => {
+    const prompt: ChatPromptBubble = {
+      label: 'Build a synthesizer',
+      prompt: 'Build me a synthesizer',
+      context: ['Use the browser audio APIs.', 'Save recordings in the workspace.'],
+      icon: IconPiano
+    }
+    const onSelect = mock(() => undefined)
+    const root = ChatPromptBubbles({ prompts: [prompt], onSelect }) as ReactElement<{
+      children: ReactNode
+    }>
+    const button = Children.toArray(root.props.children)[0] as ReactElement<{
+      onClick: () => void
+    }>
+
+    button.props.onClick()
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(prompt)
+  })
+})

--- a/client/features/chat/ChatPromptBubbles.test.tsx
+++ b/client/features/chat/ChatPromptBubbles.test.tsx
@@ -3,27 +3,51 @@ import { Children, type ReactElement, type ReactNode } from 'react'
 import { IconPiano } from '@tabler/icons-react'
 import { describe, expect, mock, test } from 'bun:test'
 
-import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
+import {
+  ChatPromptBubble,
+  ChatPromptBubbles,
+  type ChatPromptBubble as ChatPrompt
+} from '@/client/features/chat/ChatPromptBubbles'
+
+const prompt: ChatPrompt = {
+  label: 'Build a synthesizer',
+  prompt: 'Build me a synthesizer',
+  context: ['Use the browser audio APIs.', 'Save recordings in the workspace.'],
+  icon: IconPiano
+}
 
 describe('ChatPromptBubbles', () => {
-  test('returns the complete prompt when selected', () => {
-    const prompt: ChatPromptBubble = {
-      label: 'Build a synthesizer',
-      prompt: 'Build me a synthesizer',
-      context: ['Use the browser audio APIs.', 'Save recordings in the workspace.'],
-      icon: IconPiano
-    }
+  test('the singular bubble returns the complete prompt without layout styles', () => {
     const onSelect = mock(() => undefined)
-    const root = ChatPromptBubbles({ prompts: [prompt], onSelect }) as ReactElement<{
-      children: ReactNode
-    }>
-    const button = Children.toArray(root.props.children)[0] as ReactElement<{
+    const bubble = ChatPromptBubble({ prompt, onSelect }) as ReactElement<{
+      className?: string
       onClick: () => void
     }>
 
-    button.props.onClick()
+    bubble.props.onClick()
 
     expect(onSelect).toHaveBeenCalledTimes(1)
     expect(onSelect).toHaveBeenCalledWith(prompt)
+    expect(bubble.props.className).not.toContain('grid')
+    expect(bubble.props.className).not.toContain('rotate')
+    expect(bubble.props.className).not.toContain('translate')
+  })
+
+  test('the plural component owns grid and rotation styles', () => {
+    const root = ChatPromptBubbles({
+      prompts: [prompt],
+      onSelect: () => undefined
+    }) as ReactElement<{
+      children: ReactNode
+      className?: string
+    }>
+    const bubble = Children.toArray(root.props.children)[0] as ReactElement<{
+      className?: string
+    }>
+
+    expect(root.props.className).toContain('grid')
+    expect(bubble.type).toBe(ChatPromptBubble)
+    expect(bubble.props.className).toContain('rotate-3')
+    expect(bubble.props.className).toContain('translate-y-3')
   })
 })

--- a/client/features/chat/ChatPromptBubbles.tsx
+++ b/client/features/chat/ChatPromptBubbles.tsx
@@ -1,8 +1,12 @@
+import type { TablerIcon } from '@tabler/icons-react'
+
 import { Button } from '@/client/components/ui/button'
+import { cn } from '@/client/lib/cn'
 
 export type ChatPromptBubble = {
   label: string
   prompt: string
+  icon: TablerIcon
 }
 
 type ChatPromptBubblesProps = {
@@ -13,20 +17,31 @@ type ChatPromptBubblesProps = {
 
 export function ChatPromptBubbles({ prompts, disabled = false, onSelect }: ChatPromptBubblesProps) {
   return (
-    <div className="flex flex-wrap items-start gap-2">
-      {prompts.map(prompt => (
-        <Button
-          key={prompt.prompt}
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled}
-          onClick={() => onSelect(prompt.prompt)}
-          className="h-auto min-h-8 max-w-full shrink justify-start rounded-lg px-3 py-2 text-left leading-snug whitespace-normal shadow-sm hover:shadow-md"
-        >
-          {prompt.label}
-        </Button>
-      ))}
+    <div className="grid w-full grid-cols-1 gap-3 py-2 sm:grid-cols-3">
+      {prompts.map((prompt, index) => {
+        const Icon = prompt.icon
+
+        return (
+          <Button
+            key={prompt.prompt}
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={disabled}
+            onClick={() => onSelect(prompt.prompt)}
+            className={cn(
+              'h-full w-full items-start justify-start gap-2 rounded-lg p-3 pl-4 text-left leading-snug whitespace-normal',
+              'hover:bg-accent',
+              index === 0 && 'translate-y-3 rotate-3 hover:translate-y-2.5',
+              index === 1 && 'translate-y-0 -rotate-1 hover:-translate-y-0.5',
+              index === 2 && 'translate-y-3 -rotate-4 hover:translate-y-2.5'
+            )}
+          >
+            <Icon stroke={2} aria-hidden className="mt-0.5 text-muted-foreground" />
+            <span>{prompt.label}</span>
+          </Button>
+        )
+      })}
     </div>
   )
 }

--- a/client/features/chat/ChatPromptBubbles.tsx
+++ b/client/features/chat/ChatPromptBubbles.tsx
@@ -10,6 +10,40 @@ export type ChatPromptBubble = {
   icon: TablerIcon
 }
 
+type ChatPromptBubbleProps = {
+  className?: string
+  prompt: ChatPromptBubble
+  disabled?: boolean
+  onSelect: (prompt: ChatPromptBubble) => void
+}
+
+export function ChatPromptBubble({
+  className,
+  prompt,
+  disabled = false,
+  onSelect
+}: ChatPromptBubbleProps) {
+  const Icon = prompt.icon
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      disabled={disabled}
+      onClick={() => onSelect(prompt)}
+      className={cn(
+        'h-auto items-start justify-start gap-2 rounded-lg p-3 px-4 text-left leading-snug whitespace-normal',
+        'hover:bg-accent',
+        className
+      )}
+    >
+      <Icon stroke={2} aria-hidden className="mt-0.5 text-muted-foreground" />
+      <span>{prompt.label}</span>
+    </Button>
+  )
+}
+
 type ChatPromptBubblesProps = {
   prompts: readonly ChatPromptBubble[]
   disabled?: boolean
@@ -20,27 +54,19 @@ export function ChatPromptBubbles({ prompts, disabled = false, onSelect }: ChatP
   return (
     <div className="grid w-full grid-cols-1 gap-3 py-2 sm:grid-cols-3">
       {prompts.map((prompt, index) => {
-        const Icon = prompt.icon
-
         return (
-          <Button
+          <ChatPromptBubble
             key={prompt.prompt}
-            type="button"
-            variant="secondary"
-            size="sm"
+            prompt={prompt}
             disabled={disabled}
-            onClick={() => onSelect(prompt)}
+            onSelect={onSelect}
             className={cn(
-              'h-full w-full items-start justify-start gap-2 rounded-lg p-3 pl-4 text-left leading-snug whitespace-normal',
-              'hover:bg-accent',
+              'h-full w-full',
               index === 0 && 'translate-y-3 rotate-3 hover:translate-y-2.5',
               index === 1 && 'translate-y-0 -rotate-1 hover:-translate-y-0.5',
               index === 2 && 'translate-y-3 -rotate-4 hover:translate-y-2.5'
             )}
-          >
-            <Icon stroke={2} aria-hidden className="mt-0.5 text-muted-foreground" />
-            <span>{prompt.label}</span>
-          </Button>
+          />
         )
       })}
     </div>

--- a/client/features/chat/ChatPromptBubbles.tsx
+++ b/client/features/chat/ChatPromptBubbles.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/client/components/ui/button'
+
+export type ChatPromptBubble = {
+  label: string
+  prompt: string
+}
+
+type ChatPromptBubblesProps = {
+  prompts: readonly ChatPromptBubble[]
+  disabled?: boolean
+  onSelect: (prompt: string) => void
+}
+
+export function ChatPromptBubbles({ prompts, disabled = false, onSelect }: ChatPromptBubblesProps) {
+  return (
+    <div className="flex flex-wrap items-start gap-2">
+      {prompts.map(prompt => (
+        <Button
+          key={prompt.prompt}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => onSelect(prompt.prompt)}
+          className="h-auto min-h-8 max-w-full shrink justify-start rounded-lg px-3 py-2 text-left leading-snug whitespace-normal shadow-sm hover:shadow-md"
+        >
+          {prompt.label}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/client/features/chat/ChatPromptBubbles.tsx
+++ b/client/features/chat/ChatPromptBubbles.tsx
@@ -6,13 +6,14 @@ import { cn } from '@/client/lib/cn'
 export type ChatPromptBubble = {
   label: string
   prompt: string
+  context: readonly string[]
   icon: TablerIcon
 }
 
 type ChatPromptBubblesProps = {
   prompts: readonly ChatPromptBubble[]
   disabled?: boolean
-  onSelect: (prompt: string) => void
+  onSelect: (prompt: ChatPromptBubble) => void
 }
 
 export function ChatPromptBubbles({ prompts, disabled = false, onSelect }: ChatPromptBubblesProps) {
@@ -28,7 +29,7 @@ export function ChatPromptBubbles({ prompts, disabled = false, onSelect }: ChatP
             variant="secondary"
             size="sm"
             disabled={disabled}
-            onClick={() => onSelect(prompt.prompt)}
+            onClick={() => onSelect(prompt)}
             className={cn(
               'h-full w-full items-start justify-start gap-2 rounded-lg p-3 pl-4 text-left leading-snug whitespace-normal',
               'hover:bg-accent',

--- a/client/features/chat/ChatWelcome.test.tsx
+++ b/client/features/chat/ChatWelcome.test.tsx
@@ -1,0 +1,46 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { describe, expect, test } from 'bun:test'
+
+import { ChatWelcome } from '@/client/features/chat/ChatWelcome'
+
+function renderedParagraphs(html: string): string[] {
+  return [...html.matchAll(/<p>(.*?)<\/p>/gs)].map(match =>
+    match[1]
+      .replace(/<svg.*?<\/svg>/gs, '')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
+}
+
+describe('ChatWelcome', () => {
+  test('keeps the canonical welcome copy exact', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChatWelcome, { onSelectPrompt: () => undefined })
+    )
+
+    expect(renderedParagraphs(html)).toEqual([
+      'moi is the UI for your AI.',
+      'Build functional, reusable interfaces for your workspace. moi makes it easy to create apps that work with your data, manage workspace files, connect to external services, and adapt to your specific needs. Describe what you want, and your agent builds it directly inside the workspace.',
+      'You start in Chat, where you can build with your agent and ask any questions. Widgets are small apps on the Widgets tab that surface information and provide quick actions. For more complex tools, you can build Views that open in their own tabs. Scratchpad is a shared canvas for exploring and shaping ideas with your agent.',
+      'As your needs evolve, you can add new tools, refine existing ones, and keep shaping the workspace around the way you work. You can also use your existing Claude or ChatGPT subscription directly in moi.',
+      'What would you like to create first?'
+    ])
+  })
+
+  test('renders four inline icons and three floating prompt bubbles', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChatWelcome, { onSelectPrompt: () => undefined })
+    )
+
+    expect((html.match(/<svg/g) ?? []).length).toBe(4)
+    expect((html.match(/<button/g) ?? []).length).toBe(3)
+    expect(html).toContain('rounded-lg')
+    expect(html).toContain('shadow-sm')
+    expect(html).toContain('whitespace-normal')
+    expect(html).toContain('“Track my daily habits.”')
+    expect(html).not.toContain('<li>')
+  })
+})

--- a/client/features/chat/ChatWelcome.test.tsx
+++ b/client/features/chat/ChatWelcome.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 
 import { describe, expect, test } from 'bun:test'
 
-import { CHAT_WELCOME_PROMPTS, ChatWelcome } from '@/client/features/chat/ChatWelcome'
+import { CHAT_WELCOME_PROMPTS, ChatWelcome } from '@/client/features/chat/ChatEmptyState'
 import { renderMoiContext } from '@/lib/moi-context'
 
 function renderedParagraphs(html: string): string[] {

--- a/client/features/chat/ChatWelcome.test.tsx
+++ b/client/features/chat/ChatWelcome.test.tsx
@@ -50,6 +50,16 @@ describe('ChatWelcome', () => {
     expect(html).toContain('Make a job tracker')
   })
 
+  test('disables every prompt when sending is unavailable', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChatWelcome, { disabled: true, onSelectPrompt: () => undefined })
+    )
+    const promptButtons = [...html.matchAll(/<button.*?<\/button>/gs)]
+
+    expect(promptButtons).toHaveLength(3)
+    expect(promptButtons.every(([button]) => button.includes('disabled=""'))).toBe(true)
+  })
+
   test('keeps visible requests separate from detailed build context', () => {
     expect(CHAT_WELCOME_PROMPTS.map(({ label, prompt }) => ({ label, prompt }))).toEqual([
       {

--- a/client/features/chat/ChatWelcome.test.tsx
+++ b/client/features/chat/ChatWelcome.test.tsx
@@ -3,13 +3,15 @@ import { renderToStaticMarkup } from 'react-dom/server'
 
 import { describe, expect, test } from 'bun:test'
 
-import { ChatWelcome } from '@/client/features/chat/ChatWelcome'
+import { CHAT_WELCOME_PROMPTS, ChatWelcome } from '@/client/features/chat/ChatWelcome'
+import { renderMoiContext } from '@/lib/moi-context'
 
 function renderedParagraphs(html: string): string[] {
   return [...html.matchAll(/<p>(.*?)<\/p>/gs)].map(match =>
     match[1]
       .replace(/<svg.*?<\/svg>/gs, '')
       .replace(/<[^>]+>/g, '')
+      .replaceAll('&#x27;', "'")
       .replace(/\s+/g, ' ')
       .trim()
   )
@@ -22,25 +24,73 @@ describe('ChatWelcome', () => {
     )
 
     expect(renderedParagraphs(html)).toEqual([
-      'moi is the UI for your AI.',
-      'Build functional, reusable interfaces for your workspace. moi makes it easy to create apps that work with your data, manage workspace files, connect to external services, and adapt to your specific needs. Describe what you want, and your agent builds it directly inside the workspace.',
-      'You start in Chat, where you can build with your agent and ask any questions. Widgets are small apps on the Widgets tab that surface information and provide quick actions. For more complex tools, you can build Views that open in their own tabs. Scratchpad is a shared canvas for exploring and shaping ideas with your agent.',
-      'As your needs evolve, you can add new tools, refine existing ones, and keep shaping the workspace around the way you work. You can also use your existing Claude or ChatGPT subscription directly in moi.',
-      'What would you like to create first?'
+      'moi is the visual workspace for you and your agent.',
+      "It can grow and adapt it to the work you're doing. Just describe what you want, and the agent will build small apps in the workspace.",
+      'You start chatting with Agent, where you can ask questions and build anything. Widgets are small apps that surface information and provide quick actions. For more complex tools, you can build Views that open in their own tabs. Scratchpad is a shared canvas for exploring and shaping ideas with your agent.',
+      'Give it a try:'
     ])
   })
 
-  test('renders four inline icons and three floating prompt bubbles', () => {
+  test('renders four inline icons and three prompt bubbles with icons', () => {
     const html = renderToStaticMarkup(
       createElement(ChatWelcome, { onSelectPrompt: () => undefined })
     )
 
-    expect((html.match(/<svg/g) ?? []).length).toBe(4)
-    expect((html.match(/<button/g) ?? []).length).toBe(3)
+    const welcomeTerms = [...html.matchAll(/<strong.*?<\/strong>/gs)]
+    const promptButtons = [...html.matchAll(/<button.*?<\/button>/gs)]
+
+    expect(welcomeTerms).toHaveLength(4)
+    expect(welcomeTerms.every(([term]) => term.includes('<svg'))).toBe(true)
+    expect(promptButtons).toHaveLength(3)
+    expect(promptButtons.every(([button]) => button.includes('<svg'))).toBe(true)
     expect(html).toContain('rounded-lg')
-    expect(html).toContain('shadow-sm')
     expect(html).toContain('whitespace-normal')
-    expect(html).toContain('“Track my daily habits.”')
-    expect(html).not.toContain('<li>')
+    expect(html).toContain('What&#x27;s the weather?')
+    expect(html).toContain('Build a fun synthesizer')
+    expect(html).toContain('Make a job tracker')
+  })
+
+  test('keeps visible requests separate from detailed build context', () => {
+    expect(CHAT_WELCOME_PROMPTS.map(({ label, prompt }) => ({ label, prompt }))).toEqual([
+      {
+        label: "What's the weather?",
+        prompt:
+          "Build me a set of weather widgets that surface current conditions, today's hourly forecast, and a simple weekly outlook at a glance"
+      },
+      {
+        label: 'Build a fun synthesizer',
+        prompt:
+          'Build me a view with a simple, playful synthesizer featuring a keyboard, five sound controls, and the ability to record, save, and load music files from the workspace'
+      },
+      {
+        label: 'Make a job tracker',
+        prompt:
+          'Build me a view with a visual job search board where I can add opportunities by pasting a job link, automatically extract the details, move opportunities through stages, and keep notes and related files in the workspace'
+      }
+    ])
+
+    const [weather, synthesizer, jobTracker] = CHAT_WELCOME_PROMPTS.map(prompt =>
+      prompt.context.join(' ')
+    )
+    expect(weather).toContain('Open-Meteo')
+    expect(weather).toContain('three separate widgets')
+    expect(synthesizer).toContain('computer-keyboard controls')
+    expect(synthesizer).toContain('JSON music files')
+    expect(jobTracker).toContain('Saved, Applied, Interviewing, Offer, and Closed')
+    expect(jobTracker).toContain('workspace-local JSON file')
+
+    const html = renderToStaticMarkup(
+      createElement(ChatWelcome, { onSelectPrompt: () => undefined })
+    )
+    expect(html).not.toContain('Open-Meteo')
+    expect(html).not.toContain('workspace-local JSON file')
+
+    const context = renderMoiContext({
+      activeTab: 'agent',
+      directives: [...CHAT_WELCOME_PROMPTS[0].context]
+    })
+    expect(context).toContain('# This message only')
+    expect(context).toContain('Open-Meteo')
+    expect(context).toContain('smoke-test the shared weather function')
   })
 })

--- a/client/features/chat/ChatWelcome.test.tsx
+++ b/client/features/chat/ChatWelcome.test.tsx
@@ -25,7 +25,7 @@ describe('ChatWelcome', () => {
 
     expect(renderedParagraphs(html)).toEqual([
       'moi is the visual workspace for you and your agent.',
-      "It can grow and adapt it to the work you're doing. Just describe what you want, and the agent will build small apps in the workspace.",
+      "It can grow and adapt to the work you're doing. Just describe what you want, and the agent will build small apps in the workspace.",
       'You start chatting with Agent, where you can ask questions and build anything. Widgets are small apps that surface information and provide quick actions. For more complex tools, you can build Views that open in their own tabs. Scratchpad is a shared canvas for exploring and shaping ideas with your agent.',
       'Give it a try:'
     ])

--- a/client/features/chat/ChatWelcome.tsx
+++ b/client/features/chat/ChatWelcome.tsx
@@ -1,0 +1,67 @@
+import {
+  IconArticle,
+  IconGhost,
+  IconLayout2,
+  IconSketching,
+  type TablerIcon
+} from '@tabler/icons-react'
+
+import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
+
+const PROMPTS = [
+  { label: '“Track my daily habits.”', prompt: 'Track my daily habits.' },
+  {
+    label: '“Help me work with my project files.”',
+    prompt: 'Help me work with my project files.'
+  },
+  { label: '“Build a tool to manage my sales.”', prompt: 'Build a tool to manage my sales.' }
+] satisfies ChatPromptBubble[]
+
+type ChatWelcomeProps = {
+  onSelectPrompt: (prompt: string) => void
+}
+
+export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
+  return (
+    <div className="flex min-w-0 flex-col gap-3 pb-2">
+      <div className="prose prose-sm max-w-full min-w-0 wrap-anywhere prose-inherit">
+        <p>moi is the UI for your AI.</p>
+        <p>
+          Build functional, reusable interfaces for your workspace. moi makes it easy to create apps
+          that work with your data, manage workspace files, connect to external services, and adapt
+          to your specific needs. Describe what you want, and your agent builds it directly inside
+          the workspace.
+        </p>
+        <p>
+          You start in <WelcomeTerm Icon={IconGhost}>Chat</WelcomeTerm>, where you can build with
+          your agent and ask any questions. <WelcomeTerm Icon={IconLayout2}>Widgets</WelcomeTerm>{' '}
+          are small apps on the Widgets tab that surface information and provide quick actions. For
+          more complex tools, you can build <WelcomeTerm Icon={IconArticle}>Views</WelcomeTerm> that
+          open in their own tabs. <WelcomeTerm Icon={IconSketching}>Scratchpad</WelcomeTerm> is a
+          shared canvas for exploring and shaping ideas with your agent.
+        </p>
+        <p>
+          As your needs evolve, you can add new tools, refine existing ones, and keep shaping the
+          workspace around the way you work. You can also use your existing Claude or ChatGPT
+          subscription directly in moi.
+        </p>
+        <p>What would you like to create first?</p>
+      </div>
+      <ChatPromptBubbles prompts={PROMPTS} onSelect={onSelectPrompt} />
+    </div>
+  )
+}
+
+type WelcomeTermProps = {
+  Icon: TablerIcon
+  children: string
+}
+
+function WelcomeTerm({ Icon, children }: WelcomeTermProps) {
+  return (
+    <strong className="inline-flex items-center gap-1 font-medium">
+      <Icon size={16} stroke={1.75} aria-hidden />
+      {children}
+    </strong>
+  )
+}

--- a/client/features/chat/ChatWelcome.tsx
+++ b/client/features/chat/ChatWelcome.tsx
@@ -65,8 +65,8 @@ export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
       <div className="prose prose-sm min-w-0 wrap-anywhere prose-inherit">
         <p>moi is the visual workspace for you and your agent.</p>
         <p>
-          It can grow and adapt it to the work you're doing. Just describe what you want, and the
-          agent will build small apps in the workspace.
+          It can grow and adapt to the work you're doing. Just describe what you want, and the agent
+          will build small apps in the workspace.
         </p>
         <p>
           You start chatting with <WelcomeTerm Icon={IconGhost}>Agent</WelcomeTerm>, where you can

--- a/client/features/chat/ChatWelcome.tsx
+++ b/client/features/chat/ChatWelcome.tsx
@@ -1,27 +1,34 @@
 import {
   IconArticle,
-  IconChartBar,
-  IconFolder,
+  IconBriefcase,
   IconGhost,
   IconLayout2,
-  IconRepeat,
+  IconPiano,
   IconSketching,
+  IconUmbrella2,
   type TablerIcon
 } from '@tabler/icons-react'
 
 import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
 
 const PROMPTS = [
-  { label: 'Track my daily habits', prompt: 'Track my daily habits.', icon: IconRepeat },
   {
-    label: 'Work with my files',
-    prompt: 'Work with my files.',
-    icon: IconFolder
+    label: "What's the weather?",
+    prompt:
+      "Build me a set of weather widgets that surface current conditions, today's hourly forecast, and a simple weekly outlook at a glance",
+    icon: IconUmbrella2
   },
   {
-    label: 'Build a sales tool',
-    prompt: 'Build a tool to manage my sales.',
-    icon: IconChartBar
+    label: 'Build a fun sythesizer',
+    prompt:
+      'Build me a view with a simple, playful synthesizer featuring a keyboard, five sound controls, and the ability to record, save, and load music files from the workspace',
+    icon: IconPiano
+  },
+  {
+    label: 'Make a job tracker',
+    prompt:
+      'Build me a view with a visual job search board where I can add opportunities by pasting a job link, automatically extract the details, move opportunities through stages, and keep notes and related files in the workspace',
+    icon: IconBriefcase
   }
 ] satisfies ChatPromptBubble[]
 
@@ -31,12 +38,12 @@ type ChatWelcomeProps = {
 
 export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
   return (
-    <div className="flex max-w-md min-w-0 flex-col pb-2">
+    <div className="flex min-h-full max-w-md min-w-0 flex-col items-center justify-center self-center pb-2">
       <div className="prose prose-sm min-w-0 wrap-anywhere prose-inherit">
         <p>moi is the visual workspace for you and your agent.</p>
         <p>
-          It can grow and adapt it to the work you're doing. Just describe what you want, and your
-          agent will extend the workspace with small apps wired to your data.
+          It can grow and adapt it to the work you're doing. Just describe what you want, and the
+          agent will build small apps in the workspace.
         </p>
         <p>
           You start chatting with <WelcomeTerm Icon={IconGhost}>Agent</WelcomeTerm>, where you can

--- a/client/features/chat/ChatWelcome.tsx
+++ b/client/features/chat/ChatWelcome.tsx
@@ -11,29 +11,52 @@ import {
 
 import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
 
-const PROMPTS = [
+export const CHAT_WELCOME_PROMPTS = [
   {
     label: "What's the weather?",
     prompt:
       "Build me a set of weather widgets that surface current conditions, today's hourly forecast, and a simple weekly outlook at a glance",
+    context: [
+      'Build this onboarding example immediately without asking follow-up questions.',
+      "Create three separate widgets: current conditions, today's hourly forecast, and a seven-day outlook.",
+      'Use one shared Open-Meteo server function with no API key and use Berlin as the default location.',
+      'Give each widget an appropriate grid size and a compact, visually distinct layout with loading, error, and last-updated states.',
+      'Bundle all three widgets, smoke-test the shared weather function, and check runtime logs before finishing.'
+    ],
     icon: IconUmbrella2
   },
   {
-    label: 'Build a fun sythesizer',
+    label: 'Build a fun synthesizer',
     prompt:
       'Build me a view with a simple, playful synthesizer featuring a keyboard, five sound controls, and the ability to record, save, and load music files from the workspace',
+    context: [
+      "Build this onboarding example immediately without asking follow-up questions, and don't use external services.",
+      "Create a responsive View that uses the browser's audio capabilities, with an onscreen piano and computer-keyboard controls.",
+      'Include five clearly labeled sound controls for waveform, attack, release, filter cutoff, and volume.',
+      'Let the user record timed note events, play and stop recordings, give them names, and save and load them as JSON music files in a workspace music folder.',
+      'Include clear empty and error states, then bundle the View and check runtime logs before finishing.'
+    ],
     icon: IconPiano
   },
   {
     label: 'Make a job tracker',
     prompt:
       'Build me a view with a visual job search board where I can add opportunities by pasting a job link, automatically extract the details, move opportunities through stages, and keep notes and related files in the workspace',
+    context: [
+      'Build this onboarding example immediately without asking follow-up questions.',
+      'Create a visual View with Saved, Applied, Interviewing, Offer, and Closed stages.',
+      'Let the user add a job by pasting its URL, and use a server function to parse public metadata for the title, company, and location.',
+      'When a page blocks parsing or lacks metadata, keep the URL and provide editable manual fields.',
+      'Support moving opportunities between stages, editing their details and notes, and referencing related workspace files.',
+      'Persist the board in a workspace-local JSON file and include loading, empty, and error states.',
+      'Bundle the View and smoke-test its persistence and parsing functions before finishing.'
+    ],
     icon: IconBriefcase
   }
 ] satisfies ChatPromptBubble[]
 
 type ChatWelcomeProps = {
-  onSelectPrompt: (prompt: string) => void
+  onSelectPrompt: (prompt: ChatPromptBubble) => void
 }
 
 export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
@@ -55,7 +78,7 @@ export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
         </p>
         <p>Give it a try:</p>
       </div>
-      <ChatPromptBubbles prompts={PROMPTS} onSelect={onSelectPrompt} />
+      <ChatPromptBubbles prompts={CHAT_WELCOME_PROMPTS} onSelect={onSelectPrompt} />
     </div>
   )
 }

--- a/client/features/chat/ChatWelcome.tsx
+++ b/client/features/chat/ChatWelcome.tsx
@@ -56,10 +56,11 @@ export const CHAT_WELCOME_PROMPTS = [
 ] satisfies ChatPromptBubble[]
 
 type ChatWelcomeProps = {
+  disabled?: boolean
   onSelectPrompt: (prompt: ChatPromptBubble) => void
 }
 
-export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
+export function ChatWelcome({ disabled = false, onSelectPrompt }: ChatWelcomeProps) {
   return (
     <div className="flex min-h-full max-w-md min-w-0 flex-col items-center justify-center self-center pb-2">
       <div className="prose prose-sm min-w-0 wrap-anywhere prose-inherit">
@@ -78,7 +79,11 @@ export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
         </p>
         <p>Give it a try:</p>
       </div>
-      <ChatPromptBubbles prompts={CHAT_WELCOME_PROMPTS} onSelect={onSelectPrompt} />
+      <ChatPromptBubbles
+        prompts={CHAT_WELCOME_PROMPTS}
+        disabled={disabled}
+        onSelect={onSelectPrompt}
+      />
     </div>
   )
 }

--- a/client/features/chat/ChatWelcome.tsx
+++ b/client/features/chat/ChatWelcome.tsx
@@ -1,7 +1,10 @@
 import {
   IconArticle,
+  IconChartBar,
+  IconFolder,
   IconGhost,
   IconLayout2,
+  IconRepeat,
   IconSketching,
   type TablerIcon
 } from '@tabler/icons-react'
@@ -9,12 +12,17 @@ import {
 import { ChatPromptBubbles, type ChatPromptBubble } from '@/client/features/chat/ChatPromptBubbles'
 
 const PROMPTS = [
-  { label: '“Track my daily habits.”', prompt: 'Track my daily habits.' },
+  { label: 'Track my daily habits', prompt: 'Track my daily habits.', icon: IconRepeat },
   {
-    label: '“Help me work with my project files.”',
-    prompt: 'Help me work with my project files.'
+    label: 'Work with my files',
+    prompt: 'Work with my files.',
+    icon: IconFolder
   },
-  { label: '“Build a tool to manage my sales.”', prompt: 'Build a tool to manage my sales.' }
+  {
+    label: 'Build a sales tool',
+    prompt: 'Build a tool to manage my sales.',
+    icon: IconChartBar
+  }
 ] satisfies ChatPromptBubble[]
 
 type ChatWelcomeProps = {
@@ -23,29 +31,22 @@ type ChatWelcomeProps = {
 
 export function ChatWelcome({ onSelectPrompt }: ChatWelcomeProps) {
   return (
-    <div className="flex min-w-0 flex-col gap-3 pb-2">
-      <div className="prose prose-sm max-w-full min-w-0 wrap-anywhere prose-inherit">
-        <p>moi is the UI for your AI.</p>
+    <div className="flex max-w-md min-w-0 flex-col pb-2">
+      <div className="prose prose-sm min-w-0 wrap-anywhere prose-inherit">
+        <p>moi is the visual workspace for you and your agent.</p>
         <p>
-          Build functional, reusable interfaces for your workspace. moi makes it easy to create apps
-          that work with your data, manage workspace files, connect to external services, and adapt
-          to your specific needs. Describe what you want, and your agent builds it directly inside
-          the workspace.
+          It can grow and adapt it to the work you're doing. Just describe what you want, and your
+          agent will extend the workspace with small apps wired to your data.
         </p>
         <p>
-          You start in <WelcomeTerm Icon={IconGhost}>Chat</WelcomeTerm>, where you can build with
-          your agent and ask any questions. <WelcomeTerm Icon={IconLayout2}>Widgets</WelcomeTerm>{' '}
-          are small apps on the Widgets tab that surface information and provide quick actions. For
-          more complex tools, you can build <WelcomeTerm Icon={IconArticle}>Views</WelcomeTerm> that
-          open in their own tabs. <WelcomeTerm Icon={IconSketching}>Scratchpad</WelcomeTerm> is a
-          shared canvas for exploring and shaping ideas with your agent.
+          You start chatting with <WelcomeTerm Icon={IconGhost}>Agent</WelcomeTerm>, where you can
+          ask questions and build anything. <WelcomeTerm Icon={IconLayout2}>Widgets</WelcomeTerm>{' '}
+          are small apps that surface information and provide quick actions. For more complex tools,
+          you can build <WelcomeTerm Icon={IconArticle}>Views</WelcomeTerm> that open in their own
+          tabs. <WelcomeTerm Icon={IconSketching}>Scratchpad</WelcomeTerm> is a shared canvas for
+          exploring and shaping ideas with your agent.
         </p>
-        <p>
-          As your needs evolve, you can add new tools, refine existing ones, and keep shaping the
-          workspace around the way you work. You can also use your existing Claude or ChatGPT
-          subscription directly in moi.
-        </p>
-        <p>What would you like to create first?</p>
+        <p>Give it a try:</p>
       </div>
       <ChatPromptBubbles prompts={PROMPTS} onSelect={onSelectPrompt} />
     </div>
@@ -59,8 +60,8 @@ type WelcomeTermProps = {
 
 function WelcomeTerm({ Icon, children }: WelcomeTermProps) {
   return (
-    <strong className="inline-flex items-center gap-1 font-medium">
-      <Icon size={16} stroke={1.75} aria-hidden />
+    <strong className="inline-flex items-center gap-0.5 align-bottom font-medium">
+      <Icon size={16} stroke={2} aria-hidden />
       {children}
     </strong>
   )

--- a/client/features/chat/ChatWorkspaceWelcome.test.tsx
+++ b/client/features/chat/ChatWorkspaceWelcome.test.tsx
@@ -5,11 +5,9 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   ChatWorkspaceWelcome,
-  WORKSPACE_ANALYSIS_PROMPTS
+  WORKSPACE_ANALYSIS_PROMPT
 } from '@/client/features/chat/ChatEmptyState'
 import { renderMoiContext } from '@/lib/moi-context'
-
-const workspaceAnalysisPrompt = WORKSPACE_ANALYSIS_PROMPTS[0]
 
 describe('ChatWorkspaceWelcome', () => {
   test('renders the workspace analysis copy and one plain prompt', () => {
@@ -18,8 +16,8 @@ describe('ChatWorkspaceWelcome', () => {
     )
     const promptButtons = [...html.matchAll(/<button.*?<\/button>/gs)]
 
-    expect(html).toContain('Let&#x27;s explore the workspace')
-    expect(html).toContain('What could you build?')
+    expect(html).toContain('See what moi can build for you')
+    expect(html).toContain('Explore the workspace')
     expect(promptButtons).toHaveLength(1)
     expect(promptButtons[0]?.[0]).toContain('<svg')
     expect(promptButtons[0]?.[0]).not.toContain('grid')
@@ -38,10 +36,9 @@ describe('ChatWorkspaceWelcome', () => {
   })
 
   test('keeps analysis instructions in hidden message context', () => {
-    expect(workspaceAnalysisPrompt).toMatchObject({
-      label: 'What could you build?',
-      prompt:
-        'Analyze this workspace and suggest useful widgets and views moi can build based on its content'
+    expect(WORKSPACE_ANALYSIS_PROMPT).toMatchObject({
+      label: 'Explore the workspace',
+      prompt: 'Explore this workspace and suggest what moi can build based on its content'
     })
 
     const html = renderToStaticMarkup(
@@ -51,7 +48,7 @@ describe('ChatWorkspaceWelcome', () => {
 
     const context = renderMoiContext({
       activeTab: 'agent',
-      directives: [...workspaceAnalysisPrompt.context]
+      directives: [...WORKSPACE_ANALYSIS_PROMPT.context]
     })
     expect(context).toContain('Explore the existing workspace files')
     expect(context).toContain('which content informed your ideas')

--- a/client/features/chat/ChatWorkspaceWelcome.test.tsx
+++ b/client/features/chat/ChatWorkspaceWelcome.test.tsx
@@ -1,0 +1,60 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  ChatWorkspaceWelcome,
+  WORKSPACE_ANALYSIS_PROMPTS
+} from '@/client/features/chat/ChatEmptyState'
+import { renderMoiContext } from '@/lib/moi-context'
+
+const workspaceAnalysisPrompt = WORKSPACE_ANALYSIS_PROMPTS[0]
+
+describe('ChatWorkspaceWelcome', () => {
+  test('renders the workspace analysis copy and one plain prompt', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChatWorkspaceWelcome, { onSelectPrompt: () => undefined })
+    )
+    const promptButtons = [...html.matchAll(/<button.*?<\/button>/gs)]
+
+    expect(html).toContain('Let&#x27;s explore the workspace')
+    expect(html).toContain('What could you build?')
+    expect(promptButtons).toHaveLength(1)
+    expect(promptButtons[0]?.[0]).toContain('<svg')
+    expect(promptButtons[0]?.[0]).not.toContain('grid')
+    expect(promptButtons[0]?.[0]).not.toContain('rotate')
+  })
+
+  test('disables the analysis prompt when sending is unavailable', () => {
+    const html = renderToStaticMarkup(
+      createElement(ChatWorkspaceWelcome, {
+        disabled: true,
+        onSelectPrompt: () => undefined
+      })
+    )
+
+    expect(html.match(/<button.*?<\/button>/s)?.[0]).toContain('disabled=""')
+  })
+
+  test('keeps analysis instructions in hidden message context', () => {
+    expect(workspaceAnalysisPrompt).toMatchObject({
+      label: 'What could you build?',
+      prompt:
+        'Analyze this workspace and suggest useful widgets and views moi can build based on its content'
+    })
+
+    const html = renderToStaticMarkup(
+      createElement(ChatWorkspaceWelcome, { onSelectPrompt: () => undefined })
+    )
+    expect(html).not.toContain('Wait for me to choose')
+
+    const context = renderMoiContext({
+      activeTab: 'agent',
+      directives: [...workspaceAnalysisPrompt.context]
+    })
+    expect(context).toContain('Explore the existing workspace files')
+    expect(context).toContain('which content informed your ideas')
+    expect(context).toContain('Wait for me to choose before building anything')
+  })
+})

--- a/client/features/chat/MarkdownContent.tsx
+++ b/client/features/chat/MarkdownContent.tsx
@@ -26,7 +26,7 @@ const components = {
   pre({ children }: ComponentProps<'pre'>) {
     return (
       <div className="not-prose my-2 rounded-md border border-border bg-muted px-3 py-2.5">
-        <pre className="max-h-[300px] overflow-auto font-mono text-xs leading-relaxed whitespace-pre text-foreground [&>code]:rounded-none [&>code]:bg-transparent [&>code]:p-0">
+        <pre className="overflow-auto font-mono text-xs leading-relaxed whitespace-pre text-foreground [&>code]:rounded-none [&>code]:bg-transparent [&>code]:p-0">
           {children}
         </pre>
       </div>

--- a/client/features/chat/TurnView.tsx
+++ b/client/features/chat/TurnView.tsx
@@ -7,16 +7,6 @@ import { ToolCallGroup } from '@/client/features/chat/tool-group/ToolCallGroup'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
 import type { Part, Turn } from '@/lib/types'
 
-export function EmptyState() {
-  return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-1 text-center">
-      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-        Chat with your agent, create widgets and views, and manage your workspace context from here
-      </p>
-    </div>
-  )
-}
-
 export function ThinkingIndicator() {
   return (
     <div className="flex items-center gap-1.5 px-1 py-3">

--- a/client/features/chat/TurnView.tsx
+++ b/client/features/chat/TurnView.tsx
@@ -9,9 +9,8 @@ import type { Part, Turn } from '@/lib/types'
 
 export function EmptyState() {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-1 text-center text-sm">
-      <h2 className="font-medium">It all starts somewhere</h2>
-      <p className="mx-auto max-w-sm text-muted-foreground">
+    <div className="flex flex-1 flex-col items-center justify-center gap-1 text-center">
+      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
         Chat with your agent, create widgets and views, and manage your workspace context from here
       </p>
     </div>

--- a/client/features/chat/TurnView.tsx
+++ b/client/features/chat/TurnView.tsx
@@ -9,10 +9,10 @@ import type { Part, Turn } from '@/lib/types'
 
 export function EmptyState() {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-1.5 text-center">
-      <h2 className="font-medium">Every journey starts somewhere</h2>
-      <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-        Chat with your agent, create widgets and views, and manage your workspace context from here.
+    <div className="flex flex-1 flex-col items-center justify-center gap-1 text-center text-sm">
+      <h2 className="font-medium">It all starts somewhere</h2>
+      <p className="mx-auto max-w-sm text-muted-foreground">
+        Chat with your agent, create widgets and views, and manage your workspace context from here
       </p>
     </div>
   )

--- a/client/features/chat/chat-send.ts
+++ b/client/features/chat/chat-send.ts
@@ -6,6 +6,10 @@ import { STREAM_RESPONSES } from '@/client/lib/flags'
 import { applyEvent, emptyViewState } from '@/lib/format'
 import type { Part, ViewState, WorkspaceModels } from '@/lib/types'
 
+export type ChatSendOptions = {
+  directives?: readonly string[]
+}
+
 type StartOptimisticTurnInput = {
   queryClient: QueryClient
   workspaceId: string

--- a/client/features/chat/tool-group/TimelineRow.tsx
+++ b/client/features/chat/tool-group/TimelineRow.tsx
@@ -50,7 +50,7 @@ export function TimelineRow({
           <span className="absolute top-0 left-1/2 h-3 w-px -translate-x-1/2 bg-border" />
         )}
         {!isLast && (
-          <span className="absolute bottom-0 left-1/2 h-3 w-px -translate-x-1/2 bg-border" />
+          <span className="absolute top-[18px] bottom-0 left-1/2 w-px -translate-x-1/2 bg-border" />
         )}
         {marker ? (
           <span className="absolute top-[15px] left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">

--- a/client/features/chat/tool-group/TimelineRow.tsx
+++ b/client/features/chat/tool-group/TimelineRow.tsx
@@ -47,10 +47,10 @@ export function TimelineRow({
           1px rule lands on a single pixel column instead of straddling two. */}
       <div className="relative w-[13px] shrink-0">
         {!isFirst && (
-          <span className="absolute top-0 left-1/2 h-4 w-px -translate-x-1/2 bg-border" />
+          <span className="absolute top-0 left-1/2 h-3 w-px -translate-x-1/2 bg-border" />
         )}
         {!isLast && (
-          <span className="absolute top-[15px] bottom-0 left-1/2 w-px -translate-x-1/2 bg-border" />
+          <span className="absolute bottom-0 left-1/2 h-3 w-px -translate-x-1/2 bg-border" />
         )}
         {marker ? (
           <span className="absolute top-[15px] left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">

--- a/client/features/chat/tool-group/ToolCallGroup.tsx
+++ b/client/features/chat/tool-group/ToolCallGroup.tsx
@@ -191,7 +191,7 @@ function ToolCallCard({ call, cwd, isFirst, isLast }: ToolCallCardProps) {
         isLast={isLast}
         call={call}
         marker={succeeded ? <IconMarker icon={IconPackage} size={16} stroke={1.75} /> : undefined}
-        name="Loading Skill"
+        name="Loading skill"
         brief={call.skill.skillName}
       />
     )

--- a/client/features/chat/tool-group/format.ts
+++ b/client/features/chat/tool-group/format.ts
@@ -128,9 +128,9 @@ const OPENCLAW_TOOL_LABELS: Record<string, string> = {
 // Claude tool names are mostly already presentable (Read, Bash, …); only a few
 // need spacing/relabelling.
 const CLAUDE_TOOL_LABELS: Record<string, string> = {
-  ToolSearch: 'Tool Search',
-  WebSearch: 'Web Search',
-  WebFetch: 'Web Fetch'
+  ToolSearch: 'Tool search',
+  WebSearch: 'Web search',
+  WebFetch: 'Web fetch'
 }
 
 // Codex emits semantic items, which the adapter maps to a small fixed set of

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -13,7 +13,11 @@ import { useMoiUserMessageContext } from '@/client/features/workspace/moi-contex
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
 import { sendMessage } from '@/client/features/chat/chat-connection'
-import { resolveChatRunOptions, startOptimisticTurn } from '@/client/features/chat/chat-send'
+import {
+  type ChatSendOptions,
+  resolveChatRunOptions,
+  startOptimisticTurn
+} from '@/client/features/chat/chat-send'
 import { buildPreviewTurn } from '@/client/features/chat/preview-turn'
 import { draftKey, liveStore, selectPreviews, useLive } from '@/client/features/chat/chat-store'
 import { useUiStore } from '@/client/store/ui'
@@ -77,7 +81,7 @@ export function useChat() {
   // keystroke re-renders only the composer — not this hook's host (WorkspaceView)
   // and its whole subtree. See `ChatInput`.
   const send = useCallback(
-    (draft: string) => {
+    (draft: string, options?: ChatSendOptions) => {
       const text = draft.trim()
       // Attachments for the active thread, keyed exactly like the draft. Only
       // fully-uploaded ones are sent; the composer disables send while any are
@@ -135,7 +139,7 @@ export function useChat() {
         model,
         effort,
         stream,
-        context: buildMoiContext(),
+        context: buildMoiContext(options?.directives),
         ...(ready.length > 0 ? { attachments: ready.map(a => a.upload!.id) } : {})
       })
       useUiStore.getState().markMessageSentFromMoi()

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -3,7 +3,12 @@ import { useCallback, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { workspaceKeys } from '@/client/api/workspace-keys'
-import { useSessionView, useThreadConfig, useWorkspaceModels } from '@/client/features/chat/api'
+import {
+  useSessionView,
+  useThreadConfig,
+  useWorkspaceModels,
+  useWorkspaceSessions
+} from '@/client/features/chat/api'
 import { useMoiUserMessageContext } from '@/client/features/workspace/moi-context'
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
@@ -11,6 +16,7 @@ import { sendMessage } from '@/client/features/chat/chat-connection'
 import { resolveChatRunOptions, startOptimisticTurn } from '@/client/features/chat/chat-send'
 import { buildPreviewTurn } from '@/client/features/chat/preview-turn'
 import { draftKey, liveStore, selectPreviews, useLive } from '@/client/features/chat/chat-store'
+import { useUiStore } from '@/client/store/ui'
 import { emptyViewState } from '@/lib/format'
 import type { Part, ViewState } from '@/lib/types'
 
@@ -24,11 +30,15 @@ export function useChat() {
   const qc = useQueryClient()
   const { layout } = useWorkspaceLayoutCtx()
   const modelsData = useWorkspaceModels(workspaceId).data
+  const sessions = useWorkspaceSessions(workspaceId).data
   // Snapshot of the workspace's ambient UI state + queued one-shot
   // directives, taken when the message actually goes out.
   const buildMoiContext = useMoiUserMessageContext()
 
   const activeSessionId = useLive(s => s.activeByWorkspace[workspaceId] ?? null)
+  const sessionSelectionInitialized = useLive(s =>
+    Object.prototype.hasOwnProperty.call(s.activeByWorkspace, workspaceId)
+  )
   const activity = useLive(s =>
     activeSessionId ? (s.activity[`${workspaceId}:${activeSessionId}`] ?? 'idle') : 'idle'
   )
@@ -39,7 +49,14 @@ export function useChat() {
     activeSessionId ? (s.errors[`${workspaceId}:${activeSessionId}`] ?? null) : null
   )
 
-  const view = useSessionView(workspaceId, activeSessionId).data ?? EMPTY
+  const viewQuery = useSessionView(workspaceId, activeSessionId)
+  const view = viewQuery.data ?? EMPTY
+  const chatReady =
+    sessionSelectionInitialized &&
+    sessions !== undefined &&
+    (activeSessionId === null ||
+      (sessions.some(session => session.sessionId === activeSessionId) &&
+        viewQuery.data !== undefined))
 
   // The live streaming preview as a synthetic assistant turn, so the ChatPanel
   // can run it through the SAME groupTurns pipeline as finalized turns — a
@@ -121,6 +138,7 @@ export function useChat() {
         context: buildMoiContext(),
         ...(ready.length > 0 ? { attachments: ready.map(a => a.upload!.id) } : {})
       })
+      useUiStore.getState().markMessageSentFromMoi()
       if (isNew) {
         qc.invalidateQueries({ queryKey: workspaceKeys.preview(workspaceId) })
       }
@@ -161,6 +179,7 @@ export function useChat() {
 
   return {
     view,
+    chatReady,
     previewTurn,
     sessionId: activeSessionId,
     processing,

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -142,7 +142,7 @@ export function useChat() {
         context: buildMoiContext(options?.directives),
         ...(ready.length > 0 ? { attachments: ready.map(a => a.upload!.id) } : {})
       })
-      useUiStore.getState().markMessageSentFromMoi()
+      useUiStore.getState().markMessageSentFromMoi(workspaceId)
       if (isNew) {
         qc.invalidateQueries({ queryKey: workspaceKeys.preview(workspaceId) })
       }

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -55,7 +55,7 @@ export function useChat() {
 
   const viewQuery = useSessionView(workspaceId, activeSessionId)
   const view = viewQuery.data ?? EMPTY
-  const chatReady =
+  const chatLoaded =
     sessionSelectionInitialized &&
     sessions !== undefined &&
     (activeSessionId === null ||
@@ -183,7 +183,7 @@ export function useChat() {
 
   return {
     view,
-    chatReady,
+    chatLoaded,
     previewTurn,
     sessionId: activeSessionId,
     processing,

--- a/client/features/chat/useStickToBottom.ts
+++ b/client/features/chat/useStickToBottom.ts
@@ -22,6 +22,9 @@ type StickToBottom = {
   atBottom: boolean
   // Scroll to the bottom and re-pin. `smooth` for user-initiated jumps.
   scrollToBottom: (behavior?: ScrollBehavior) => void
+  // Show top-anchored content such as the initial Chat welcome without the
+  // resize observer pulling it back to the bottom.
+  scrollToTop: () => void
 }
 
 export function useStickToBottom(
@@ -47,6 +50,13 @@ export function useStickToBottom(
     },
     [scrollRef, setPinned]
   )
+
+  const scrollToTop = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setPinned(false)
+    el.scrollTo({ top: 0, behavior: 'auto' })
+  }, [scrollRef, setPinned])
 
   // Track whether the user is at the bottom. A programmatic scroll-to-bottom
   // also fires this with distance ≈ 0, so pinned stays true — no fight.
@@ -82,5 +92,5 @@ export function useStickToBottom(
     scrollToBottom('auto')
   }, [resetKey, scrollToBottom])
 
-  return { atBottom, scrollToBottom }
+  return { atBottom, scrollToBottom, scrollToTop }
 }

--- a/client/features/home/HomePage.tsx
+++ b/client/features/home/HomePage.tsx
@@ -3,10 +3,9 @@ import { Link, useLocation } from 'wouter'
 
 import {
   useDiscoveredWorkspaces,
-  useWorkspacePreviews,
+  useWorkspacePreview,
   useWorkspaces,
-  useWorkspaceSetupInfo,
-  resolveWorkspacePreview
+  useWorkspaceSetupInfo
 } from './api'
 import { CreateWorkspaceDialog } from './workspace-setup/CreateWorkspaceDialog'
 import { ImportWorkspaceDialog } from './workspace-setup/ImportWorkspaceDialog'
@@ -26,7 +25,6 @@ import {
   workspaceProviderIcon
 } from '@/client/features/home/workspace-presentation'
 import type { DiscoveredWorkspace, WorkspaceEntry } from '@/lib/types'
-import type { ResolvedWorkspacePreview } from './api'
 
 import { WorkspacePreview } from './WorkspacePreview'
 
@@ -38,8 +36,6 @@ export function HomePage() {
   const importFlow = useWorkspaceImport({
     onSuccess: entry => navigate(`/workspace/${entry.id}`)
   })
-  const workspaces = workspacesQuery.data ?? []
-  const previewQueries = useWorkspacePreviews(workspaces)
   const discoveredWorkspacesOpen = useUiStore(state => state.discoveredWorkspacesOpen)
   const setDiscoveredWorkspacesOpen = useUiStore(state => state.setDiscoveredWorkspacesOpen)
 
@@ -59,14 +55,9 @@ export function HomePage() {
     )
   }
 
+  const workspaces = workspacesQuery.data
   const discovered = discoveredQuery.data
   const count = workspaces.length
-  const workspaceCards = workspaces
-    .map((workspace, index) => ({
-      workspace,
-      preview: resolveWorkspacePreview(workspace, previewQueries[index]?.data)
-    }))
-    .sort((a, b) => b.preview.updatedAt - a.preview.updatedAt)
 
   function handleAdd(suggestion: DiscoveredWorkspace) {
     importFlow.startImport(suggestion)
@@ -91,8 +82,8 @@ export function HomePage() {
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
-            {workspaceCards.map(({ workspace, preview }) => (
-              <WorkspaceCard key={workspace.id} workspace={workspace} preview={preview} />
+            {workspaces.map(workspace => (
+              <WorkspaceCard key={workspace.id} workspace={workspace} />
             ))}
           </div>
         </section>
@@ -162,18 +153,19 @@ export function HomePage() {
 
 type WorkspaceCardProps = {
   workspace: WorkspaceEntry
-  preview: ResolvedWorkspacePreview
 }
 
-function WorkspaceCard({ workspace, preview }: WorkspaceCardProps) {
+function WorkspaceCard({ workspace }: WorkspaceCardProps) {
   const name = workspaceDisplayName(workspace)
+  const previewQuery = useWorkspacePreview(workspace.id)
+  const updatedAt = previewQuery.data?.updatedAt ?? new Date(workspace.addedAt).getTime()
 
   return (
     <Link
       href={`/workspace/${workspace.id}`}
       className="group flex min-w-0 flex-col gap-4 rounded-xl bg-card p-2 shadow-xs transition-shadow hover:shadow-sm"
     >
-      <WorkspacePreview workspaceId={workspace.id} preview={preview} />
+      <WorkspacePreview workspaceId={workspace.id} />
       <div className="flex min-w-0 flex-col gap-2 px-2 pb-2">
         <div className="flex min-w-0 items-center gap-1.5">
           <img
@@ -183,7 +175,7 @@ function WorkspaceCard({ workspace, preview }: WorkspaceCardProps) {
           />
           <span className="truncate text-sm font-medium text-foreground">{name}</span>
         </div>
-        <span className="text-xs text-muted-foreground">{formatUpdatedAt(preview.updatedAt)}</span>
+        <span className="text-xs text-muted-foreground">{formatUpdatedAt(updatedAt)}</span>
       </div>
     </Link>
   )

--- a/client/features/home/HomePage.tsx
+++ b/client/features/home/HomePage.tsx
@@ -3,9 +3,10 @@ import { Link, useLocation } from 'wouter'
 
 import {
   useDiscoveredWorkspaces,
-  useWorkspacePreview,
+  useWorkspacePreviews,
   useWorkspaces,
-  useWorkspaceSetupInfo
+  useWorkspaceSetupInfo,
+  resolveWorkspacePreview
 } from './api'
 import { CreateWorkspaceDialog } from './workspace-setup/CreateWorkspaceDialog'
 import { ImportWorkspaceDialog } from './workspace-setup/ImportWorkspaceDialog'
@@ -25,6 +26,7 @@ import {
   workspaceProviderIcon
 } from '@/client/features/home/workspace-presentation'
 import type { DiscoveredWorkspace, WorkspaceEntry } from '@/lib/types'
+import type { ResolvedWorkspacePreview } from './api'
 
 import { WorkspacePreview } from './WorkspacePreview'
 
@@ -36,6 +38,8 @@ export function HomePage() {
   const importFlow = useWorkspaceImport({
     onSuccess: entry => navigate(`/workspace/${entry.id}`)
   })
+  const workspaces = workspacesQuery.data ?? []
+  const previewQueries = useWorkspacePreviews(workspaces)
   const discoveredWorkspacesOpen = useUiStore(state => state.discoveredWorkspacesOpen)
   const setDiscoveredWorkspacesOpen = useUiStore(state => state.setDiscoveredWorkspacesOpen)
 
@@ -55,9 +59,14 @@ export function HomePage() {
     )
   }
 
-  const workspaces = workspacesQuery.data
   const discovered = discoveredQuery.data
   const count = workspaces.length
+  const workspaceCards = workspaces
+    .map((workspace, index) => ({
+      workspace,
+      preview: resolveWorkspacePreview(workspace, previewQueries[index]?.data)
+    }))
+    .sort((a, b) => b.preview.updatedAt - a.preview.updatedAt)
 
   function handleAdd(suggestion: DiscoveredWorkspace) {
     importFlow.startImport(suggestion)
@@ -82,8 +91,8 @@ export function HomePage() {
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3">
-            {workspaces.map(ws => (
-              <WorkspaceCard key={ws.id} workspace={ws} />
+            {workspaceCards.map(({ workspace, preview }) => (
+              <WorkspaceCard key={workspace.id} workspace={workspace} preview={preview} />
             ))}
           </div>
         </section>
@@ -153,19 +162,18 @@ export function HomePage() {
 
 type WorkspaceCardProps = {
   workspace: WorkspaceEntry
+  preview: ResolvedWorkspacePreview
 }
 
-function WorkspaceCard({ workspace }: WorkspaceCardProps) {
+function WorkspaceCard({ workspace, preview }: WorkspaceCardProps) {
   const name = workspaceDisplayName(workspace)
-  const previewQuery = useWorkspacePreview(workspace.id)
-  const updatedAt = previewQuery.data?.updatedAt ?? new Date(workspace.addedAt).getTime()
 
   return (
     <Link
       href={`/workspace/${workspace.id}`}
       className="group flex min-w-0 flex-col gap-4 rounded-xl bg-card p-2 shadow-xs transition-shadow hover:shadow-sm"
     >
-      <WorkspacePreview workspaceId={workspace.id} />
+      <WorkspacePreview workspaceId={workspace.id} preview={preview} />
       <div className="flex min-w-0 flex-col gap-2 px-2 pb-2">
         <div className="flex min-w-0 items-center gap-1.5">
           <img
@@ -175,7 +183,7 @@ function WorkspaceCard({ workspace }: WorkspaceCardProps) {
           />
           <span className="truncate text-sm font-medium text-foreground">{name}</span>
         </div>
-        <span className="text-xs text-muted-foreground">{formatUpdatedAt(updatedAt)}</span>
+        <span className="text-xs text-muted-foreground">{formatUpdatedAt(preview.updatedAt)}</span>
       </div>
     </Link>
   )

--- a/client/features/home/WorkspacePreview.tsx
+++ b/client/features/home/WorkspacePreview.tsx
@@ -1,11 +1,11 @@
 import { useLayoutEffect, useRef, useState } from 'react'
 
 import { cn } from '@/client/lib/cn'
-
-import { useWorkspacePreview } from './api'
+import type { ResolvedWorkspacePreview } from './api'
 
 type WorkspacePreviewProps = {
   workspaceId: string
+  preview: ResolvedWorkspacePreview
 }
 
 const FOLDER = {
@@ -104,11 +104,10 @@ const STACK = [
   )
 ]
 
-export function WorkspacePreview({ workspaceId }: WorkspacePreviewProps) {
-  const query = useWorkspacePreview(workspaceId)
-  const thumbnails = query.data ? [...query.data.thumbnails].reverse() : []
+export function WorkspacePreview({ workspaceId, preview }: WorkspacePreviewProps) {
+  const thumbnails = [...preview.thumbnails].reverse()
   const slots = STACK.slice(STACK.length - thumbnails.length)
-  const firstUserMessage = query.data?.firstUserMessage
+  const firstUserMessage = preview.firstUserMessage
   const { ref, horizontalRadiusScale } = useFolderRadiusScale()
   const backdropPath = folderBackdropPath(horizontalRadiusScale)
   const noiseFilterId = `folder-noise-${workspaceId}`

--- a/client/features/home/WorkspacePreview.tsx
+++ b/client/features/home/WorkspacePreview.tsx
@@ -1,11 +1,11 @@
 import { useLayoutEffect, useRef, useState } from 'react'
 
 import { cn } from '@/client/lib/cn'
-import type { ResolvedWorkspacePreview } from './api'
+
+import { useWorkspacePreview } from './api'
 
 type WorkspacePreviewProps = {
   workspaceId: string
-  preview: ResolvedWorkspacePreview
 }
 
 const FOLDER = {
@@ -104,10 +104,11 @@ const STACK = [
   )
 ]
 
-export function WorkspacePreview({ workspaceId, preview }: WorkspacePreviewProps) {
-  const thumbnails = [...preview.thumbnails].reverse()
+export function WorkspacePreview({ workspaceId }: WorkspacePreviewProps) {
+  const query = useWorkspacePreview(workspaceId)
+  const thumbnails = query.data ? [...query.data.thumbnails].reverse() : []
   const slots = STACK.slice(STACK.length - thumbnails.length)
-  const firstUserMessage = preview.firstUserMessage
+  const firstUserMessage = query.data?.firstUserMessage
   const { ref, horizontalRadiusScale } = useFolderRadiusScale()
   const backdropPath = folderBackdropPath(horizontalRadiusScale)
   const noiseFilterId = `folder-noise-${workspaceId}`

--- a/client/features/home/api.test.ts
+++ b/client/features/home/api.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { WorkspaceEntry } from '@/lib/types'
 
-import { resolveWorkspacePreview, upsertWorkspaceEntry } from './api'
+import { upsertWorkspaceEntry } from './api'
 
 const existing: WorkspaceEntry = {
   id: 'one',
@@ -12,23 +12,28 @@ const existing: WorkspaceEntry = {
 }
 
 describe('upsertWorkspaceEntry', () => {
-  test('appends a new workspace', () => {
+  test('prepends a new workspace', () => {
     const added: WorkspaceEntry = {
       id: 'two',
       path: '/tmp/two',
       addedAt: '2026-01-02T00:00:00.000Z'
     }
 
-    expect(upsertWorkspaceEntry([existing], added)).toEqual([existing, added])
+    expect(upsertWorkspaceEntry([existing], added)).toEqual([added, existing])
   })
 
-  test('updates an existing workspace without duplicating it', () => {
+  test('updates an existing workspace in place without duplicating it', () => {
+    const other: WorkspaceEntry = {
+      id: 'two',
+      path: '/tmp/two',
+      addedAt: '2026-01-02T00:00:00.000Z'
+    }
     const imported: WorkspaceEntry = {
       ...existing,
       name: 'Updated name'
     }
 
-    expect(upsertWorkspaceEntry([existing], imported)).toEqual([imported])
+    expect(upsertWorkspaceEntry([other, existing], imported)).toEqual([other, imported])
   })
 
   test('deduplicates a registry match returned with a different id', () => {
@@ -39,21 +44,5 @@ describe('upsertWorkspaceEntry', () => {
     }
 
     expect(upsertWorkspaceEntry([existing], imported)).toEqual([imported])
-  })
-})
-
-describe('resolveWorkspacePreview', () => {
-  test('uses provider activity when it is available', () => {
-    expect(resolveWorkspacePreview(existing, { thumbnails: ['preview'], updatedAt: 200 })).toEqual({
-      thumbnails: ['preview'],
-      updatedAt: 200
-    })
-  })
-
-  test('falls back to the date the workspace was added', () => {
-    expect(resolveWorkspacePreview(existing, undefined)).toEqual({
-      thumbnails: [],
-      updatedAt: new Date(existing.addedAt).getTime()
-    })
   })
 })

--- a/client/features/home/api.test.ts
+++ b/client/features/home/api.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { WorkspaceEntry } from '@/lib/types'
 
-import { upsertWorkspaceEntry } from './api'
+import { resolveWorkspacePreview, upsertWorkspaceEntry } from './api'
 
 const existing: WorkspaceEntry = {
   id: 'one',
@@ -39,5 +39,21 @@ describe('upsertWorkspaceEntry', () => {
     }
 
     expect(upsertWorkspaceEntry([existing], imported)).toEqual([imported])
+  })
+})
+
+describe('resolveWorkspacePreview', () => {
+  test('uses provider activity when it is available', () => {
+    expect(resolveWorkspacePreview(existing, { thumbnails: ['preview'], updatedAt: 200 })).toEqual({
+      thumbnails: ['preview'],
+      updatedAt: 200
+    })
+  })
+
+  test('falls back to the date the workspace was added', () => {
+    expect(resolveWorkspacePreview(existing, undefined)).toEqual({
+      thumbnails: [],
+      updatedAt: new Date(existing.addedAt).getTime()
+    })
   })
 })

--- a/client/features/home/api.ts
+++ b/client/features/home/api.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { workspaceKeys } from '@/client/api/workspace-keys'
+import { liveStore } from '@/client/features/chat/chat-store'
 import type {
   DiscoveredWorkspace,
   HarnessAvailability,
@@ -50,6 +51,7 @@ export function useImportWorkspace() {
     mutationFn: input =>
       requestJson('/api/workspaces', jsonRequest('POST', input), 'Failed to add workspace'),
     onSuccess: (entry, input) => {
+      liveStore.getState().setActive(entry.id, null)
       queryClient.setQueryData<WorkspaceEntry[]>(workspaceKeys.all, previous =>
         upsertWorkspaceEntry(previous, entry)
       )

--- a/client/features/home/api.ts
+++ b/client/features/home/api.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { workspaceKeys } from '@/client/api/workspace-keys'
@@ -30,12 +30,27 @@ export function useWorkspaces() {
   })
 }
 
-export function useWorkspacePreview(workspaceId: string) {
-  return useQuery<WorkspacePreview>({
-    queryKey: workspaceKeys.preview(workspaceId),
-    queryFn: () => requestJson(`/api/workspaces/${workspaceId}/preview`),
-    staleTime: 60_000
+export function useWorkspacePreviews(workspaces: WorkspaceEntry[]) {
+  return useQueries({
+    queries: workspaces.map(workspace => ({
+      queryKey: workspaceKeys.preview(workspace.id),
+      queryFn: () => requestJson<WorkspacePreview>(`/api/workspaces/${workspace.id}/preview`),
+      staleTime: 60_000
+    }))
   })
+}
+
+export type ResolvedWorkspacePreview = WorkspacePreview & { updatedAt: number }
+
+export function resolveWorkspacePreview(
+  workspace: WorkspaceEntry,
+  preview: WorkspacePreview | undefined
+): ResolvedWorkspacePreview {
+  return {
+    ...preview,
+    thumbnails: preview?.thumbnails ?? [],
+    updatedAt: preview?.updatedAt ?? new Date(workspace.addedAt).getTime()
+  }
 }
 
 export function useDiscoveredWorkspaces() {

--- a/client/features/home/api.ts
+++ b/client/features/home/api.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { workspaceKeys } from '@/client/api/workspace-keys'
 import { liveStore } from '@/client/features/chat/chat-store'
+import { useUiStore } from '@/client/store/ui'
 import type {
   DiscoveredWorkspace,
   HarnessAvailability,
@@ -52,6 +53,7 @@ export function useImportWorkspace() {
       requestJson('/api/workspaces', jsonRequest('POST', input), 'Failed to add workspace'),
     onSuccess: (entry, input) => {
       liveStore.getState().setActive(entry.id, null)
+      useUiStore.getState().markWorkspacePendingAnalysis(entry.id)
       queryClient.setQueryData<WorkspaceEntry[]>(workspaceKeys.all, previous =>
         upsertWorkspaceEntry(previous, entry)
       )

--- a/client/features/home/api.ts
+++ b/client/features/home/api.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { workspaceKeys } from '@/client/api/workspace-keys'
@@ -17,7 +17,7 @@ export function upsertWorkspaceEntry(
 ): WorkspaceEntry[] {
   const current = entries ?? []
   const existing = current.findIndex(item => item.id === entry.id || item.path === entry.path)
-  if (existing === -1) return [...current, entry]
+  if (existing === -1) return [entry, ...current]
   return current.map((item, index) => (index === existing ? { ...item, ...entry } : item))
 }
 
@@ -30,27 +30,12 @@ export function useWorkspaces() {
   })
 }
 
-export function useWorkspacePreviews(workspaces: WorkspaceEntry[]) {
-  return useQueries({
-    queries: workspaces.map(workspace => ({
-      queryKey: workspaceKeys.preview(workspace.id),
-      queryFn: () => requestJson<WorkspacePreview>(`/api/workspaces/${workspace.id}/preview`),
-      staleTime: 60_000
-    }))
+export function useWorkspacePreview(workspaceId: string) {
+  return useQuery<WorkspacePreview>({
+    queryKey: workspaceKeys.preview(workspaceId),
+    queryFn: () => requestJson(`/api/workspaces/${workspaceId}/preview`),
+    staleTime: 60_000
   })
-}
-
-export type ResolvedWorkspacePreview = WorkspacePreview & { updatedAt: number }
-
-export function resolveWorkspacePreview(
-  workspace: WorkspaceEntry,
-  preview: WorkspacePreview | undefined
-): ResolvedWorkspacePreview {
-  return {
-    ...preview,
-    thumbnails: preview?.thumbnails ?? [],
-    updatedAt: preview?.updatedAt ?? new Date(workspace.addedAt).getTime()
-  }
 }
 
 export function useDiscoveredWorkspaces() {
@@ -126,10 +111,9 @@ export function useCreateWorkspace() {
         'Failed to create workspace'
       ),
     onSuccess: entry => {
-      queryClient.setQueryData<WorkspaceEntry[]>(workspaceKeys.all, previous => [
-        ...(previous ?? []),
-        entry
-      ])
+      queryClient.setQueryData<WorkspaceEntry[]>(workspaceKeys.all, previous =>
+        upsertWorkspaceEntry(previous, entry)
+      )
     }
   })
 }

--- a/client/features/home/workspace-presentation.tsx
+++ b/client/features/home/workspace-presentation.tsx
@@ -10,7 +10,7 @@ export const workspaceProviderIcon: Record<WorkspaceType, string> = {
 }
 
 export const workspaceTypeLabel: Record<WorkspaceType, string> = {
-  'claude-code': 'Claude',
+  'claude-code': 'Claude Code',
   openclaw: 'OpenClaw',
   codex: 'Codex'
 }

--- a/client/features/home/workspace-setup/WorkspaceAgentStep.test.ts
+++ b/client/features/home/workspace-setup/WorkspaceAgentStep.test.ts
@@ -13,12 +13,12 @@ describe('getWorkspaceAgentOptions', () => {
   test.each([
     {
       type: 'claude-code' as const,
-      description: 'By Anthropic',
+      description: 'Anthropic',
       reason: 'Run curl -fsSL https://claude.ai/install.sh | sh in your terminal to install Claude'
     },
     {
       type: 'codex' as const,
-      description: 'By OpenAI',
+      description: 'OpenAI',
       reason:
         'Run curl -fsSL https://chatgpt.com/codex/install.sh | sh in your terminal to install Codex'
     }

--- a/client/features/home/workspace-setup/WorkspaceAgentStep.tsx
+++ b/client/features/home/workspace-setup/WorkspaceAgentStep.tsx
@@ -10,6 +10,7 @@ import {
   workspaceTypeLabel
 } from '@/client/features/home/workspace-presentation'
 import { cn } from '@/client/lib/cn'
+import { useUiStore } from '@/client/store/ui'
 import { WORKSPACE_TYPE_ORDER } from '@/lib/workspace-types'
 import type { HarnessAvailability, WorkspaceType } from '@/lib/types'
 
@@ -91,9 +92,16 @@ export function WorkspaceAgentStep({
   onTypeChange,
   onSubmit
 }: WorkspaceAgentStepProps) {
+  const hasSentMessageFromMoi = useUiStore(state => state.hasSentMessageFromMoi)
   const options = getWorkspaceAgentOptions({ availability, detectedTypes })
   const selectableType = resolveWorkspaceAgentSelection(options, selectedType)
   const selectedUnavailable = selectableType !== selectedType
+  const subscriptionTip =
+    selectableType === 'claude-code'
+      ? 'Tip: you can use your existing Claude subscription in moi'
+      : selectableType === 'codex'
+        ? 'Tip: you can use your existing ChatGPT subscription in moi'
+        : undefined
 
   useEffect(() => {
     if (selectableType && selectedUnavailable) onTypeChange(selectableType)
@@ -106,11 +114,16 @@ export function WorkspaceAgentStep({
         <DialogDescription>{WORKSPACE_AGENT_DESCRIPTION}</DialogDescription>
       </div>
 
-      <WorkspaceAgentSelector
-        options={options}
-        selectedType={selectedUnavailable ? undefined : selectedType}
-        onTypeChange={onTypeChange}
-      />
+      <div className="flex flex-col gap-4">
+        <WorkspaceAgentSelector
+          options={options}
+          selectedType={selectedUnavailable ? undefined : selectedType}
+          onTypeChange={onTypeChange}
+        />
+        {!hasSentMessageFromMoi && subscriptionTip && (
+          <p className="text-sm text-muted-foreground">{subscriptionTip}</p>
+        )}
+      </div>
 
       {errorMessage && (
         <p role="alert" className="text-xs text-destructive">

--- a/client/features/home/workspace-setup/WorkspaceAgentStep.tsx
+++ b/client/features/home/workspace-setup/WorkspaceAgentStep.tsx
@@ -18,8 +18,8 @@ const OPENCLAW_LOCKED_DESCRIPTION =
   'Initialize OpenClaw in the folder\nmanually, then import it to moi'
 
 const workspaceAgentDescription: Record<WorkspaceType, string> = {
-  'claude-code': 'By Anthropic',
-  codex: 'By OpenAI',
+  'claude-code': 'Anthropic',
+  codex: 'OpenAI',
   openclaw: 'Open-source'
 }
 

--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -264,6 +264,7 @@ function applyVisibleTabOrder(
 export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenProps) {
   const {
     view,
+    chatReady,
     previewTurn,
     sessionId,
     processing,
@@ -523,6 +524,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
     <ChatPanel
       active={mode === 'split'}
       focusRequest={chatFocusRequest}
+      chatReady={chatReady}
       view={view}
       previewTurn={previewTurn}
       sessionId={sessionId}
@@ -540,6 +542,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
     <ChatPanel
       active={mode === 'fullscreen' && activeTab === 'agent'}
       focusRequest={chatFocusRequest}
+      chatReady={chatReady}
       view={view}
       previewTurn={previewTurn}
       sessionId={sessionId}
@@ -670,6 +673,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
             <ChatPanel
               active={floatingChatOpen}
               focusRequest={chatFocusRequest}
+              chatReady={chatReady}
               view={view}
               previewTurn={previewTurn}
               sessionId={sessionId}

--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -264,7 +264,7 @@ function applyVisibleTabOrder(
 export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenProps) {
   const {
     view,
-    chatReady,
+    chatLoaded,
     previewTurn,
     sessionId,
     processing,
@@ -524,7 +524,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
     <ChatPanel
       active={mode === 'split'}
       focusRequest={chatFocusRequest}
-      chatReady={chatReady}
+      chatLoaded={chatLoaded}
       view={view}
       previewTurn={previewTurn}
       sessionId={sessionId}
@@ -542,7 +542,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
     <ChatPanel
       active={mode === 'fullscreen' && activeTab === 'agent'}
       focusRequest={chatFocusRequest}
-      chatReady={chatReady}
+      chatLoaded={chatLoaded}
       view={view}
       previewTurn={previewTurn}
       sessionId={sessionId}
@@ -673,7 +673,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
             <ChatPanel
               active={floatingChatOpen}
               focusRequest={chatFocusRequest}
-              chatReady={chatReady}
+              chatLoaded={chatLoaded}
               view={view}
               previewTurn={previewTurn}
               sessionId={sessionId}

--- a/client/features/workspace/moi-context.test.ts
+++ b/client/features/workspace/moi-context.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
-import { activeTabTitle, drainChatDirectives, pushChatDirective } from './moi-context'
+import {
+  activeTabTitle,
+  drainChatDirectives,
+  pushChatDirective,
+  takeChatDirectives
+} from './moi-context'
 import type { ViewBuilder, ViewInfo } from '@/lib/types'
 
 describe('moi context assembly', () => {
@@ -11,6 +16,17 @@ describe('moi context assembly', () => {
     expect(drainChatDirectives('ws-1')).toEqual(['First.', 'Second.'])
     expect(drainChatDirectives('ws-1')).toEqual([])
     expect(drainChatDirectives('ws-2')).toEqual(['Other workspace.'])
+  })
+
+  test('appends directives tied to the current message after queued directives', () => {
+    pushChatDirective('ws-3', 'Queued first.')
+
+    expect(takeChatDirectives('ws-3', ['Inline second.', 'Inline third.'])).toEqual([
+      'Queued first.',
+      'Inline second.',
+      'Inline third.'
+    ])
+    expect(takeChatDirectives('ws-3')).toEqual([])
   })
 
   test('activeTabTitle resolves view titles and claimed builder titles', () => {

--- a/client/features/workspace/moi-context.ts
+++ b/client/features/workspace/moi-context.ts
@@ -12,8 +12,9 @@
 //
 //   useMoiUserMessageContext()
 //     Hook for the chat send path: returns a builder that snapshots ambient
-//     state (active tab, view title) and drains the directive queue. Call
-//     the builder only for a message that actually goes out.
+//     state (active tab, view title), drains the directive queue, and accepts
+//     directives tied directly to that message. Call the builder only for a
+//     message that actually goes out.
 //
 //   Adding a new ambient field (e.g. scratchpad selection): extend the
 //   `MoiContext` type and its renderer in lib/moi-context.ts, then supply
@@ -48,6 +49,16 @@ export function drainChatDirectives(workspaceId: string): string[] {
   return queue
 }
 
+// Drain queued directives and append instructions explicitly attached to the
+// message being sent. Keeping the latter out of the queue ties them to that
+// exact send while preserving queued directives from other UI actions.
+export function takeChatDirectives(
+  workspaceId: string,
+  messageDirectives: readonly string[] = []
+): string[] {
+  return [...drainChatDirectives(workspaceId), ...messageDirectives]
+}
+
 // The UI label of the active tab when it has one beyond its id: a view's
 // configured title, or a builder's claimed title while the build runs.
 // Undefined otherwise (the envelope then falls back to the id, like the tab
@@ -68,18 +79,21 @@ export function activeTabTitle(
 // it when the message is actually sent, not at render. Draining the
 // directive queue is part of the snapshot, so only call it for a message
 // that will really go out.
-export function useMoiUserMessageContext(): () => MoiContext {
+export function useMoiUserMessageContext(): (directives?: readonly string[]) => MoiContext {
   const workspaceId = useWorkspaceId()
   const { layout } = useWorkspaceLayoutCtx()
   const views = useWorkspaceViews(workspaceId).data
   const builders = useViewBuilders(workspaceId).data
   const activeTab = layout.tabs.active
-  return useCallback(() => {
-    const directives = drainChatDirectives(workspaceId)
-    return {
-      activeTab,
-      tabTitle: activeTabTitle(activeTab, views, builders),
-      ...(directives.length > 0 ? { directives } : {})
-    }
-  }, [workspaceId, activeTab, views, builders])
+  return useCallback(
+    (messageDirectives: readonly string[] = []) => {
+      const directives = takeChatDirectives(workspaceId, messageDirectives)
+      return {
+        activeTab,
+        tabTitle: activeTabTitle(activeTab, views, builders),
+        ...(directives.length > 0 ? { directives } : {})
+      }
+    },
+    [workspaceId, activeTab, views, builders]
+  )
 }

--- a/client/store/ui.ts
+++ b/client/store/ui.ts
@@ -4,11 +4,8 @@ import { persist } from 'zustand/middleware'
 // Global, device-local UI preferences — persisted to localStorage so they
 // survive reloads. Server-owned or per-workspace state does NOT belong here.
 type UiStore = {
-  sidebarCollapsed: boolean
   discoveredWorkspacesOpen: boolean
   hasSentMessageFromMoi: boolean
-  toggleSidebar: () => void
-  setSidebarCollapsed: (collapsed: boolean) => void
   setDiscoveredWorkspacesOpen: (open: boolean) => void
   markMessageSentFromMoi: () => void
 }
@@ -16,11 +13,8 @@ type UiStore = {
 export const useUiStore = create<UiStore>()(
   persist(
     set => ({
-      sidebarCollapsed: false,
       discoveredWorkspacesOpen: true,
       hasSentMessageFromMoi: false,
-      toggleSidebar: () => set(s => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-      setSidebarCollapsed: collapsed => set({ sidebarCollapsed: collapsed }),
       setDiscoveredWorkspacesOpen: open => set({ discoveredWorkspacesOpen: open }),
       markMessageSentFromMoi: () => set({ hasSentMessageFromMoi: true })
     }),

--- a/client/store/ui.ts
+++ b/client/store/ui.ts
@@ -1,13 +1,15 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-// Global, device-local UI preferences — persisted to localStorage so they
-// survive reloads. Server-owned or per-workspace state does NOT belong here.
+// Device-local UI preferences and onboarding markers, persisted to localStorage
+// so they survive reloads. Server-owned workspace data does NOT belong here.
 type UiStore = {
   discoveredWorkspacesOpen: boolean
   hasSentMessageFromMoi: boolean
+  workspaceIdsPendingAnalysis: string[]
   setDiscoveredWorkspacesOpen: (open: boolean) => void
-  markMessageSentFromMoi: () => void
+  markWorkspacePendingAnalysis: (workspaceId: string) => void
+  markMessageSentFromMoi: (workspaceId: string) => void
 }
 
 export const useUiStore = create<UiStore>()(
@@ -15,8 +17,24 @@ export const useUiStore = create<UiStore>()(
     set => ({
       discoveredWorkspacesOpen: true,
       hasSentMessageFromMoi: false,
+      workspaceIdsPendingAnalysis: [],
       setDiscoveredWorkspacesOpen: open => set({ discoveredWorkspacesOpen: open }),
-      markMessageSentFromMoi: () => set({ hasSentMessageFromMoi: true })
+      markWorkspacePendingAnalysis: workspaceId =>
+        set(state => {
+          const workspaceIds = state.workspaceIdsPendingAnalysis ?? []
+          return {
+            workspaceIdsPendingAnalysis: workspaceIds.includes(workspaceId)
+              ? workspaceIds
+              : [...workspaceIds, workspaceId]
+          }
+        }),
+      markMessageSentFromMoi: workspaceId =>
+        set(state => ({
+          hasSentMessageFromMoi: true,
+          workspaceIdsPendingAnalysis: (state.workspaceIdsPendingAnalysis ?? []).filter(
+            id => id !== workspaceId
+          )
+        }))
     }),
     { name: 'moi:ui' }
   )

--- a/client/store/ui.ts
+++ b/client/store/ui.ts
@@ -6,9 +6,11 @@ import { persist } from 'zustand/middleware'
 type UiStore = {
   sidebarCollapsed: boolean
   discoveredWorkspacesOpen: boolean
+  hasSentMessageFromMoi: boolean
   toggleSidebar: () => void
   setSidebarCollapsed: (collapsed: boolean) => void
   setDiscoveredWorkspacesOpen: (open: boolean) => void
+  markMessageSentFromMoi: () => void
 }
 
 export const useUiStore = create<UiStore>()(
@@ -16,9 +18,11 @@ export const useUiStore = create<UiStore>()(
     set => ({
       sidebarCollapsed: false,
       discoveredWorkspacesOpen: true,
+      hasSentMessageFromMoi: false,
       toggleSidebar: () => set(s => ({ sidebarCollapsed: !s.sidebarCollapsed })),
       setSidebarCollapsed: collapsed => set({ sidebarCollapsed: collapsed }),
-      setDiscoveredWorkspacesOpen: open => set({ discoveredWorkspacesOpen: open })
+      setDiscoveredWorkspacesOpen: open => set({ discoveredWorkspacesOpen: open }),
+      markMessageSentFromMoi: () => set({ hasSentMessageFromMoi: true })
     }),
     { name: 'moi:ui' }
   )

--- a/server/api-order.test.ts
+++ b/server/api-order.test.ts
@@ -35,13 +35,13 @@ test('reordering workspaces broadcasts a workspace update', async () => {
   const response = await api.request('/api/workspaces/order', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ids: [second.id, first.id] })
+    body: JSON.stringify({ ids: [first.id, second.id] })
   })
 
   expect(response.status).toBe(200)
   expect((await response.json()).map((entry: WorkspaceEntry) => entry.id)).toEqual([
-    second.id,
-    first.id
+    first.id,
+    second.id
   ])
   expect(published).toEqual([JSON.stringify({ type: 'workspaces-list:updated' })])
 })

--- a/server/registry.test.ts
+++ b/server/registry.test.ts
@@ -42,6 +42,15 @@ describe('registerWorkspace', () => {
     expect(a.addedAt).toBe(b.addedAt)
   })
 
+  test('prepends new workspaces without moving existing registrations', async () => {
+    const first = await registerWorkspace('/Users/foo/first')
+    const second = await registerWorkspace('/Users/foo/second')
+
+    await registerWorkspace('/Users/foo/first')
+
+    expect((await listWorkspaces()).map(entry => entry.id)).toEqual([second.id, first.id])
+  })
+
   test('resolves relative paths to absolute', async () => {
     const entry = await registerWorkspace('.')
     expect(entry.path).toBe(process.cwd())
@@ -127,6 +136,16 @@ describe('reorderWorkspaces', () => {
 
     const list = await listWorkspaces()
     expect(list.map(e => e.id)).toEqual([c.id, a.id, b.id])
+  })
+
+  test('keeps manual order below a newly registered workspace', async () => {
+    const a = await registerWorkspace('/Users/foo/project-a')
+    const b = await registerWorkspace('/Users/foo/project-b')
+    await reorderWorkspaces([a.id, b.id])
+
+    const c = await registerWorkspace('/Users/foo/project-c')
+
+    expect((await listWorkspaces()).map(entry => entry.id)).toEqual([c.id, a.id, b.id])
   })
 
   test('rejects missing ids', async () => {

--- a/server/registry.ts
+++ b/server/registry.ts
@@ -73,7 +73,7 @@ export async function registerWorkspace(
     ...(opts.isDefault ? { isDefault: opts.isDefault } : {}),
     ...(opts.lastRunAt ? { lastRunAt: opts.lastRunAt } : {})
   }
-  await writeRegistry([...entries, entry])
+  await writeRegistry([entry, ...entries])
   return withDisplayPath(entry)
 }
 


### PR DESCRIPTION
## Summary

- Add a first-chat welcome screen with three guided workspace-building prompts
- Pass prompt-specific directives into chat context and track onboarding message state
- Improve chat readiness, session selection, layout sizing, and empty-state behavior
- Add coverage for prompt selection, welcome copy, and directive separation
- Apply sentence-case labels and refine chat timeline and markdown layout

## Testing

- Not run (not requested)