### PR TITLE
Fail fast on Bun older than 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For OpenClaw or a manual setup, read on.
 
 ## Manual install
 
-Make sure [Bun](https://bun.sh) is installed. moi uses it to run the web server and bundle the dynamic UI.
+Make sure [Bun](https://bun.sh) 1.3 or newer is installed. moi uses it to run the web server and bundle the dynamic UI.
 
 Install the `moi-computer` package from npm and start the web UI:
 

--- a/bin/moi.mjs
+++ b/bin/moi.mjs
@@ -11,6 +11,17 @@ if (!process.versions.bun) {
   process.exit(1)
 }
 
+// The widget bundler needs Bun 1.3: it hands `Bun.build` a virtual entrypoint
+// that only 1.3+ lets a plugin resolve. Older Bun starts fine and then fails on
+// the first widget build, so reject it here where the cause is still legible.
+// `?.` because a Bun without `Bun.semver` is old enough to reject anyway.
+const MIN_BUN = '1.3.0'
+if (!Bun.semver?.satisfies(Bun.version, `>=${MIN_BUN}`)) {
+  console.error(`moi requires Bun ${MIN_BUN} or newer (this is Bun ${Bun.version}).`)
+  console.error('Upgrade Bun:  bun upgrade')
+  process.exit(1)
+}
+
 // The `moi` command is meant to live on your PATH permanently: the agent
 // shells out to `moi bundle`/`moi refresh` from your workspaces, which only
 // works if it's installed. If `moi` doesn't resolve as a command, nudge toward


### PR DESCRIPTION
moi's real floor is Bun 1.3.0, set by the widget bundler: build-applet.ts
passes a virtual entrypoint ('__widget-entry') to Bun.build that only a
plugin resolves, and plugin-resolved entrypoints landed in 1.3. Verified
against real binaries — 1.2.21 fails with "ModuleNotFound resolving
__widget-entry (entry point)", 1.3.0 builds. Every other Bun API the repo
touches clears at 1.2.17 or earlier; Bun.secrets needs 1.2.21 but degrades
to the file-backed secret store when absent.

engines.bun already said >=1.3, but nothing enforced it: a user on 1.2
installed cleanly, started the server, and only hit the wall when a widget
first built — as an unattributable bundler error. The launcher now rejects
old Bun where the cause is still legible, and the README states the version.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018BZ9esHjtjaZNRUT9AB7tz