### PR TITLE
Support shadcn UI generation in workspace applets

### DIFF
--- a/server/api-skills.test.ts
+++ b/server/api-skills.test.ts
@@ -1,26 +1,38 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type { WorkspaceSkillsStatus } from '@/lib/types'
+import type { WorkspaceSkillsStatus, WorkspaceSkillsUpdateFailure } from '@/lib/types'
 
 import { api } from './api'
 import { DEFAULT_REGISTRY_PATH, registerWorkspace, setRegistryPath } from './registry'
 import { skillsDirFor } from './workspace-init'
 
 let tempRoot = ''
+let originalPath: string | undefined
 
 beforeEach(async () => {
   tempRoot = await mkdtemp(join(tmpdir(), 'moi-api-skills-'))
   setRegistryPath(join(tempRoot, 'workspaces.json'))
+  originalPath = process.env.PATH
 })
 
 afterEach(async () => {
+  process.env.PATH = originalPath
   setRegistryPath(DEFAULT_REGISTRY_PATH)
   await rm(tempRoot, { recursive: true, force: true })
   tempRoot = ''
 })
+
+async function makeBunx(exitCode: number): Promise<void> {
+  const binDir = join(tempRoot, 'bin')
+  const bunx = join(binDir, 'bunx')
+  await mkdir(binDir, { recursive: true })
+  await Bun.write(bunx, `#!/bin/sh\nexit ${exitCode}\n`)
+  await chmod(bunx, 0o755)
+  process.env.PATH = binDir
+}
 
 async function createOutdatedWorkspace(type: 'claude-code' | 'codex') {
   const workspaceRoot = join(tempRoot, type)
@@ -41,11 +53,12 @@ describe('workspace skills API', () => {
     expect(status.updateAvailable).toBe(true)
     expect(status.skills.find(skill => skill.name === 'moi-workspace')).toMatchObject({
       installed: '0.7.1',
-      bundled: '0.8.0'
+      bundled: '0.9.0'
     })
   })
 
-  test('updates bundled skills', async () => {
+  test('updates bundled and official skills', async () => {
+    await makeBunx(0)
     const workspace = await createOutdatedWorkspace('codex')
     const customSkill = join(skillsDirFor(workspace.path, 'codex'), 'custom', 'SKILL.md')
     await mkdir(join(customSkill, '..'), { recursive: true })
@@ -59,5 +72,21 @@ describe('workspace skills API', () => {
     expect(response.status).toBe(200)
     expect(status.updateAvailable).toBe(false)
     expect(await Bun.file(customSkill).text()).toBe('custom\n')
+  })
+
+  test('returns refreshed status when shadcn fails', async () => {
+    await makeBunx(23)
+    const workspace = await createOutdatedWorkspace('claude-code')
+
+    const response = await api.request(`/api/workspaces/${workspace.id}/skills/update`, {
+      method: 'POST'
+    })
+    const failure = (await response.json()) as WorkspaceSkillsUpdateFailure
+
+    expect(response.status).toBe(502)
+    expect(failure.updateAvailable).toBe(false)
+    expect(failure.error).toContain(
+      'moi skill updated, but the official shadcn skill could not be refreshed'
+    )
   })
 })

--- a/server/api.ts
+++ b/server/api.ts
@@ -10,6 +10,7 @@ import type {
   ViewBuilderInput,
   WorkspaceEntry,
   WorkspaceModels,
+  WorkspaceSkillsUpdateFailure,
   WorkspaceType
 } from '@/lib/types'
 import type { MoiContext } from '@/lib/moi-context'
@@ -554,6 +555,15 @@ one.get('/skills', async c => {
 one.post('/skills/update', async c => {
   const ws = c.get('ws')
   const result = await updateWorkspaceSkills(ws.path, ws.type ?? 'claude-code')
+  if (!result.shadcn.ok) {
+    return c.json(
+      {
+        ...result.status,
+        error: `moi skill updated, but the official shadcn skill could not be refreshed: ${result.shadcn.reason}`
+      } satisfies WorkspaceSkillsUpdateFailure,
+      502
+    )
+  }
   return c.json(result.status)
 })
 

--- a/server/bundler/applet-shadcn.css
+++ b/server/bundler/applet-shadcn.css
@@ -1,0 +1,8 @@
+@import 'tw-animate-css';
+@import 'shadcn/tailwind.css';
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+}

--- a/server/bundler/build-applet.ts
+++ b/server/bundler/build-applet.ts
@@ -388,8 +388,9 @@ function appletRuntimePlugin(
 // Inlined into the widget's synthetic CSS at build time so Tailwind sees the
 // theme tokens.
 const HOST_THEME_PATH = join(import.meta.dir, '..', '..', 'client', 'theme.css')
+const APPLET_SHADCN_CSS_PATH = join(import.meta.dir, 'applet-shadcn.css')
 
-// Three things matter for widget styling:
+// Five things matter for widget styling:
 //   1. The umbrella `@import 'tailwindcss'` brings in @layer theme + base +
 //      utilities — which is what spacing/color utilities like `left-2.5`,
 //      `gap-1.5`, `text-amber-500` need to resolve. The split
@@ -402,9 +403,17 @@ const HOST_THEME_PATH = join(import.meta.dir, '..', '..', 'client', 'theme.css')
 //      means the widget's CSS does NOT redefine the underlying
 //      `--background`/`--foreground` variables — those stay host-owned and
 //      the widget picks them up from `:root` at runtime.
-//   3. Tailwind's auto-detection treats `.moi/` as a hidden directory
+//   3. Tailwind preflight resets border color to `currentColor`. The standard
+//      shadcn base rule in applet-shadcn.css restores semantic border and
+//      outline colors before the compiled CSS is scoped to the applet.
+//   4. Tailwind's auto-detection treats `.moi/` as a hidden directory
 //      and skips it. An explicit `@source` bypasses the dot-dir + gitignore
 //      filters.
+//   5. Generated shadcn components use named data variants such as
+//      `data-horizontal:` and `data-open:`. Their definitions live in
+//      `shadcn/tailwind.css`, while their default transition utilities come
+//      from `tw-animate-css`. applet-shadcn.css resolves both from moi's pinned
+//      dependencies so workspaces need no extra CSS setup.
 //
 // Important: the synthetic CSS must live on disk in the `file` namespace
 // because `bun-plugin-tailwind`'s `onLoad` only matches that namespace —
@@ -424,6 +433,7 @@ async function writeSyntheticTailwindCss(
   const cssPath = join(buildDir, `${kind}-tailwind.css`)
   const contents = [
     `@import 'tailwindcss';`,
+    `@import ${JSON.stringify(APPLET_SHADCN_CSS_PATH)};`,
     await Bun.file(HOST_THEME_PATH).text(),
     // Mirror the host's class-based dark mode (client/index.css) so an applet's
     // `dark:` variants flip with the app theme. Without this Tailwind falls

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -1852,11 +1852,33 @@ async function runSkillUpdate(cwd: string): Promise<void> {
   // Type-aware: an OpenClaw workspace keeps its skills in `skills/`, so the
   // update must target the same dir the agent actually loads from.
   const { root, type } = await resolveWorkspace(cwd)
-  const { before, status } = await updateWorkspaceSkills(root, type ?? 'claude-code')
+  const { before, status, shadcn } = await updateWorkspaceSkills(root, type ?? 'claude-code')
   const after = status.skills
+
+  if (!shadcn.ok) {
+    console.log('\n' + pc.yellow('!') + ' moi skill updated in ' + pc.bold(root) + '\n')
+    printSkillUpdateTable(before, after)
+    console.log(
+      '\n  ' +
+        pc.red('✗') +
+        ' Official shadcn skill refresh failed: ' +
+        pc.dim(shadcn.reason) +
+        '\n'
+    )
+    process.exitCode = 1
+    return
+  }
 
   console.log('\n' + pc.green('✓') + ' Skills updated in ' + pc.bold(root) + '\n')
   printSkillUpdateTable(before, after)
+  console.log('\n  ' + pc.green('✓') + ' Official shadcn skill refreshed')
+  console.log(
+    '\n' +
+      pc.dim(
+        '  Changes apply when the skill is next loaded (new session or next skill invocation).'
+      ) +
+      '\n'
+  )
 }
 
 function printSkillUpdateTable(
@@ -1876,13 +1898,6 @@ function printSkillUpdateTable(
         ]
       })
     )
-  )
-  console.log(
-    '\n' +
-      pc.dim(
-        '  Changes apply when the skill is next loaded (new session or next skill invocation).'
-      ) +
-      '\n'
   )
 }
 
@@ -1908,10 +1923,7 @@ const defineSkillUpdate = (name: string, description: string) =>
   })
 
 const skillSubCommands = {
-  update: defineSkillUpdate(
-    'update',
-    'Update this workspace’s skills to the version shipped with the CLI'
-  ),
+  update: defineSkillUpdate('update', 'Update this workspace’s bundled and official skills'),
   install: defineSkillUpdate('install', 'Alias for `moi skill update`')
 }
 

--- a/server/external-skills.ts
+++ b/server/external-skills.ts
@@ -1,0 +1,106 @@
+import type { WorkspaceType } from '@/lib/types'
+
+export const SHADCN_SKILL_INSTALL_TIMEOUT_MS = 30_000
+
+const SKILL_INSTALL_ENV_KEYS = [
+  'PATH',
+  'HOME',
+  'USERPROFILE',
+  'SYSTEMROOT',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'XDG_CACHE_HOME',
+  'BUN_INSTALL',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'NODE_EXTRA_CA_CERTS',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR'
+] as const
+
+function skillInstallEnv(source: NodeJS.ProcessEnv): Record<string, string> {
+  const env: Record<string, string> = {
+    DISABLE_TELEMETRY: '1',
+    NO_COLOR: '1'
+  }
+  for (const key of SKILL_INSTALL_ENV_KEYS) {
+    const value = source[key]
+    if (value) env[key] = value
+  }
+  return env
+}
+
+export type ShadcnSkillInstallSpec = {
+  command: string[]
+  cwd: string
+  env: Record<string, string>
+  timeout: number
+  killSignal: 'SIGKILL'
+}
+
+export function shadcnSkillInstallSpec(
+  workspaceRoot: string,
+  type: WorkspaceType = 'claude-code',
+  sourceEnv: NodeJS.ProcessEnv = process.env
+): ShadcnSkillInstallSpec {
+  return {
+    command: [
+      'bunx',
+      '--bun',
+      'skills',
+      'add',
+      'shadcn/ui',
+      '--skill',
+      'shadcn',
+      '--agent',
+      type,
+      '--yes'
+    ],
+    cwd: workspaceRoot,
+    env: skillInstallEnv(sourceEnv),
+    timeout: SHADCN_SKILL_INSTALL_TIMEOUT_MS,
+    killSignal: 'SIGKILL'
+  }
+}
+
+export type RunShadcnSkillInstall = (workspaceRoot: string, type: WorkspaceType) => Promise<number>
+
+async function runShadcnSkillInstall(workspaceRoot: string, type: WorkspaceType): Promise<number> {
+  const spec = shadcnSkillInstallSpec(workspaceRoot, type)
+  const install = Bun.spawn(spec.command, {
+    cwd: spec.cwd,
+    env: spec.env,
+    stdout: 'ignore',
+    stderr: 'inherit',
+    timeout: spec.timeout,
+    killSignal: spec.killSignal
+  })
+  return install.exited
+}
+
+export type ShadcnSkillInstallResult =
+  | { ok: true }
+  | {
+      ok: false
+      reason: string
+    }
+
+// Fetch the current official shadcn skill into the active agent's standard
+// project skill directory. Callers decide whether a failure is fatal: workspace
+// initialization warns and continues, while a manual skill update fails.
+export async function installOfficialShadcnSkill(
+  workspaceRoot: string,
+  type: WorkspaceType = 'claude-code',
+  runInstall: RunShadcnSkillInstall = runShadcnSkillInstall
+): Promise<ShadcnSkillInstallResult> {
+  try {
+    const code = await runInstall(workspaceRoot, type)
+    if (code === 0) return { ok: true }
+    return { ok: false, reason: `installer exited with code ${code}` }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, reason: message }
+  }
+}

