### PR TITLE
Compare Bun's release version, ignoring prerelease tags

### DIFF
--- a/bin/moi.mjs
+++ b/bin/moi.mjs
@@ -15,8 +15,10 @@ if (!process.versions.bun) {
 // that only 1.3+ lets a plugin resolve. Older Bun starts fine and then fails on
 // the first widget build, so reject it here where the cause is still legible.
 // `?.` because a Bun without `Bun.semver` is old enough to reject anyway.
+// Compare the release version alone: semver ranges exclude prereleases, so a
+// `1.4.0-canary.1` would be rejected for being newer.
 const MIN_BUN = '1.3.0'
-if (!Bun.semver?.satisfies(Bun.version, `>=${MIN_BUN}`)) {
+if (!Bun.semver?.satisfies(Bun.version.split(/[-+]/)[0], `>=${MIN_BUN}`)) {
   console.error(`moi requires Bun ${MIN_BUN} or newer (this is Bun ${Bun.version}).`)
   console.error('Upgrade Bun:  bun upgrade')
   process.exit(1)


### PR DESCRIPTION
Follow-up to #61, from the Codex review left on it. Semver ranges exclude prereleases, so the launcher's guard would reject a Bun build for being *newer* than the floor if it carried a tag. The guard now strips prerelease and build metadata before comparing.

```
1.4.0-canary.1+ed1c48f   accept     (was: REJECT)
1.3.14+abc               accept
1.2.21                   REJECT
1.2.21-canary.9          REJECT
```

**The review's premise doesn't hold today — no user is affected.** I checked the actual canary channel (`bun upgrade --canary`): it reports `Bun.version = 1.4.0`, plain. Only `bun --revision` carries the `-canary.1+6c12afd8e` form, and the guard doesn't read that. Codex evaluated a hand-written version string, not one from a real build. So this is hardening against a format change, not a fix for live breakage — worth the one line, but don't read it as a bug that shipped.

Worth a close look: stripping means a hypothetical `1.3.0-canary.N` now passes as `1.3.0`, even though a prerelease of 1.3.0 could predate the plugin-resolved-entrypoint support the guard exists to require. That's the deliberate trade — wrongly rejecting a 1.4 canary is worse than wrongly accepting a 1.3 one, and Bun numbers canaries as the upcoming version.

Verified by running `bin/moi.mjs` under real binaries: Bun 1.2.21 rejected (exit 1), 1.3.11 and canary 1.4.0 both reach the CLI. Plus the synthetic version table above. `oxlint` and `oxfmt --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018BZ9esHjtjaZNRUT9AB7tz)_