### PR TITLE
Rebuild an applet when a dependency vanishes or resolves outside the TS extensions

### DIFF
--- a/server/applets.ts
+++ b/server/applets.ts
@@ -20,9 +20,7 @@ import {
   APPLET_API_BASE_SENTINEL,
   type AppletKind,
   buildApplet,
-  scanAssetImports,
-  scanModuleImports,
-  scanServerImports
+  scanRelativeImports
 } from './bundler/build-applet'
 
 export type AppletPaths = {
@@ -66,13 +64,16 @@ async function resolveSource(sourceDir: string, name: string): Promise<string | 
 // Backstop for pathological graphs: an applet wiring more distinct files than
 // this is reported stale without walking further — stale-but-rebuilt is the
 // safe degradation, and the cap keeps the per-bundle check bounded no matter
-// what the imports look like. Far above any sane applet (the walk never enters
-// node_modules), so hitting it means something is off anyway.
-const MAX_GRAPH_FILES = 128
+// what the imports look like. Counts every input, images and JSON included, so
+// it sits well above what an asset-heavy applet reaches (the walk never enters
+// node_modules); hitting it means something is off anyway.
+const MAX_GRAPH_FILES = 256
 
 // Files the walk keeps descending through — anything Bun treats as a module
-// (`.ts`, `.mjs`, `.cts`, …). Everything else (`.json`, `.css`) is a leaf.
+// (`.ts`, `.mjs`, `.cts`, …). Everything else (`.json`, `.css`, images) is a
+// leaf, and so are `.server.ts` modules.
 const MODULE_FILE_RE = /\.[mc]?[jt]sx?$/
+const SERVER_FILE_RE = /\.server\.tsx?$/
 // Which transpiler loader lexes a module's imports. Only `.ts`/`.mts`/`.cts`
 // take the `ts` loader: angle-bracket casts (`<string>x`) parse there and are
 // JSX everywhere else. `.js`/`.mjs`/`.cjs` go through `tsx`, which accepts both
@@ -81,14 +82,16 @@ const TS_ONLY_FILE_RE = /\.[mc]?ts$/
 
 // A bundle is stale if its entry `index.js` is missing, any file in its local
 // import graph has an mtime >= the built entry's, or one of those imports no
-// longer resolves to a file at all. The graph is walked
-// transitively over relative module imports (shared `_utils.tsx`,
-// `../lib/*.ts`, `./data.json`), and every visited module's `.server.ts`
-// imports (RPC stubs are inlined) and asset imports (emitted into the bundle
-// dir) are checked as leaves. Bare specifiers (node_modules) are not walked —
-// after a dependency bump, `moi bundle --force`. The bundle itself is
-// React-mode-agnostic (see buildApplet), so it needs no rebuild when the server
-// switches between the development and production React.
+// longer resolves to a file at all.
+//
+// The graph is one uniform walk over every RELATIVE import the entry reaches:
+// shared `_utils.tsx`, `../lib/*.ts`, `./data.json`, `./logo.png`,
+// `./db.server`. Each is resolved to a real path, mtime-checked, and descended
+// into when it's a module — so an imported image and a transitively imported
+// helper are the same case, not two mechanisms. Bare specifiers (node_modules)
+// are not walked: after a dependency bump, `moi bundle --force`. The bundle
+// itself is React-mode-agnostic (see buildApplet), so it needs no rebuild when
+// the server switches between the development and production React.
 async function needsRebuild(buildDir: string, name: string, srcPath: string): Promise<boolean> {
   const built = Bun.file(join(buildDir, name, 'index.js'))
   if (!(await built.exists())) return true
@@ -104,28 +107,22 @@ async function needsRebuild(buildDir: string, name: string, srcPath: string): Pr
     const file = Bun.file(path)
     if (!(await file.exists())) continue
     if (file.lastModified >= builtMtime) return true
-    // Only JS/TS modules can import further files; other leaves (JSON, CSS)
-    // end at the mtime check above.
-    if (!MODULE_FILE_RE.test(path)) continue
+    // Leaves stop at the mtime check above: an asset, JSON, or CSS file can't
+    // import anything, and a `.server.ts` module contributes only its export
+    // list to the bundle — what its own imports do is invisible here (edit one
+    // of those and `moi bundle --force`).
+    if (!MODULE_FILE_RE.test(path) || SERVER_FILE_RE.test(path)) continue
     const source = await file.text()
     const dir = dirname(path)
-    for (const specifier of scanServerImports(source)) {
-      const serverFile = Bun.file(join(dir, `${specifier}.server.ts`))
-      if ((await serverFile.exists()) && serverFile.lastModified >= builtMtime) return true
-    }
-    for (const specifier of scanAssetImports(source)) {
-      const assetFile = Bun.file(join(dir, specifier))
-      if ((await assetFile.exists()) && assetFile.lastModified >= builtMtime) return true
-    }
-    for (const specifier of scanModuleImports(source, TS_ONLY_FILE_RE.test(path) ? 'ts' : 'tsx')) {
+    for (const specifier of scanRelativeImports(
+      source,
+      TS_ONLY_FILE_RE.test(path) ? 'ts' : 'tsx'
+    )) {
       const resolved = await resolveModuleImport(dir, specifier)
       // Nothing on disk answers this import, so the next build will fail on it.
       // Report stale rather than skip: a helper deleted since the last build
       // would otherwise leave `moi bundle` serving the last good bundle and
-      // never surfacing the missing-import error. Only this branch fails toward
-      // stale — it's the one lexed by the transpiler, so a specifier here is
-      // really imported. The regex-based server/asset scanners above can match
-      // inside a comment or string, where a missing file means nothing.
+      // never surfacing the missing-import error.
       if (!resolved) return true
       queue.push(resolved)
     }

--- a/server/applets.ts
+++ b/server/applets.ts
@@ -70,8 +70,18 @@ async function resolveSource(sourceDir: string, name: string): Promise<string | 
 // node_modules), so hitting it means something is off anyway.
 const MAX_GRAPH_FILES = 128
 
-// A bundle is stale if its entry `index.js` is missing, or any file in its
-// local import graph has an mtime >= the built entry's. The graph is walked
+// Files the walk keeps descending through — anything Bun treats as a module
+// (`.ts`, `.mjs`, `.cts`, …). Everything else (`.json`, `.css`) is a leaf.
+const MODULE_FILE_RE = /\.[mc]?[jt]sx?$/
+// Which transpiler loader lexes a module's imports. Only `.ts`/`.mts`/`.cts`
+// take the `ts` loader: angle-bracket casts (`<string>x`) parse there and are
+// JSX everywhere else. `.js`/`.mjs`/`.cjs` go through `tsx`, which accepts both
+// plain JS and the JSX some of them contain.
+const TS_ONLY_FILE_RE = /\.[mc]?ts$/
+
+// A bundle is stale if its entry `index.js` is missing, any file in its local
+// import graph has an mtime >= the built entry's, or one of those imports no
+// longer resolves to a file at all. The graph is walked
 // transitively over relative module imports (shared `_utils.tsx`,
 // `../lib/*.ts`, `./data.json`), and every visited module's `.server.ts`
 // imports (RPC stubs are inlined) and asset imports (emitted into the bundle
@@ -96,7 +106,7 @@ async function needsRebuild(buildDir: string, name: string, srcPath: string): Pr
     if (file.lastModified >= builtMtime) return true
     // Only JS/TS modules can import further files; other leaves (JSON, CSS)
     // end at the mtime check above.
-    if (!/\.[jt]sx?$/.test(path)) continue
+    if (!MODULE_FILE_RE.test(path)) continue
     const source = await file.text()
     const dir = dirname(path)
     for (const specifier of scanServerImports(source)) {
@@ -107,32 +117,76 @@ async function needsRebuild(buildDir: string, name: string, srcPath: string): Pr
       const assetFile = Bun.file(join(dir, specifier))
       if ((await assetFile.exists()) && assetFile.lastModified >= builtMtime) return true
     }
-    for (const specifier of scanModuleImports(source, /\.(tsx|jsx)$/.test(path) ? 'tsx' : 'ts')) {
+    for (const specifier of scanModuleImports(source, TS_ONLY_FILE_RE.test(path) ? 'ts' : 'tsx')) {
       const resolved = await resolveModuleImport(dir, specifier)
-      if (resolved) queue.push(resolved)
+      // Nothing on disk answers this import, so the next build will fail on it.
+      // Report stale rather than skip: a helper deleted since the last build
+      // would otherwise leave `moi bundle` serving the last good bundle and
+      // never surfacing the missing-import error. Only this branch fails toward
+      // stale — it's the one lexed by the transpiler, so a specifier here is
+      // really imported. The regex-based server/asset scanners above can match
+      // inside a comment or string, where a missing file means nothing.
+      if (!resolved) return true
+      queue.push(resolved)
     }
   }
   return false
 }
 
-// Resolve a relative import the way the bundler would, limited to what the
-// staleness check needs: the literal file (explicit-extension imports like
-// `./data.json`), the `.tsx`/`.ts`/`.jsx`/`.js` variants, or a directory
-// index. Unresolvable specifiers are skipped — the build itself surfaces those
-// as errors.
+// Extensions Bun appends to an extensionless import, in its own preference
+// order (`./data` finds `data.tsx` before `data.ts` before … `data.json`).
+// Doubles as the directory-index set: `./helpers` → `helpers/index.jsx`.
+const RESOLVE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs', '.json', '.mts', '.cts']
+
+// TypeScript's output-extension rewrite: an import written against the emitted
+// file name resolves to the source that produces it. (`.cjs` → `.cts` is
+// deliberately absent — Bun doesn't do that one.)
+const TS_EXTENSION_REWRITES: Record<string, string[]> = {
+  '.js': ['.ts', '.tsx'],
+  '.jsx': ['.tsx'],
+  '.mjs': ['.mts']
+}
+
+// Resolve a relative import to the file the bundler will actually read. This
+// mirrors Bun's resolution rather than delegating to `Bun.resolveSync`, which
+// memoizes results for the life of the process: in the long-running server it
+// keeps handing back the path of a dependency that has since been deleted or
+// renamed, which is exactly the case this check has to catch. Every candidate
+// is probed against the filesystem, in Bun's order — literal path, TS
+// extension rewrite, appended extension, then directory (`package.json` main,
+// else `index.*`). Returns null when nothing on disk answers the specifier.
 async function resolveModuleImport(dir: string, specifier: string): Promise<string | null> {
   const base = join(dir, specifier)
-  const candidates = [
-    base,
-    `${base}.tsx`,
-    `${base}.ts`,
-    `${base}.jsx`,
-    `${base}.js`,
-    join(base, 'index.tsx'),
-    join(base, 'index.ts')
-  ]
+  const candidates = [base]
+
+  // Extension of the final segment only — a dot in a directory name (`./v1.2/x`)
+  // is not one.
+  const ext = /\.[^./\\]+$/.exec(base)?.[0] ?? ''
+  for (const rewrite of TS_EXTENSION_REWRITES[ext] ?? []) {
+    candidates.push(base.slice(0, base.length - ext.length) + rewrite)
+  }
+  for (const e of RESOLVE_EXTENSIONS) candidates.push(base + e)
+
   for (const candidate of candidates) {
     if (await Bun.file(candidate).exists()) return candidate
+  }
+
+  // Directory import. `package.json` main wins over `index.*`, matching Bun;
+  // an unreadable or `main`-less manifest just falls through to the indexes.
+  const pkg: unknown = await Bun.file(join(base, 'package.json'))
+    .json()
+    .catch(() => null)
+  const main =
+    typeof pkg === 'object' && pkg !== null && 'main' in pkg && typeof pkg.main === 'string'
+      ? pkg.main
+      : null
+  if (main) {
+    const mainPath = join(base, main)
+    if (await Bun.file(mainPath).exists()) return mainPath
+  }
+  for (const e of RESOLVE_EXTENSIONS) {
+    const index = join(base, `index${e}`)
+    if (await Bun.file(index).exists()) return index
   }
   return null
 }

--- a/server/applets.ts
+++ b/server/applets.ts
@@ -71,9 +71,8 @@ const MAX_GRAPH_FILES = 256
 
 // Files the walk keeps descending through — anything Bun treats as a module
 // (`.ts`, `.mjs`, `.cts`, …). Everything else (`.json`, `.css`, images) is a
-// leaf, and so are `.server.ts` modules.
+// leaf.
 const MODULE_FILE_RE = /\.[mc]?[jt]sx?$/
-const SERVER_FILE_RE = /\.server\.tsx?$/
 // Which transpiler loader lexes a module's imports. Only `.ts`/`.mts`/`.cts`
 // take the `ts` loader: angle-bracket casts (`<string>x`) parse there and are
 // JSX everywhere else. `.js`/`.mjs`/`.cjs` go through `tsx`, which accepts both
@@ -92,6 +91,17 @@ const TS_ONLY_FILE_RE = /\.[mc]?ts$/
 // are not walked: after a dependency bump, `moi bundle --force`. The bundle
 // itself is React-mode-agnostic (see buildApplet), so it needs no rebuild when
 // the server switches between the development and production React.
+//
+// `.server.ts` modules are walked like anything else, which is deliberately
+// MORE than the bundle needs: their code never ships to the client (only the
+// export list, inlined as RPC stubs), so editing one — or anything it imports
+// — cannot change a byte of `index.js`. We report stale anyway because 'built'
+// is what drives the worker recycle downstream (see `reloadModules`, called
+// from widgets.ts/views.ts for every rebuilt applet). Without it, editing a
+// helper that only a server module imports would leave a live worker serving
+// the old code with nothing to dislodge it. The redundant rebuild is the price
+// of that signal; the alternative is a second staleness channel threaded
+// through the build results.
 async function needsRebuild(buildDir: string, name: string, srcPath: string): Promise<boolean> {
   const built = Bun.file(join(buildDir, name, 'index.js'))
   if (!(await built.exists())) return true
@@ -107,11 +117,9 @@ async function needsRebuild(buildDir: string, name: string, srcPath: string): Pr
     const file = Bun.file(path)
     if (!(await file.exists())) continue
     if (file.lastModified >= builtMtime) return true
-    // Leaves stop at the mtime check above: an asset, JSON, or CSS file can't
-    // import anything, and a `.server.ts` module contributes only its export
-    // list to the bundle — what its own imports do is invisible here (edit one
-    // of those and `moi bundle --force`).
-    if (!MODULE_FILE_RE.test(path) || SERVER_FILE_RE.test(path)) continue
+    // Leaves stop at the mtime check above — an asset, JSON, or CSS file can't
+    // import anything.
+    if (!MODULE_FILE_RE.test(path)) continue
     const source = await file.text()
     const dir = dirname(path)
     for (const specifier of scanRelativeImports(

--- a/server/bundler/build-applet.ts
+++ b/server/bundler/build-applet.ts
@@ -519,44 +519,28 @@ export function scanServerImports(source: string): string[] {
   return specifiers
 }
 
-// Relative asset import specifiers in an applet source (`./logo.png`,
-// `../shared/icon.svg`). Used by the rebuild staleness check so editing an
-// imported image rebuilds the bundle even when the `.tsx` itself is untouched.
-const ASSET_IMPORT_RE =
-  /from\s+['"](\.\.?\/[^'"]+?\.(?:png|jpe?g|gif|svg|webp|avif|ico|woff2?|ttf|otf))['"]/gi
-export function scanAssetImports(source: string): string[] {
-  const specifiers: string[] = []
-  let match
-  while ((match = ASSET_IMPORT_RE.exec(source)) !== null) {
-    specifiers.push(match[1])
-  }
-  return specifiers
-}
-
-// Relative module import specifiers in an applet source (`./_utils`,
-// `../lib/data`, `./table.tsx`) — static, re-export, side-effect, and dynamic
-// forms alike, lexed by Bun's own transpiler so comments and string literals
-// can't false-positive. Type-only imports are erased by the lexer — correct
-// here, since they never affect the emitted bundle. `.server` imports and
-// assets are excluded (each has its own scanner above); bare specifiers
-// (node_modules) are filtered out. A file that fails to lex contributes no
+// Every relative import specifier in an applet source — modules (`./_utils`,
+// `../lib/data`), assets (`./logo.png`), `.server` stubs, JSON, CSS alike, in
+// static, re-export, side-effect, and dynamic form. Lexed by Bun's own
+// transpiler, so comments and string literals can't false-positive. Type-only
+// imports are erased by the lexer — correct here, since they never affect the
+// emitted bundle. Bare specifiers (node_modules) are filtered out: the
+// staleness check doesn't walk them. A file that fails to lex contributes no
 // imports — the build itself surfaces the syntax error. Used by the rebuild
-// staleness check to walk the applet's local import graph, so editing a shared
-// module marks every applet that (transitively) imports it stale.
+// staleness check to walk the applet's local import graph, so editing anything
+// it (transitively) pulls in marks every applet using it stale.
 const IMPORT_SCANNERS = {
   ts: new Bun.Transpiler({ loader: 'ts' }),
   tsx: new Bun.Transpiler({ loader: 'tsx' })
 }
-export function scanModuleImports(source: string, loader: 'ts' | 'tsx' = 'tsx'): string[] {
+export function scanRelativeImports(source: string, loader: 'ts' | 'tsx' = 'tsx'): string[] {
   let imports: { path: string }[]
   try {
     imports = IMPORT_SCANNERS[loader].scanImports(source)
   } catch {
     return []
   }
-  return imports
-    .map(i => i.path)
-    .filter(p => /^\.\.?\//.test(p) && !/\.server(\.ts)?$/.test(p) && !ASSET_EXTENSIONS.test(p))
+  return imports.map(i => i.path).filter(p => /^\.\.?\//.test(p))
 }
 
 async function prevalidateServerFiles(entrypoint: string): Promise<void> {

--- a/server/functions-worker.ts
+++ b/server/functions-worker.ts
@@ -67,7 +67,8 @@ async function evictModule(name: string) {
 
 type CallMessage = { id: string; type: 'call'; module: string; name: string; args: string }
 type ReloadMessage = { type: 'reload'; modules: string[] }
-type IncomingMessage = CallMessage | ReloadMessage
+type ShutdownMessage = { type: 'shutdown' }
+type IncomingMessage = CallMessage | ReloadMessage | ShutdownMessage
 
 process.on('message', async (raw: IncomingMessage) => {
   if (raw.type === 'reload') {
@@ -75,6 +76,19 @@ process.on('message', async (raw: IncomingMessage) => {
       await evictModule(name)
     }
     return
+  }
+
+  // Graceful exit. The parent kills this process to pick up edited server code
+  // — evicting from moduleCache isn't enough, because a module's own imports
+  // are pinned in Bun's ESM registry with no way to invalidate them (the
+  // `?t=` buster below only busts the .server.ts itself, one level deep). Run
+  // every cached module's `dispose()` first so a hard kill doesn't strand a db
+  // handle or timer; the parent hard-kills us if we take too long.
+  if (raw.type === 'shutdown') {
+    for (const name of [...moduleCache.keys()]) {
+      await evictModule(name)
+    }
+    process.exit(0)
   }
 
   if (raw.type === 'call') {

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -68,6 +68,41 @@ function killSlot(slot: Slot, reason: string) {
   } catch {}
 }
 
+// How long a worker gets to run its modules' `dispose()` and exit on its own
+// before we kill it outright.
+const SHUTDOWN_GRACE_MS = 2_000
+
+// Same end state as killSlot — a dead worker — but the worker is asked to exit
+// so it can run each cached module's `dispose()` first. Used when server code
+// changed: a hard kill would strand whatever those modules hold open (db
+// handles, timers, watchers).
+//
+// The slot is marked killed immediately, so a call arriving mid-shutdown spawns
+// a fresh worker rather than queueing behind a dying one. In-flight calls are
+// rejected rather than left to hit the 30s timeout.
+function gracefulKillSlot(slot: Slot, reason: string) {
+  if (slot.killed) return
+  slot.killed = true
+  rejectAndClearPending(slot, reason)
+
+  const timer = setTimeout(() => {
+    try {
+      slot.worker.kill()
+    } catch {}
+  }, SHUTDOWN_GRACE_MS)
+  timer.unref?.()
+  void slot.worker.exited.then(() => clearTimeout(timer)).catch(() => clearTimeout(timer))
+
+  try {
+    slot.worker.send({ type: 'shutdown' })
+  } catch {
+    clearTimeout(timer)
+    try {
+      slot.worker.kill()
+    } catch {}
+  }
+}
+
 const slots = new LRUCache<string, Slot>({
   max: MAX_WORKERS,
   ttl: WORKER_IDLE_TTL_MS,
@@ -331,16 +366,26 @@ export function getWorkersDebugSnapshot(): WorkerDebugInfo[] {
   return out
 }
 
+// Make edited server code take effect: recycle the workspace's worker so the
+// next call loads it fresh.
+//
+// This RECYCLES THE WHOLE WORKER rather than evicting the named modules,
+// because eviction cannot actually reload edited code. `loadModule` busts its
+// import with `?t=<mtime>`, which only makes a new URL for the `.server.ts`
+// itself — everything that file imports stays pinned in Bun's ESM registry
+// with no API to invalidate it. So a module whose *dependency* changed re-
+// executes against the old dependency, and one whose own mtime is unchanged
+// doesn't re-execute at all. A fresh process is the only reliable reset.
+//
+// `modules` is the reason, not the scope: every module in the worker is
+// dropped. Kept in the signature for the kill reason surfaced to callers.
 export function reloadModules(modules: string[], workspacePath: string) {
   if (modules.length === 0) return
   // peek: don't refresh TTL just because files changed. If the worker was
   // already idle-evicted, the next callFunction will re-spawn fresh anyway.
   const slot = slots.peek(workspacePath)
   if (!slot || slot.killed) return
-  try {
-    slot.worker.send({ type: 'reload', modules })
-    // The worker evicts these from its module cache; it re-reports 'loaded'
-    // on the next call, so drop them from the introspection set too.
-    for (const m of modules) slot.modules.delete(m)
-  } catch {}
+  // No need to prune `slot.modules`: the whole slot is going away, and
+  // getStatus already skips killed slots.
+  gracefulKillSlot(slot, `Server code changed (${modules.join(', ')})`)
 }

--- a/server/test/applet-staleness.test.ts
+++ b/server/test/applet-staleness.test.ts
@@ -221,9 +221,9 @@ describe('dependency staleness', () => {
     }
   })
 
-  test('imported assets and .server modules ride the same walk, as leaves', async () => {
-    // Neither has a scanner of its own any more: both are just relative imports
-    // that resolve to a non-descendable file.
+  test('imported assets and .server modules ride the same walk', async () => {
+    // Neither has a scanner of its own any more: both are just relative
+    // imports that resolve to a file like everything else.
     seed(
       '.moi/widgets/photo.tsx',
       [
@@ -259,9 +259,13 @@ describe('dependency staleness', () => {
     expect((await build())[0]).toMatchObject({ status: 'built' })
     expect((await build())[0]).toMatchObject({ status: 'skipped' })
 
-    // What the server module imports does not: none of it reaches the bundle,
-    // so the walk stops at `.server.ts` and this edit is deliberately ignored.
+    // And so does what the server module imports — even though none of it
+    // reaches the bundle. 'built' is the signal that recycles the functions
+    // worker (see needsRebuild), and without it a live worker would keep
+    // serving the old `_schema.ts` with nothing to dislodge it. The rebuilt
+    // bytes are identical; the reload is the point.
     seed('.moi/widgets/_schema.ts', `export const table = 'renamed'`)
+    expect((await build())[0]).toMatchObject({ status: 'built' })
     expect((await build())[0]).toMatchObject({ status: 'skipped' })
   })
 

--- a/server/test/applet-staleness.test.ts
+++ b/server/test/applet-staleness.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { dirname, join } from 'path'
 
 import { buildApplets, scanSources } from '../applets'
-import { buildApplet, scanModuleImports } from '../bundler/build-applet'
+import { buildApplet, scanRelativeImports } from '../bundler/build-applet'
 
 // Entry-point and staleness rules for the applet build loop: `_`-prefixed
 // files are shared modules (never entries), and a bundle goes stale when
@@ -63,7 +63,7 @@ describe('underscore-prefixed shared modules', () => {
   })
 })
 
-describe('scanModuleImports', () => {
+describe('scanRelativeImports', () => {
   test('catches static, re-export, side-effect, and dynamic relative imports', () => {
     const src = [
       `import { a } from './_utils'`,
@@ -72,7 +72,7 @@ describe('scanModuleImports', () => {
       `import './side-effect'`,
       `const lazy = await import('./panels/heavy')`
     ].join('\n')
-    expect(scanModuleImports(src)).toEqual([
+    expect(scanRelativeImports(src)).toEqual([
       './_utils',
       '../lib/shared',
       './re-export',
@@ -81,14 +81,25 @@ describe('scanModuleImports', () => {
     ])
   })
 
-  test('skips bare specifiers, .server imports, and assets', () => {
+  test('reports every kind of relative import, skipping only bare specifiers', () => {
+    // Assets, `.server` stubs, and JSON are dependencies like any other — the
+    // staleness walk resolves each and treats non-modules as leaves, so they
+    // need no scanner of their own.
     const src = [
       `import React from 'react'`,
       `import { getData } from './data.server'`,
       `import logo from './logo.png'`,
+      `import rows from './rows.json'`,
+      `import './styles.css'`,
       `import { helper } from './helper'`
     ].join('\n')
-    expect(scanModuleImports(src)).toEqual(['./helper'])
+    expect(scanRelativeImports(src)).toEqual([
+      './data.server',
+      './logo.png',
+      './rows.json',
+      './styles.css',
+      './helper'
+    ])
   })
 
   test('lexes real syntax — comments, strings, and type-only imports never count', () => {
@@ -98,16 +109,16 @@ describe('scanModuleImports', () => {
       `import type { T } from './types-only'`,
       `import { real } from './real'`
     ].join('\n')
-    expect(scanModuleImports(src)).toEqual(['./real'])
+    expect(scanRelativeImports(src)).toEqual(['./real'])
   })
 
   test('a file that fails to lex contributes no imports', () => {
-    expect(scanModuleImports(`import { from`)).toEqual([])
+    expect(scanRelativeImports(`import { from`)).toEqual([])
   })
 
   test('the ts loader handles angle-bracket casts tsx cannot', () => {
     const src = [`const v = <string>window.name`, `import { q } from './cast-file'`].join('\n')
-    expect(scanModuleImports(src, 'ts')).toEqual(['./cast-file'])
+    expect(scanRelativeImports(src, 'ts')).toEqual(['./cast-file'])
   })
 })
 
@@ -210,10 +221,54 @@ describe('dependency staleness', () => {
     }
   })
 
+  test('imported assets and .server modules ride the same walk, as leaves', async () => {
+    // Neither has a scanner of its own any more: both are just relative imports
+    // that resolve to a non-descendable file.
+    seed(
+      '.moi/widgets/photo.tsx',
+      [
+        `import logo from './logo.png'`,
+        `import { rows } from './data.server'`,
+        `export default function Photo() { return <img src={logo} alt={String(rows)} /> }`
+      ].join('\n')
+    )
+    seed('.moi/widgets/logo.png', 'not-really-a-png-but-bytes-are-bytes')
+    seed(
+      '.moi/widgets/data.server.ts',
+      [`import { table } from './_schema'`, `export async function rows() { return [table] }`].join(
+        '\n'
+      )
+    )
+    seed('.moi/widgets/_schema.ts', `export const table = 'rows'`)
+
+    expect((await build())[0]).toMatchObject({ name: 'photo', status: 'built' })
+    expect((await build())[0]).toMatchObject({ status: 'skipped' })
+
+    seed('.moi/widgets/logo.png', 'different-bytes')
+    expect((await build())[0]).toMatchObject({ status: 'built' })
+    expect((await build())[0]).toMatchObject({ status: 'skipped' })
+
+    // The server module's own mtime counts — its export list is inlined.
+    seed(
+      '.moi/widgets/data.server.ts',
+      [
+        `import { table } from './_schema'`,
+        `export async function rows() { return [table, 1] }`
+      ].join('\n')
+    )
+    expect((await build())[0]).toMatchObject({ status: 'built' })
+    expect((await build())[0]).toMatchObject({ status: 'skipped' })
+
+    // What the server module imports does not: none of it reaches the bundle,
+    // so the walk stops at `.server.ts` and this edit is deliberately ignored.
+    seed('.moi/widgets/_schema.ts', `export const table = 'renamed'`)
+    expect((await build())[0]).toMatchObject({ status: 'skipped' })
+  })
+
   test('a graph larger than the file cap always rebuilds (fails toward stale)', async () => {
-    // 130+ chained modules exceed MAX_GRAPH_FILES: the walk aborts and reports
-    // stale, so the applet rebuilds every bundle instead of risking a stale
-    // skip. Degenerate by design — no sane applet wires this many local files.
+    // A chain longer than MAX_GRAPH_FILES: the walk aborts and reports stale,
+    // so the applet rebuilds every bundle instead of risking a stale skip.
+    // Degenerate by design — no sane applet wires this many local files.
     seed(
       '.moi/widgets/big.tsx',
       [
@@ -222,7 +277,7 @@ describe('dependency staleness', () => {
       ].join('\n')
     )
     seed('.moi/widgets/_head.ts', [`import '../lib/c0'`, `export const label = 'big'`].join('\n'))
-    const LAST = 130
+    const LAST = 260
     for (let i = 0; i <= LAST; i++) {
       const next = i < LAST ? `import './c${i + 1}'\n` : ''
       seed(`.moi/lib/c${i}.ts`, `${next}export const v${i} = ${i}`)

--- a/server/test/applet-staleness.test.ts
+++ b/server/test/applet-staleness.test.ts
@@ -154,6 +154,62 @@ describe('dependency staleness', () => {
     expect((await build())[0]).toMatchObject({ status: 'skipped' })
   })
 
+  test('a dependency deleted since the last build marks the applet stale', async () => {
+    seedGraph()
+
+    expect((await build())[0]).toMatchObject({ name: 'clock', status: 'built' })
+    expect((await build())[0]).toMatchObject({ status: 'skipped' })
+
+    // `clock.tsx` itself is untouched and still older than the built entry, so
+    // the only signal that `./_utils` is gone is the unresolved import. Skipping
+    // here would keep serving the last good bundle and hide the broken import.
+    rmSync(join(WS, '.moi', 'widgets', '_utils.ts'))
+    expect((await build())[0]).toMatchObject({ name: 'clock', status: 'failed' })
+  })
+
+  test('extensionless, directory, and non-TS dependencies resolve the way Bun resolves them', async () => {
+    // Every import here misses a naive `.tsx`/`.ts`/`index.tsx` candidate list:
+    // it takes Bun's own resolver to land on the file the build reads.
+    seed(
+      '.moi/widgets/chart.tsx',
+      [
+        `import data from './_data'`, // → _data.json
+        `import { helper } from '../lib/helpers'`, // → helpers/index.js
+        `import { scale } from '../lib/scale'`, // → scale.mjs → ratio.mjs
+        `import { fmt } from './_fmt.js'`, // → _fmt.ts (TS .js rewrite)
+        `import { tint } from '../lib/paint'`, // → paint/main.js via package.json
+        `export default function Chart() { return <div>{fmt(data.n * scale + helper) + tint}</div> }`
+      ].join('\n')
+    )
+    seed('.moi/widgets/_data.json', '{ "n": 2 }')
+    seed('.moi/widgets/_fmt.ts', `export const fmt = (n: number) => String(n)`)
+    seed('.moi/lib/helpers/index.js', `export const helper = 3`)
+    // A non-TS module is walked like any other, so its own imports count too.
+    seed(
+      '.moi/lib/scale.mjs',
+      [`import { ratio } from './ratio.mjs'`, `export const scale = ratio`].join('\n')
+    )
+    seed('.moi/lib/ratio.mjs', `export const ratio = 4`)
+    seed('.moi/lib/paint/package.json', `{ "main": "main.js" }`)
+    seed('.moi/lib/paint/main.js', `export const tint = 'red'`)
+
+    expect((await build())[0]).toMatchObject({ name: 'chart', status: 'built' })
+    expect((await build())[0]).toMatchObject({ status: 'skipped' })
+
+    // Each one, edited on its own, must mark the applet stale.
+    for (const [rel, contents] of [
+      ['.moi/widgets/_data.json', '{ "n": 5 }'],
+      ['.moi/lib/helpers/index.js', `export const helper = 6`],
+      ['.moi/lib/ratio.mjs', `export const ratio = 7`],
+      ['.moi/lib/paint/main.js', `export const tint = 'blue'`],
+      ['.moi/widgets/_fmt.ts', `export const fmt = (n: number) => \`\${n}\``]
+    ] as const) {
+      seed(rel, contents)
+      expect((await build())[0]).toMatchObject({ status: 'built' })
+      expect((await build())[0]).toMatchObject({ status: 'skipped' })
+    }
+  })
+
   test('a graph larger than the file cap always rebuilds (fails toward stale)', async () => {
     // 130+ chained modules exceed MAX_GRAPH_FILES: the walk aborts and reports
     // stale, so the applet rebuilds every bundle instead of risking a stale

--- a/server/test/server-dep-reload.test.ts
+++ b/server/test/server-dep-reload.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { parse, stringify } from 'devalue'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'path'
+
+import { callFunction, killAllWorkers } from '../functions'
+import { handleBundle } from '../widgets'
+
+// Editing a helper that ONLY a `.server.ts` module imports has to reach a live
+// functions worker. Two mechanisms have to line up for that, and each was
+// independently broken:
+//
+//   1. `moi bundle` must notice. The staleness walk descends into `.server.ts`
+//      even though server code never reaches the bundle, because 'built' is
+//      what triggers the reload downstream.
+//   2. The reload must recycle the worker process. Evicting from the worker's
+//      module cache cannot help: `loadModule` busts its import with
+//      `?t=<mtime>`, which only makes a new URL for the `.server.ts` itself —
+//      whatever that file imports stays pinned in Bun's ESM registry.
+//
+// This drives the real build and a real worker subprocess, so it fails if
+// either half regresses.
+
+let WS: string
+let prevFunctionsDir: string | undefined
+beforeEach(() => {
+  // Inside the repo, not tmpdir: the applet build resolves `tailwindcss` from
+  // node_modules up the tree.
+  WS = mkdtempSync(join(import.meta.dir, 'moi-srvdep-'))
+  // functions.test.ts pins MEI_FUNCTIONS_DIR at its fixtures dir process-wide;
+  // point the worker at this workspace regardless of file order.
+  prevFunctionsDir = process.env.MEI_FUNCTIONS_DIR
+  process.env.MEI_FUNCTIONS_DIR = join(WS, '.moi')
+})
+afterEach(() => {
+  killAllWorkers()
+  if (prevFunctionsDir === undefined) delete process.env.MEI_FUNCTIONS_DIR
+  else process.env.MEI_FUNCTIONS_DIR = prevFunctionsDir
+  rmSync(WS, { recursive: true, force: true })
+})
+
+function seed(rel: string, contents: string) {
+  const path = join(WS, rel)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, contents)
+}
+
+const bundle = () => handleBundle(() => {}, WS)
+const rows = async () => parse(await callFunction('widgets/clock', 'rows', stringify([]), WS))
+
+test('editing a helper imported only by a .server.ts reaches a live worker', async () => {
+  seed(
+    '.moi/widgets/clock.tsx',
+    [
+      `import { rows } from './clock.server'`,
+      `export default function Clock() { return <div>{String(rows)}</div> }`
+    ].join('\n')
+  )
+  seed(
+    '.moi/widgets/clock.server.ts',
+    [`import { table } from './_schema'`, `export async function rows() { return table }`].join(
+      '\n'
+    )
+  )
+  seed('.moi/widgets/_schema.ts', `export const table = 'v1'`)
+
+  await bundle()
+  // Spawns the worker and caches both modules in it — the state that used to
+  // go stale and stay stale.
+  expect(await rows()).toBe('v1')
+
+  seed('.moi/widgets/_schema.ts', `export const table = 'v2'`)
+  await bundle()
+  expect(await rows()).toBe('v2')
+})
+
+test('a bundle that changes no server code leaves the worker alone', async () => {
+  seed(
+    '.moi/widgets/clock.tsx',
+    [
+      `import { rows } from './clock.server'`,
+      `export default function Clock() { return <div>{String(rows)}</div> }`
+    ].join('\n')
+  )
+  seed(
+    '.moi/widgets/clock.server.ts',
+    [`let calls = 0`, `export async function rows() { calls++; return calls }`].join('\n')
+  )
+
+  await bundle()
+  expect(await rows()).toBe(1)
+  expect(await rows()).toBe(2)
+
+  // Nothing changed, so nothing rebuilds and the worker keeps its state —
+  // the counter would reset to 1 if we recycled on every bundle.
+  await bundle()
+  expect(await rows()).toBe(3)
+})


### PR DESCRIPTION
Two staleness holes from the transitive-dependency walk (#59 review).

A relative import that resolves to nothing was silently skipped. With the
entry source still older than index.js, needsRebuild() returned false, so a
helper deleted since the last build left `moi bundle` reporting the applet
as skipped and serving the stale bundle instead of surfacing the missing
import. An unresolved specifier now reports stale. Only the module branch
fails this way — it is lexed by the transpiler, so its specifiers are really
imported, unlike the regex-based server/asset scanners that can match inside
a comment.

The candidate list also only covered .tsx/.ts/.jsx/.js plus index.tsx/index.ts,
so `./data` → data.json, `./mod` → mod.mjs, `./helpers` → helpers/index.js and
TypeScript's `./x.js` → x.ts all resolved to null: the first bundle succeeded
and later edits to those files never marked the applet stale. Resolution now
mirrors Bun's order — literal path, TS extension rewrite, appended extension,
then directory (package.json main, else index.*) — and the walk descends
through .mjs/.cjs/.mts/.cts as modules rather than stopping at them.

Resolution is probed against the filesystem rather than delegated to
Bun.resolveSync, which memoizes for the life of the process: in the
long-running server it keeps returning the path of a dependency that has
since been deleted, which is the case this check exists to catch.

bun test: 625 pass / 0 fail, including 2 new tests in
server/test/applet-staleness.test.ts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BPvRBJfWeBVv7Uc2DyRDWX