--- a/server/moi-scaffold.ts
+++ b/server/moi-scaffold.ts
@@ -13,15 +13,75 @@ export const MOI_PACKAGE_JSON = {
   private: true,
   dependencies: {
     '@tabler/icons-react': '^3.40.0',
-    tailwindcss: '^4.0.0',
+    clsx: '^2.1.1',
     react: '^19.0.0',
-    'react-dom': '^19.0.0'
+    'react-dom': '^19.0.0',
+    tailwindcss: '^4.0.0',
+    'tailwind-merge': '^3.5.0'
   },
   devDependencies: {
     '@types/react': '^19.0.0',
     '@types/react-dom': '^19.0.0'
   }
 } as const
+
+// shadcn's `add` command requires project configuration even when `--path`
+// chooses a kind-local component directory. Keep this config aligned with the
+// host's shadcn base and icon library, while leaving theme values host-owned.
+export const SHADCN_COMPONENTS_JSON = {
+  $schema: 'https://ui.shadcn.com/schema.json',
+  style: 'base-nova',
+  rsc: false,
+  tsx: true,
+  tailwind: {
+    config: '',
+    css: '',
+    baseColor: 'neutral',
+    cssVariables: true,
+    prefix: ''
+  },
+  iconLibrary: 'tabler',
+  rtl: false,
+  aliases: {
+    components: '@/components',
+    ui: '@/components/ui',
+    hooks: '@/hooks',
+    lib: '@/lib',
+    utils: '@/lib/utils'
+  },
+  registries: {}
+} as const
+
+export const APPLET_TSCONFIG_JSON = {
+  compilerOptions: {
+    target: 'ESNext',
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    jsx: 'react-jsx',
+    strict: true,
+    skipLibCheck: true,
+    isolatedModules: true,
+    noEmit: true,
+    baseUrl: '.',
+    paths: {
+      '@/*': ['./*']
+    }
+  },
+  include: ['widgets/**/*.ts', 'widgets/**/*.tsx', 'views/**/*.ts', 'views/**/*.tsx', 'lib/**/*.ts']
+} as const
+
+// shadcn generates `cn()` calls. `cx()` remains the applet-facing name, while
+// the alias keeps freshly generated source valid until the agent rewrites its
+// imports to relative paths.
+export const APPLET_CLASS_NAMES_TS = `import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cx(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+export const cn = cx
+`
 
 // Dependency installation is helpful for editor types and widget builds, but
 // it's not critical — the agent installs on demand if it's missing. So it must
@@ -104,9 +164,20 @@ export async function scaffoldMoiDir(
   // A bare `.moi/` dir without package.json counts as not-bootstrapped —
   // fill in the missing pieces.
 
-  await mkdir(join(moiDir, 'widgets'), { recursive: true })
-  await Bun.write(packagePath, JSON.stringify(MOI_PACKAGE_JSON, null, 2) + '\n')
-  await Bun.write(join(moiDir, 'applet-env.d.ts'), APPLET_ENV_DTS)
+  await Promise.all([
+    mkdir(join(moiDir, 'widgets'), { recursive: true }),
+    mkdir(join(moiDir, 'lib'), { recursive: true })
+  ])
+  await Promise.all([
+    Bun.write(packagePath, JSON.stringify(MOI_PACKAGE_JSON, null, 2) + '\n'),
+    Bun.write(
+      join(moiDir, 'components.json'),
+      JSON.stringify(SHADCN_COMPONENTS_JSON, null, 2) + '\n'
+    ),
+    Bun.write(join(moiDir, 'tsconfig.json'), JSON.stringify(APPLET_TSCONFIG_JSON, null, 2) + '\n'),
+    Bun.write(join(moiDir, 'lib', 'utils.ts'), APPLET_CLASS_NAMES_TS),
+    Bun.write(join(moiDir, 'applet-env.d.ts'), APPLET_ENV_DTS)
+  ])
 
   const exited = installDependencies(moiDir)
   let timer: ReturnType<typeof setTimeout> | undefined

--- a/server/skill-update.ts
+++ b/server/skill-update.ts
@@ -1,12 +1,19 @@
 import type { WorkspaceSkillsStatus, WorkspaceSkillStatus, WorkspaceType } from '@/lib/types'
 
+import { installOfficialShadcnSkill, type ShadcnSkillInstallResult } from './external-skills'
 import { isMinorBehind, skillStatuses } from './skill-version'
 import { installBundledSkills } from './skills-template'
 import { skillsDirFor } from './workspace-init'
 
+type InstallOfficialSkill = (
+  workspaceRoot: string,
+  type: WorkspaceType
+) => Promise<ShadcnSkillInstallResult>
+
 export type WorkspaceSkillUpdateResult = {
   before: WorkspaceSkillStatus[]
   status: WorkspaceSkillsStatus
+  shadcn: ShadcnSkillInstallResult
 }
 
 export function summarizeSkillStatuses(skills: WorkspaceSkillStatus[]): WorkspaceSkillsStatus {
@@ -25,14 +32,19 @@ export async function getWorkspaceSkillsStatus(
 
 export async function updateWorkspaceSkills(
   workspaceRoot: string,
-  type: WorkspaceType = 'claude-code'
+  type: WorkspaceType = 'claude-code',
+  installOfficialSkill: InstallOfficialSkill = installOfficialShadcnSkill
 ): Promise<WorkspaceSkillUpdateResult> {
   const before = await skillStatuses(workspaceRoot, type)
   await installBundledSkills(skillsDirFor(workspaceRoot, type))
-  const skills = await skillStatuses(workspaceRoot, type)
+  const [skills, shadcn] = await Promise.all([
+    skillStatuses(workspaceRoot, type),
+    installOfficialSkill(workspaceRoot, type)
+  ])
 
   return {
     before,
-    status: summarizeSkillStatuses(skills)
+    status: summarizeSkillStatuses(skills),
+    shadcn
   }
 }

--- a/server/test/__fixtures__/shadcn-tailwind.tsx
+++ b/server/test/__fixtures__/shadcn-tailwind.tsx
@@ -1,0 +1,7 @@
+export default function ShadcnTailwindFixture() {
+  return (
+    <div className="border data-horizontal:h-1 data-vertical:w-1 data-open:animate-in">
+      Shadcn variants
+    </div>
+  )
+}

--- a/server/test/build-applet.test.ts
+++ b/server/test/build-applet.test.ts
@@ -55,6 +55,20 @@ describe('buildApplet', () => {
     expect(result.js).toContain('widget:hello')
   })
 
+  test('compiles shadcn state variants and animations', async () => {
+    const result = await buildApplet(join(FIXTURES, 'shadcn-tailwind.tsx'))
+
+    expect(result.js).toContain('[data-orientation=\\"horizontal\\"]')
+    expect(result.js).toContain('[data-orientation=\\"vertical\\"]')
+    expect(result.js).toContain('[data-state=\\"open\\"]')
+  })
+
+  test('gives bare shadcn borders the semantic border color', async () => {
+    const result = await buildApplet(join(FIXTURES, 'shadcn-tailwind.tsx'))
+
+    expect(result.js).toMatch(/border-color:\s*var\(--border\)/)
+  })
+
   test('rewrites .server.ts imports to rpc() stubs', async () => {
     const result = await buildApplet(join(FIXTURES, 'with-server.tsx'))
 

--- a/server/test/external-skills.test.ts
+++ b/server/test/external-skills.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  installOfficialShadcnSkill,
+  SHADCN_SKILL_INSTALL_TIMEOUT_MS,
+  shadcnSkillInstallSpec
+} from '../external-skills'
+
+describe('official shadcn skill installation', () => {
+  for (const agent of ['claude-code', 'codex', 'openclaw'] as const) {
+    test(`targets the ${agent} workspace agent`, () => {
+      expect(shadcnSkillInstallSpec('/workspace', agent, {}).command).toEqual([
+        'bunx',
+        '--bun',
+        'skills',
+        'add',
+        'shadcn/ui',
+        '--skill',
+        'shadcn',
+        '--agent',
+        agent,
+        '--yes'
+      ])
+    })
+  }
+
+  test('uses a 30-second timeout and a minimal telemetry-free environment', () => {
+    const spec = shadcnSkillInstallSpec('/workspace', 'codex', {
+      PATH: '/bin',
+      HOME: '/home/tester',
+      SECRET_TOKEN: 'do-not-forward'
+    })
+
+    expect(spec).toMatchObject({
+      cwd: '/workspace',
+      timeout: SHADCN_SKILL_INSTALL_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+      env: {
+        PATH: '/bin',
+        HOME: '/home/tester',
+        DISABLE_TELEMETRY: '1',
+        NO_COLOR: '1'
+      }
+    })
+    expect(spec.timeout).toBe(30_000)
+    expect(spec.env.SECRET_TOKEN).toBeUndefined()
+  })
+
+  test('passes the workspace root and agent to the installer', async () => {
+    const calls: Array<[string, string]> = []
+
+    const installed = await installOfficialShadcnSkill(
+      '/workspace',
+      'codex',
+      async (root, type) => {
+        calls.push([root, type])
+        return 0
+      }
+    )
+
+    expect(installed).toEqual({ ok: true })
+    expect(calls).toEqual([['/workspace', 'codex']])
+  })
+
+  test('reports a non-zero installer exit', async () => {
+    const installed = await installOfficialShadcnSkill('/workspace', 'claude-code', async () => 1)
+
+    expect(installed).toEqual({ ok: false, reason: 'installer exited with code 1' })
+  })
+
+  test('reports a thrown process error', async () => {
+    const installed = await installOfficialShadcnSkill('/workspace', 'openclaw', async () => {
+      throw new Error('spawn failed')
+    })
+
+    expect(installed).toEqual({ ok: false, reason: 'spawn failed' })
+  })
+})

--- a/server/test/moi-scaffold.test.ts
+++ b/server/test/moi-scaffold.test.ts
@@ -39,7 +39,27 @@ describe('scaffoldMoiDir install', () => {
 
     expect(result).toBe(137)
     expect(existsSync(join(moiDir, 'package.json'))).toBe(true)
+    expect(existsSync(join(moiDir, 'components.json'))).toBe(true)
+    expect(existsSync(join(moiDir, 'tsconfig.json'))).toBe(true)
+    expect(existsSync(join(moiDir, 'lib', 'utils.ts'))).toBe(true)
     expect(existsSync(join(moiDir, 'widgets'))).toBe(true)
+
+    const packageJson = (await Bun.file(join(moiDir, 'package.json')).json()) as {
+      dependencies: Record<string, string>
+    }
+    const componentsJson = (await Bun.file(join(moiDir, 'components.json')).json()) as {
+      style: string
+      iconLibrary: string
+      tailwind: { css: string }
+    }
+    expect(packageJson.dependencies.clsx).toBeDefined()
+    expect(packageJson.dependencies['tailwind-merge']).toBeDefined()
+    expect(componentsJson).toMatchObject({
+      style: 'base-nova',
+      iconLibrary: 'tabler',
+      tailwind: { css: '' }
+    })
+    expect(await Bun.file(join(moiDir, 'lib', 'utils.ts')).text()).toContain('export const cn = cx')
     expect(await Bun.file(join(moiDir, 'applet-env.d.ts')).text()).toContain('icon?: string')
   })
 
@@ -67,5 +87,6 @@ describe('scaffoldMoiDir install', () => {
 
     expect(result).toBe('exists')
     expect(installs).toBe(0)
+    expect(existsSync(join(moiDir, 'components.json'))).toBe(false)
   })
 })

--- a/server/test/skill-update-service.test.ts
+++ b/server/test/skill-update-service.test.ts
@@ -45,17 +45,36 @@ describe('workspace skill update service', () => {
     })
   }
 
-  test('updates bundled skills and preserves custom skills', async () => {
+  test('updates bundled skills, preserves custom skills, and refreshes shadcn', async () => {
     tempRoot = await mkdtemp(join(tmpdir(), 'moi-skill-update-'))
     await writeInstalledVersion(tempRoot, 'codex', '0.7.1')
     const customSkill = join(skillsDirFor(tempRoot, 'codex'), 'custom', 'SKILL.md')
     await mkdir(join(customSkill, '..'), { recursive: true })
     await Bun.write(customSkill, 'custom\n')
+    const calls: Array<[string, WorkspaceType]> = []
 
-    const result = await updateWorkspaceSkills(tempRoot, 'codex')
+    const result = await updateWorkspaceSkills(tempRoot, 'codex', async (root, type) => {
+      calls.push([root, type])
+      return { ok: true }
+    })
 
     expect(result.before.find(skill => skill.name === 'moi-workspace')?.installed).toBe('0.7.1')
     expect(result.status.updateAvailable).toBe(false)
+    expect(result.shadcn).toEqual({ ok: true })
+    expect(calls).toEqual([[tempRoot, 'codex']])
     expect(await Bun.file(customSkill).text()).toBe('custom\n')
+  })
+
+  test('reports a shadcn failure after updating the bundled skill', async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'moi-skill-update-failure-'))
+    await writeInstalledVersion(tempRoot, 'claude-code', '0.7.1')
+
+    const result = await updateWorkspaceSkills(tempRoot, 'claude-code', async () => ({
+      ok: false,
+      reason: 'network unavailable'
+    }))
+
+    expect(result.status.updateAvailable).toBe(false)
+    expect(result.shadcn).toEqual({ ok: false, reason: 'network unavailable' })
   })
 })

--- a/server/test/skill-update.test.ts
+++ b/server/test/skill-update.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const CLI = join(import.meta.dir, '..', 'cli.ts')
+const PROJECT_ROOT = join(import.meta.dir, '..', '..')
+
+let tempRoot = ''
+
+afterEach(async () => {
+  if (!tempRoot) return
+  await rm(tempRoot, { recursive: true, force: true })
+  tempRoot = ''
+})
+
+describe('moi skill update commands', () => {
+  for (const command of ['update', 'install'] as const) {
+    test(`${command} exits non-zero without a full-success message when shadcn fails`, async () => {
+      tempRoot = await mkdtemp(join(tmpdir(), `moi-skill-${command}-`))
+      const workspace = join(tempRoot, 'workspace')
+      const binDir = join(tempRoot, 'bin')
+      const bunx = join(binDir, 'bunx')
+      await mkdir(binDir, { recursive: true })
+      await Bun.write(bunx, '#!/bin/sh\nexit 23\n')
+      await chmod(bunx, 0o755)
+
+      const proc = Bun.spawn([process.execPath, CLI, 'skill', command, '--dir', workspace], {
+        cwd: PROJECT_ROOT,
+        env: { ...globalThis.process.env, PATH: binDir, NO_COLOR: '1' },
+        stdout: 'pipe',
+        stderr: 'pipe'
+      })
+      const [exitCode, stdout, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text()
+      ])
+      const output = stdout + stderr
+
+      expect(exitCode).not.toBe(0)
+      expect(output).toContain('moi skill updated')
+      expect(output).toContain('Official shadcn skill refresh failed')
+      expect(output).not.toContain('✓ Skills updated')
+    })
+  }
+})

--- a/server/test/skills-template.test.ts
+++ b/server/test/skills-template.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { installBundledSkills } from '../skills-template'
+import { BUNDLED_SKILLS_DIR, installBundledSkills } from '../skills-template'
 
 let targetSkillsDir = ''
 
@@ -33,11 +33,16 @@ describe('installBundledSkills', () => {
     await installBundledSkills(targetSkillsDir)
 
     expect(await Bun.file(retiredViewDesign).exists()).toBe(false)
-    expect(await Bun.file(join(workspaceSkillDir, 'DESIGN.md')).exists()).toBe(true)
+    const designGuide = Bun.file(join(workspaceSkillDir, 'DESIGN.md'))
+    expect(await designGuide.exists()).toBe(true)
+    expect(await designGuide.text()).toContain(
+      'bunx --bun shadcn@latest add <components...> --cwd .moi'
+    )
     expect(await Bun.file(join(workspaceSkillDir, 'SKILL.md')).text()).toContain(
-      '<moi-skill version="0.8.0" />'
+      '<moi-skill version="0.9.0" />'
     )
     expect(await Bun.file(workspaceNote).text()).toBe('Keep this note\n')
     expect(await Bun.file(customSkill).text()).toBe('Keep this skill\n')
+    expect(await Bun.file(join(BUNDLED_SKILLS_DIR, 'shadcn', 'SKILL.md')).exists()).toBe(false)
   })
 })

--- a/server/test/workspace-init.test.ts
+++ b/server/test/workspace-init.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, test } from 'bun:test'
-import { join } from 'path'
+import { afterEach, describe, expect, spyOn, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { skillsDirFor, validateWorkspaceFolderName } from '../workspace-init'
+import { provisionWorkspace, skillsDirFor, validateWorkspaceFolderName } from '../workspace-init'
 
-// Pure helpers only — `provisionWorkspace` composes `installBundledSkills` and
-// `scaffoldMoiDir` (covered by their own tests) and would hit the network via
-// `bun install`.
+let workspaceRoot = ''
+
+afterEach(async () => {
+  if (!workspaceRoot) return
+  await rm(workspaceRoot, { recursive: true, force: true })
+  workspaceRoot = ''
+})
 
 describe('skillsDirFor', () => {
   test('claude-code (and untyped) workspaces load skills from .claude/skills', () => {
@@ -51,5 +57,55 @@ describe('validateWorkspaceFolderName', () => {
   test('rejects trailing dots and spaces', () => {
     expect(validateWorkspaceFolderName('name.')).not.toBeNull()
     expect(validateWorkspaceFolderName('name ')).not.toBeNull()
+  })
+})
+
+describe('provisionWorkspace', () => {
+  test('continues workspace initialization when the shadcn installer fails', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'moi-provision-'))
+    await mkdir(join(workspaceRoot, '.moi'), { recursive: true })
+    await Bun.write(join(workspaceRoot, '.moi', 'package.json'), '{}\n')
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const result = await provisionWorkspace(workspaceRoot, 'codex', async (root, type) => {
+        expect(root).toBe(workspaceRoot)
+        expect(type).toBe('codex')
+        return { ok: false, reason: 'network unavailable' }
+      })
+
+      expect(result).toEqual({
+        skillsDir: join(workspaceRoot, '.agents', 'skills'),
+        scaffold: 'exists'
+      })
+      expect(await Bun.file(join(result.skillsDir, 'moi-workspace', 'SKILL.md')).exists()).toBe(
+        true
+      )
+      expect(warn).toHaveBeenCalledWith(
+        '[skills] official shadcn skill install failed: network unavailable'
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test('continues workspace initialization when the installer process throws', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'moi-provision-'))
+    await mkdir(join(workspaceRoot, '.moi'), { recursive: true })
+    await Bun.write(join(workspaceRoot, '.moi', 'package.json'), '{}\n')
+    const warn = spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const result = await provisionWorkspace(workspaceRoot, 'claude-code', async () => {
+        throw new Error('spawn failed')
+      })
+
+      expect(result.scaffold).toBe('exists')
+      expect(warn).toHaveBeenCalledWith(
+        '[skills] official shadcn skill install failed: spawn failed'
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/server/workspace-init.ts
+++ b/server/workspace-init.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path'
 import type { WorkspaceType } from '@/lib/types'
 export { validateWorkspaceFolderName } from '@/lib/workspace-name'
 
+import { installOfficialShadcnSkill, type ShadcnSkillInstallResult } from './external-skills'
 import { harnessFor } from './harness/registry'
 import { scaffoldMoiDir } from './moi-scaffold'
 import { installBundledSkills } from './skills-template'
@@ -36,17 +37,43 @@ export type ProvisionResult = {
   scaffold: 'exists' | 'installing' | number
 }
 
-// Lay down everything a workspace needs: create the folder, copy the bundled
-// skills into the backend's skills dir, and bootstrap `.moi/`. Idempotent —
-// re-running refreshes skills and leaves an existing `.moi/` untouched.
+type InstallShadcnSkill = (
+  workspaceRoot: string,
+  type: WorkspaceType
+) => Promise<ShadcnSkillInstallResult>
+
+async function installShadcnBestEffort(
+  workspaceRoot: string,
+  type: WorkspaceType,
+  installShadcn: InstallShadcnSkill
+): Promise<void> {
+  try {
+    const result = await installShadcn(workspaceRoot, type)
+    if (!result.ok) {
+      console.warn(`[skills] official shadcn skill install failed: ${result.reason}`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`[skills] official shadcn skill install failed: ${message}`)
+  }
+}
+
+// Lay down everything a workspace needs: create the folder, copy moi's bundled
+// skill, fetch the current official shadcn skill, and bootstrap `.moi/`.
+// Idempotent — re-running refreshes skills and leaves an existing `.moi/`
+// untouched. The external skill is best-effort so offline init still works.
 // Registration in the workspace registry is a separate, caller-owned step.
 export async function provisionWorkspace(
   workspaceRoot: string,
-  type?: WorkspaceType
+  type: WorkspaceType = 'claude-code',
+  installShadcn: InstallShadcnSkill = installOfficialShadcnSkill
 ): Promise<ProvisionResult> {
   const skillsDir = skillsDirFor(workspaceRoot, type)
   await mkdir(workspaceRoot, { recursive: true })
   await installBundledSkills(skillsDir)
-  const scaffold = await scaffoldMoiDir(workspaceRoot)
+  const [scaffold] = await Promise.all([
+    scaffoldMoiDir(workspaceRoot),
+    installShadcnBestEffort(workspaceRoot, type, installShadcn)
+  ])
   return { skillsDir, scaffold }
 }

--- a/workspace/.claude/skills/moi-workspace/DESIGN.md
+++ b/workspace/.claude/skills/moi-workspace/DESIGN.md
@@ -51,7 +51,9 @@ for important labels or values. Keep inset surfaces rare so a widget does not be
 cards.
 
 Keep container edges subtle. Use `ring-1 ring-border` for custom container outlines. Do not use a
-bare `border`, black borders, or raw high-contrast border colors as custom container chrome.
+bare `border`, black borders, or raw high-contrast border colors as custom container chrome. Leave
+the default `border`, `border-input`, and related classes inside generated shadcn components
+unchanged.
 
 Custom color is welcome when it carries identity, data, status, or useful emphasis. On a saturated
 surface, choose an explicit light or dark foreground with strong contrast. Keep state colors
@@ -125,6 +127,32 @@ fields, list rows, and repeated sections should use `rounded-lg` or `rounded-xl`
 `rounded-2xl` and `rounded-3xl` for one expressive focal surface, and use `rounded-full` only for
 real pills, circular buttons, avatars, and status dots. Controls and rectangular content regions
 must not look capsule-shaped.
+
+## Components and controls
+
+Use shadcn for standard controls in widgets and views: buttons, inputs, textareas, selects, sliders,
+switches, checkboxes, tabs, dialogs, menus, popovers, tooltips, and similar UI. Read the installed
+official `shadcn` skill before working with them. Reuse an existing generated component when
+possible, and add only what the applet needs.
+
+Run the CLI from the workspace root. Keep generated components inside the relevant applet kind so
+Tailwind scans their classes:
+
+```sh
+bunx --bun shadcn@latest add <components...> --cwd .moi --path views/components/ui --yes
+```
+
+Use `widgets/components/ui` for widgets. The CLI adds each component's dependencies. If
+`.moi/components.json` or `.moi/lib/utils.ts` is missing, report that the workspace scaffold is
+incomplete. Do not run shadcn initialization, invent a replacement control, or continue with native
+controls. Native controls are allowed when shadcn has no suitable component or browser-native
+behavior is required.
+
+Keep shadcn's default variants, sizing, behavior, and accessibility. Style with moi's existing
+semantic tokens. Do not replace theme CSS, add tokens, or introduce another visual system. Generated
+source still follows the applet rules: relative imports, local `cx()`, Tabler icons, and Tailwind
+styling. Keep portalled menus and overlays inside the nearest `[data-applet]` root so scoped styles
+and theme values apply.
 
 ## Interaction and motion
 
@@ -261,8 +289,9 @@ Before finishing an applet, confirm:
 - Purple appears only for a content, brand, or user reason and never as a default gradient.
 - Type, spacing, density, and expression support the content.
 - Numeric UI values use the default font, with `tabular-nums` when alignment helps.
-- Custom container outlines use a subtle `ring-border`.
+- Custom container outlines use a subtle `ring-border`; generated shadcn borders keep their defaults.
 - The layout handles realistic content and deliberate overflow.
 - Every reachable state and interaction is complete and accessible.
+- Standard controls use shadcn and cover hover, focus, disabled, open, and error states.
 - The widget or view follows its frame, sizing, and scrolling rules.
 - It feels related to the workspace without copying the quieter host shell.

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -135,6 +135,8 @@ For more options, commands, use `moi help`.
 Every applet — a **Widget** or a **View** — is a default-exported React component in
 `.moi/<type>/<name>.tsx`, optionally paired with a `<name>.server.ts`. `moi bundle` compiles each
 into a live module the browser loads (edits hot-reload). Read `DESIGN.md` first.
+Before implementing interactive controls, read the installed official `shadcn` skill too. The moi
+workspace rules take precedence for applet paths, imports, icons, styling, and portalled content.
 Write normal React + Tailwind — below is only what's **moi-specific**.
 
 ## Anatomy
@@ -346,4 +348,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.8.0" />
+<moi-skill version="0.9.0" />


### PR DESCRIPTION
Workspace applets can now generate and bundle shadcn controls with the same semantic tokens, radius scale, icons, and scoped Tailwind behavior as moi. New workspaces also receive the official shadcn skill, while existing `.moi` scaffolds remain untouched.

```text
moi workspace init
├─ install the official shadcn skill
├─ scaffold components.json, TypeScript aliases, and local cx/cn
└─ generated control → scoped applet CSS → host theme tokens
```

## What changed

- Scaffold the shadcn project config, applet TypeScript config, local class helper, and required dependencies
- Bundle shadcn state variants, animations, semantic borders, and outlines inside scoped applet CSS
- Install the official shadcn skill for Claude Code, Codex, and OpenClaw workspaces
- Refresh the official skill through CLI and workspace API updates with explicit failure reporting
- Teach the moi workspace skill to generate kind-local controls and keep portals inside the applet root
- Bump the bundled workspace skill version from `0.8.0` to `0.9.0`

## Review focus

- Check external skill installation environment, timeout, and offline fallback behavior
- Check generated import paths and the idempotent scaffold guard for existing `.moi` folders
- Check CSS ordering and scoping for shadcn data variants, animations, borders, and theme ownership

## Verification

- Focused applet, scaffold, installer, workspace-init, API, CLI, and skill tests — 75 passed
- `bun test` — 608 passed
- `bun run format:check`, `bun run lint`, and `bun run typecheck:client`
- One commit and a clean diff against `design-guidelines`

Stacked on #56 and intended to merge after it.