### PR TITLE
Store the skill auto-update flag in server-side app settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "citty": "^0.2.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "conf": "^15.1.0",
         "devalue": "^5.6.4",
         "env-paths": "^4.0.0",
         "frimousse": "^0.3.0",
@@ -696,6 +697,8 @@
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
+    "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -786,6 +789,8 @@
 
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
+    "conf": ["conf@15.1.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "atomically": "^2.0.3", "debounce-fn": "^6.0.0", "dot-prop": "^10.0.0", "env-paths": "^3.0.0", "json-schema-typed": "^8.0.1", "semver": "^7.7.2", "uint8array-extras": "^1.5.0" } }, "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og=="],
+
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
@@ -817,6 +822,8 @@
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "debounce-fn": ["debounce-fn@6.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -857,6 +864,8 @@
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dot-prop": ["dot-prop@10.2.0", "", { "dependencies": { "type-fest": "^5.0.0" } }, "sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
@@ -1598,6 +1607,10 @@
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
+    "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
+
+    "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -1605,6 +1618,8 @@
     "sugar-high": ["sugar-high@1.2.1", "", {}, "sha512-C2E0iSC0Gwv+7t32ATFxgiH6fxskoSfd/nF5z11pQSrgJHYjY8/U11K+X0izV9ZyPNPwaomtn6uF7y11MxVNQA=="],
 
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
+
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
@@ -1647,6 +1662,8 @@
     "tslog": ["tslog@4.10.2", "", {}, "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
+
+    "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -1712,6 +1729,8 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
+    "when-exit": ["when-exit@2.1.5", "", {}, "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="],
+
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
@@ -1775,6 +1794,10 @@
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "conf/env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
+
+    "conf/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 

--- a/client/features/settings/api.ts
+++ b/client/features/settings/api.ts
@@ -3,7 +3,30 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { WORKSPACE_RESOURCE_OPTIONS } from '@/client/api/query-options'
 import { workspaceKeys } from '@/client/api/workspace-keys'
-import type { WorkspaceEntry, WorkspaceEnvView } from '@/lib/types'
+import type { AppSettings, WorkspaceEntry, WorkspaceEnvView } from '@/lib/types'
+
+// App-wide settings (server-side settings.json, GET/PATCH /api/settings) —
+// shared by every workspace, unlike the per-workspace queries below.
+export const appSettingsKey = ['app-settings'] as const
+
+export function useAppSettings() {
+  return useQuery<AppSettings>({
+    queryKey: appSettingsKey,
+    queryFn: () => requestJson('/api/settings'),
+    staleTime: 30_000
+  })
+}
+
+export function useSaveAppSettings() {
+  const queryClient = useQueryClient()
+  return useMutation<AppSettings, Error, Partial<AppSettings>>({
+    mutationFn: patch =>
+      requestJson('/api/settings', jsonRequest('PATCH', patch), 'Failed to save settings'),
+    onSuccess: next => {
+      queryClient.setQueryData<AppSettings>(appSettingsKey, next)
+    }
+  })
+}
 
 export function useWorkspaceEnv(workspaceId: string) {
   return useQuery<WorkspaceEnvView>({

--- a/client/features/settings/api.ts
+++ b/client/features/settings/api.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { WORKSPACE_RESOURCE_OPTIONS } from '@/client/api/query-options'
 import { workspaceKeys } from '@/client/api/workspace-keys'
+import { useWorkspaceEvent } from '@/client/runtime/useWorkspaceEvents'
 import type { AppSettings, WorkspaceEntry, WorkspaceEnvView } from '@/lib/types'
 
 // App-wide settings (server-side settings.json, GET/PATCH /api/settings) —
@@ -10,6 +11,14 @@ import type { AppSettings, WorkspaceEntry, WorkspaceEnvView } from '@/lib/types'
 export const appSettingsKey = ['app-settings'] as const
 
 export function useAppSettings() {
+  const queryClient = useQueryClient()
+  // Another client can change settings; the server broadcasts the new value
+  // over the live-events socket so every open client stays in sync.
+  useWorkspaceEvent(event => {
+    if (event.type === 'settings:updated') {
+      queryClient.setQueryData<AppSettings>(appSettingsKey, event.settings)
+    }
+  })
   return useQuery<AppSettings>({
     queryKey: appSettingsKey,
     queryFn: () => requestJson('/api/settings'),

--- a/client/features/workspace/useWorkspaceSkillUpdates.ts
+++ b/client/features/workspace/useWorkspaceSkillUpdates.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { useUiStore } from '@/client/store/ui'
+import { useAppSettings, useSaveAppSettings } from '@/client/features/settings/api'
 import { useUpdateWorkspaceSkills, useWorkspaceSkills } from '@/client/features/workspace/api'
 
 import type {
@@ -62,8 +62,17 @@ export function useWorkspaceSkillUpdates(workspaceId: string): WorkspaceSkillUpd
     mutate: updateSkills,
     reset: resetUpdate
   } = useUpdateWorkspaceSkills(workspaceId)
-  const autoUpdateEnabled = useUiStore(state => state.skillAutoUpdateEnabled)
-  const enableAutoUpdate = useUiStore(state => state.enableSkillAutoUpdate)
+  // The auto-update flag is an app setting (server-side, shared across
+  // clients). Until it loads, neither prompt nor auto-update — acting on the
+  // default would flash the banner or skip an enabled auto-update.
+  const settings = useAppSettings()
+  const { mutate: saveSettings } = useSaveAppSettings()
+  const settingsReady = settings.data !== undefined
+  const autoUpdateEnabled = settings.data?.autoUpdateSkills ?? false
+  const enableAutoUpdate = useCallback(
+    () => saveSettings({ autoUpdateSkills: true }),
+    [saveSettings]
+  )
   const [visit, setVisit] = useState<VisitState>(() => initialVisitState(workspaceId))
   const currentVisit = visit.workspaceId === workspaceId ? visit : initialVisitState(workspaceId)
 
@@ -106,6 +115,7 @@ export function useWorkspaceSkillUpdates(workspaceId: string): WorkspaceSkillUpd
 
   useEffect(() => {
     if (
+      settingsReady &&
       shouldAutomaticallyUpdateWorkspaceSkills({
         updateAvailable,
         autoUpdateEnabled,
@@ -115,13 +125,22 @@ export function useWorkspaceSkillUpdates(workspaceId: string): WorkspaceSkillUpd
     ) {
       onUpdate('auto')
     }
-  }, [autoUpdateEnabled, currentVisit.phase, onUpdate, updateAvailable, updatePending])
-
-  const visible = shouldShowWorkspaceSkillUpdateBanner({
-    updateAvailable,
+  }, [
     autoUpdateEnabled,
-    phase: currentVisit.phase
-  })
+    currentVisit.phase,
+    onUpdate,
+    settingsReady,
+    updateAvailable,
+    updatePending
+  ])
+
+  const visible =
+    settingsReady &&
+    shouldShowWorkspaceSkillUpdateBanner({
+      updateAvailable,
+      autoUpdateEnabled,
+      phase: currentVisit.phase
+    })
   return {
     bannerProps: visible
       ? {

--- a/client/runtime/useWorkspaceEvents.ts
+++ b/client/runtime/useWorkspaceEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { wsUrl } from '@/client/lib/ws-url'
-import type { ViewBuilder, ViewInfo, WidgetInfo } from '@/lib/types'
+import type { AppSettings, ViewBuilder, ViewInfo, WidgetInfo } from '@/lib/types'
 
 export type WorkspaceEvent =
   | { type: 'widget:updated'; name: string }
@@ -23,6 +23,9 @@ export type WorkspaceEvent =
   // The Scratchpad canvas for `workspaceId` was saved — open tabs reload from
   // disk. `origin` is the tab that wrote it, so that tab can skip its own echo.
   | { type: 'scratchpad:updated'; workspaceId: string; origin?: string }
+  // App settings changed (PATCH /api/settings from any client) — carries the
+  // new value so caches update without a refetch.
+  | { type: 'settings:updated'; settings: AppSettings }
 
 type WorkspaceEventHandler = (event: WorkspaceEvent) => void
 

--- a/client/store/ui.test.ts
+++ b/client/store/ui.test.ts
@@ -13,18 +13,25 @@ const useUiStore = createUiStore(localStorage)
 
 beforeEach(() => {
   storedValues.clear()
-  useUiStore.setState({ skillAutoUpdateEnabled: false })
+  useUiStore.setState({ hasSentMessageFromMoi: false, workspaceIdsPendingAnalysis: [] })
 })
 
-describe('skill Auto-update preference', () => {
-  test('enables one persisted preference for every workspace', () => {
-    expect(useUiStore.getState().skillAutoUpdateEnabled).toBe(false)
+describe('first-message onboarding markers', () => {
+  test('persists the pending-analysis workspace until a message is sent', () => {
+    useUiStore.getState().markWorkspacePendingAnalysis('ws-1')
+    useUiStore.getState().markWorkspacePendingAnalysis('ws-1')
 
-    useUiStore.getState().enableSkillAutoUpdate()
-
-    expect(useUiStore.getState().skillAutoUpdateEnabled).toBe(true)
+    expect(useUiStore.getState().workspaceIdsPendingAnalysis).toEqual(['ws-1'])
     expect(JSON.parse(storedValues.get('moi:ui') ?? '{}')).toMatchObject({
-      state: { skillAutoUpdateEnabled: true }
+      state: { workspaceIdsPendingAnalysis: ['ws-1'] }
+    })
+
+    useUiStore.getState().markMessageSentFromMoi('ws-1')
+
+    expect(useUiStore.getState().hasSentMessageFromMoi).toBe(true)
+    expect(useUiStore.getState().workspaceIdsPendingAnalysis).toEqual([])
+    expect(JSON.parse(storedValues.get('moi:ui') ?? '{}')).toMatchObject({
+      state: { hasSentMessageFromMoi: true, workspaceIdsPendingAnalysis: [] }
     })
   })
 })

--- a/client/store/ui.ts
+++ b/client/store/ui.ts
@@ -8,11 +8,9 @@ type UiStore = {
   discoveredWorkspacesOpen: boolean
   hasSentMessageFromMoi: boolean
   workspaceIdsPendingAnalysis: string[]
-  skillAutoUpdateEnabled: boolean
   setDiscoveredWorkspacesOpen: (open: boolean) => void
   markWorkspacePendingAnalysis: (workspaceId: string) => void
   markMessageSentFromMoi: (workspaceId: string) => void
-  enableSkillAutoUpdate: () => void
 }
 
 export const createUiStore = (storage?: StateStorage) =>
@@ -22,7 +20,6 @@ export const createUiStore = (storage?: StateStorage) =>
         discoveredWorkspacesOpen: true,
         hasSentMessageFromMoi: false,
         workspaceIdsPendingAnalysis: [],
-        skillAutoUpdateEnabled: false,
         setDiscoveredWorkspacesOpen: open => set({ discoveredWorkspacesOpen: open }),
         markWorkspacePendingAnalysis: workspaceId =>
           set(state => {
@@ -39,8 +36,7 @@ export const createUiStore = (storage?: StateStorage) =>
             workspaceIdsPendingAnalysis: (state.workspaceIdsPendingAnalysis ?? []).filter(
               id => id !== workspaceId
             )
-          })),
-        enableSkillAutoUpdate: () => set({ skillAutoUpdateEnabled: true })
+          }))
       }),
       storage
         ? {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -259,6 +259,15 @@ export type ThreadConfig = {
   effort?: string
 }
 
+// App-wide settings, persisted server-side as `settings.json` in moi's data
+// dir and exposed via GET/PATCH /api/settings. Every key has a default, so
+// GET always returns a complete object.
+export type AppSettings = {
+  // Apply bundled workspace-skill updates automatically when a workspace
+  // with outdated skills is opened, instead of prompting each time.
+  autoUpdateSkills: boolean
+}
+
 // Re-export the display format
 export type {
   Citation,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "citty": "^0.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "conf": "^15.1.0",
     "devalue": "^5.6.4",
     "env-paths": "^4.0.0",
     "frimousse": "^0.3.0",

--- a/server/api.ts
+++ b/server/api.ts
@@ -973,7 +973,11 @@ api.patch('/api/settings', async c => {
     }
     patch.autoUpdateSkills = body.autoUpdateSkills
   }
-  return c.json(saveAppSettings(patch))
+  const settings = saveAppSettings(patch)
+  // Other open clients hold these in a query cache with no polling; broadcast
+  // the new value so an app-wide preference applies everywhere immediately.
+  publishEvent({ type: 'settings:updated', settings })
+  return c.json(settings)
 })
 
 // Everything else: in production, serve the prebuilt client from `dist/` via

--- a/server/api.ts
+++ b/server/api.ts
@@ -5,7 +5,6 @@ import { existsSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 
 import type {
-  AppSettings,
   HarnessAvailability,
   UploadInfo,
   ViewBuilderInput,
@@ -16,8 +15,7 @@ import type {
 import type { MoiContext } from '@/lib/moi-context'
 import { viewBuilderDirectives } from '@/lib/view-builder-directives'
 
-import { getAppSettings, saveAppSettings } from './app-settings'
-import type { AppSettingsPatch } from './app-settings'
+import { getAppSettings, parseAppSettingsPatch, saveAppSettings } from './app-settings'
 import { appletForModule, recordAppletError } from './applet-log'
 import { apiBaseFor, parseAppletTail, serveWorkspaceFile } from './applets'
 import { applyEnvChanged } from './env-apply'
@@ -960,20 +958,16 @@ api.route('/api/workspaces', workspaces)
 api.get('/api/settings', c => c.json(getAppSettings()))
 
 api.patch('/api/settings', async c => {
-  let body: Partial<Record<keyof AppSettings, unknown>>
+  let body: unknown
   try {
     body = await c.req.json()
   } catch {
     return c.text('Invalid JSON body', 400)
   }
-  const patch: AppSettingsPatch = {}
-  if (body.autoUpdateSkills !== undefined) {
-    if (typeof body.autoUpdateSkills !== 'boolean') {
-      return c.text('autoUpdateSkills must be a boolean', 400)
-    }
-    patch.autoUpdateSkills = body.autoUpdateSkills
-  }
-  const settings = saveAppSettings(patch)
+  // app-settings declares which fields are API-updatable and validates them.
+  const parsed = parseAppSettingsPatch(body)
+  if ('error' in parsed) return c.text(parsed.error, 400)
+  const settings = saveAppSettings(parsed.patch)
   // Other open clients hold these in a query cache with no polling; broadcast
   // the new value so an app-wide preference applies everywhere immediately.
   publishEvent({ type: 'settings:updated', settings })

--- a/server/api.ts
+++ b/server/api.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 
 import type {
+  AppSettings,
   HarnessAvailability,
   UploadInfo,
   ViewBuilderInput,
@@ -15,7 +16,7 @@ import type {
 import type { MoiContext } from '@/lib/moi-context'
 import { viewBuilderDirectives } from '@/lib/view-builder-directives'
 
-import { getAppSettings, parseAppSettingsPatch, saveAppSettings } from './app-settings'
+import { getAppSettings, pickAppSettingsPatch, saveAppSettings } from './app-settings'
 import { appletForModule, recordAppletError } from './applet-log'
 import { apiBaseFor, parseAppletTail, serveWorkspaceFile } from './applets'
 import { applyEnvChanged } from './env-apply'
@@ -964,10 +965,17 @@ api.patch('/api/settings', async c => {
   } catch {
     return c.text('Invalid JSON body', 400)
   }
-  // app-settings declares which fields are API-updatable and validates them.
-  const parsed = parseAppSettingsPatch(body)
-  if ('error' in parsed) return c.text(parsed.error, 400)
-  const settings = saveAppSettings(parsed.patch)
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return c.text('Settings patch must be an object', 400)
+  }
+  // app-settings whitelists the updatable fields; the conf schema validates
+  // the values on save, rejecting the whole patch before anything persists.
+  let settings: AppSettings
+  try {
+    settings = saveAppSettings(pickAppSettingsPatch(body as Record<string, unknown>))
+  } catch (error) {
+    return c.text(error instanceof Error ? error.message : 'Invalid settings patch', 400)
+  }
   // Other open clients hold these in a query cache with no polling; broadcast
   // the new value so an app-wide preference applies everywhere immediately.
   publishEvent({ type: 'settings:updated', settings })

--- a/server/api.ts
+++ b/server/api.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 
 import type {
+  AppSettings,
   HarnessAvailability,
   UploadInfo,
   ViewBuilderInput,
@@ -15,6 +16,8 @@ import type {
 import type { MoiContext } from '@/lib/moi-context'
 import { viewBuilderDirectives } from '@/lib/view-builder-directives'
 
+import { getAppSettings, saveAppSettings } from './app-settings'
+import type { AppSettingsPatch } from './app-settings'
 import { appletForModule, recordAppletError } from './applet-log'
 import { apiBaseFor, parseAppletTail, serveWorkspaceFile } from './applets'
 import { applyEnvChanged } from './env-apply'
@@ -951,6 +954,27 @@ workspaces.route('/:id', one)
 export const api = new Hono()
 
 api.route('/api/workspaces', workspaces)
+
+// App-wide settings (settings.json in the data dir). GET returns every key
+// with defaults applied; PATCH merges a partial body and returns the result.
+api.get('/api/settings', c => c.json(getAppSettings()))
+
+api.patch('/api/settings', async c => {
+  let body: Partial<Record<keyof AppSettings, unknown>>
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.text('Invalid JSON body', 400)
+  }
+  const patch: AppSettingsPatch = {}
+  if (body.autoUpdateSkills !== undefined) {
+    if (typeof body.autoUpdateSkills !== 'boolean') {
+      return c.text('autoUpdateSkills must be a boolean', 400)
+    }
+    patch.autoUpdateSkills = body.autoUpdateSkills
+  }
+  return c.json(saveAppSettings(patch))
+})
 
 // Everything else: in production, serve the prebuilt client from `dist/` via
 // Hono's static handler (mime types, traversal-safe, optional precompression).

--- a/server/app-settings.test.ts
+++ b/server/app-settings.test.ts
@@ -8,12 +8,16 @@ import type { AppSettings } from '@/lib/types'
 import { api } from './api'
 import { setAppSettingsDir } from './app-settings'
 import { DATA_DIR } from './data-dir'
+import { setEventServer } from './events'
 
 let tempDir = ''
+let published: unknown[] = []
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), 'moi-app-settings-'))
   setAppSettingsDir(tempDir)
+  published = []
+  setEventServer({ publish: (_topic, data) => published.push(JSON.parse(data)) })
 })
 
 afterEach(async () => {
@@ -47,6 +51,9 @@ describe('app settings API', () => {
 
     const readBack = await api.request('/api/settings')
     expect(((await readBack.json()) as AppSettings).autoUpdateSkills).toBe(true)
+
+    // Other open clients learn about the change over the live-event channel.
+    expect(published).toEqual([{ type: 'settings:updated', settings: { autoUpdateSkills: true } }])
   })
 
   test('rejects a non-boolean flag and unknown-only patches change nothing', async () => {

--- a/server/app-settings.test.ts
+++ b/server/app-settings.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { AppSettings } from '@/lib/types'
+
+import { api } from './api'
+import { setAppSettingsDir } from './app-settings'
+import { DATA_DIR } from './data-dir'
+
+let tempDir = ''
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'moi-app-settings-'))
+  setAppSettingsDir(tempDir)
+})
+
+afterEach(async () => {
+  setAppSettingsDir(DATA_DIR)
+  await rm(tempDir, { recursive: true, force: true })
+  tempDir = ''
+})
+
+describe('app settings API', () => {
+  test('returns defaults before anything is saved', async () => {
+    const response = await api.request('/api/settings')
+    const settings = (await response.json()) as AppSettings
+
+    expect(response.status).toBe(200)
+    expect(settings).toEqual({ autoUpdateSkills: false })
+  })
+
+  test('persists a patched setting to settings.json', async () => {
+    const response = await api.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ autoUpdateSkills: true })
+    })
+    const settings = (await response.json()) as AppSettings
+
+    expect(response.status).toBe(200)
+    expect(settings.autoUpdateSkills).toBe(true)
+    expect(JSON.parse(await Bun.file(join(tempDir, 'settings.json')).text())).toEqual({
+      autoUpdateSkills: true
+    })
+
+    const readBack = await api.request('/api/settings')
+    expect(((await readBack.json()) as AppSettings).autoUpdateSkills).toBe(true)
+  })
+
+  test('rejects a non-boolean flag and unknown-only patches change nothing', async () => {
+    const invalid = await api.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ autoUpdateSkills: 'yes' })
+    })
+    expect(invalid.status).toBe(400)
+
+    const unknown = await api.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nope: true })
+    })
+    expect(unknown.status).toBe(200)
+    expect((await unknown.json()) as AppSettings).toEqual({ autoUpdateSkills: false })
+  })
+})

--- a/server/app-settings.ts
+++ b/server/app-settings.ts
@@ -1,0 +1,49 @@
+import Conf from 'conf'
+
+import type { AppSettings } from '@/lib/types'
+
+import { DATA_DIR } from './data-dir'
+
+// App-wide user settings, stored as `settings.json` in moi's data dir next to
+// the workspace registry. Backed by `conf`: atomic writes, per-key JSON-schema
+// validation, and migrations when the settings shape evolves. Add new keys to
+// `AppSettings` (lib/types.ts) and to the schema here — with a default, so GET
+// /api/settings always returns a complete object.
+
+export type AppSettingsPatch = Partial<AppSettings>
+
+let _dir = DATA_DIR
+let _store: Conf<AppSettings> | null = null
+
+// Test seam: point the store at a scratch dir (mirrors setThreadConfigPath).
+export function setAppSettingsDir(dir: string): void {
+  _dir = dir
+  _store = null
+}
+
+function store(): Conf<AppSettings> {
+  _store ??= new Conf<AppSettings>({
+    cwd: _dir,
+    configName: 'settings',
+    schema: {
+      autoUpdateSkills: { type: 'boolean', default: false }
+    }
+  })
+  return _store
+}
+
+export function getAppSettings(): AppSettings {
+  return store().store
+}
+
+// Merge a partial settings object over the stored one. `undefined` fields are
+// left untouched; there is no clear-to-default, since every key always holds a
+// concrete value. Returns the full merged settings.
+export function saveAppSettings(patch: AppSettingsPatch): AppSettings {
+  const settings = store()
+  for (const key of Object.keys(patch) as (keyof AppSettings)[]) {
+    const value = patch[key]
+    if (value !== undefined) settings.set(key, value)
+  }
+  return settings.store
+}

--- a/server/app-settings.ts
+++ b/server/app-settings.ts
@@ -6,40 +6,28 @@ import { DATA_DIR } from './data-dir'
 
 // App-wide user settings, stored as `settings.json` in moi's data dir next to
 // the workspace registry. Backed by `conf`: atomic writes, per-key JSON-schema
-// validation, and migrations when the settings shape evolves. Add new keys to
-// `AppSettings` (lib/types.ts) and to the schema here — with a default, so GET
-// /api/settings always returns a complete object.
+// validation, and migrations when the settings shape evolves. Adding a key
+// means extending `AppSettings` (lib/types.ts) and the schema here — with a
+// default, so GET /api/settings always returns a complete object — plus
+// `API_UPDATABLE` if clients may change it.
 
 export type AppSettingsPatch = Partial<AppSettings>
 
-// Which fields the API may update, each with its runtime check. Declared here
-// so the PATCH /api/settings route stays generic — a new settings key only
-// touches this module (schema below, and this map if it is API-updatable).
-type FieldRule<K extends keyof AppSettings> = {
-  expects: string
-  check: (value: unknown) => value is AppSettings[K]
-}
+// Whitelist of fields the API may update. Type validation is NOT duplicated
+// here — `saveAppSettings` validates the merged store against the conf schema
+// before anything is written, so a bad value throws with nothing persisted.
+const API_UPDATABLE = ['autoUpdateSkills'] as const satisfies readonly (keyof AppSettings)[]
 
-const apiUpdatable: { [K in keyof AppSettings]?: FieldRule<K> } = {
-  autoUpdateSkills: { expects: 'a boolean', check: value => typeof value === 'boolean' }
-}
-
-// Pick the API-updatable fields out of an untrusted body. Unknown keys are
-// ignored; a declared key holding the wrong type rejects the whole patch.
-export function parseAppSettingsPatch(
-  body: unknown
-): { patch: AppSettingsPatch } | { error: string } {
-  if (!body || typeof body !== 'object') return { error: 'Settings patch must be an object' }
-  const raw = body as Record<string, unknown>
-  const patch: AppSettingsPatch = {}
-  for (const key of Object.keys(apiUpdatable) as (keyof AppSettings)[]) {
-    const rule = apiUpdatable[key]
-    const value = raw[key]
-    if (!rule || value === undefined) continue
-    if (!rule.check(value)) return { error: `${key} must be ${rule.expects}` }
-    patch[key] = value
+// Pick the API-updatable fields out of an untrusted body; unknown keys are
+// dropped. Values are intentionally unchecked — the conf schema rejects wrong
+// types when the patch is saved.
+export function pickAppSettingsPatch(body: Record<string, unknown>): AppSettingsPatch {
+  const picked: Record<string, unknown> = {}
+  for (const key of API_UPDATABLE) {
+    if (body[key] !== undefined) picked[key] = body[key]
   }
-  return { patch }
+  // Not yet schema-validated; saveAppSettings is the enforcement point.
+  return picked as AppSettingsPatch
 }
 
 let _dir = DATA_DIR
@@ -66,14 +54,12 @@ export function getAppSettings(): AppSettings {
   return store().store
 }
 
-// Merge a partial settings object over the stored one. `undefined` fields are
-// left untouched; there is no clear-to-default, since every key always holds a
-// concrete value. Returns the full merged settings.
+// Merge a partial settings object over the stored one and return the result.
+// The object-form `set` validates the whole merged store against the schema
+// before writing, so an invalid patch throws (`Config schema violation: …`)
+// and persists nothing.
 export function saveAppSettings(patch: AppSettingsPatch): AppSettings {
   const settings = store()
-  for (const key of Object.keys(patch) as (keyof AppSettings)[]) {
-    const value = patch[key]
-    if (value !== undefined) settings.set(key, value)
-  }
+  if (Object.keys(patch).length > 0) settings.set(patch)
   return settings.store
 }

--- a/server/app-settings.ts
+++ b/server/app-settings.ts
@@ -12,6 +12,36 @@ import { DATA_DIR } from './data-dir'
 
 export type AppSettingsPatch = Partial<AppSettings>
 
+// Which fields the API may update, each with its runtime check. Declared here
+// so the PATCH /api/settings route stays generic — a new settings key only
+// touches this module (schema below, and this map if it is API-updatable).
+type FieldRule<K extends keyof AppSettings> = {
+  expects: string
+  check: (value: unknown) => value is AppSettings[K]
+}
+
+const apiUpdatable: { [K in keyof AppSettings]?: FieldRule<K> } = {
+  autoUpdateSkills: { expects: 'a boolean', check: value => typeof value === 'boolean' }
+}
+
+// Pick the API-updatable fields out of an untrusted body. Unknown keys are
+// ignored; a declared key holding the wrong type rejects the whole patch.
+export function parseAppSettingsPatch(
+  body: unknown
+): { patch: AppSettingsPatch } | { error: string } {
+  if (!body || typeof body !== 'object') return { error: 'Settings patch must be an object' }
+  const raw = body as Record<string, unknown>
+  const patch: AppSettingsPatch = {}
+  for (const key of Object.keys(apiUpdatable) as (keyof AppSettings)[]) {
+    const rule = apiUpdatable[key]
+    const value = raw[key]
+    if (!rule || value === undefined) continue
+    if (!rule.check(value)) return { error: `${key} must be ${rule.expects}` }
+    patch[key] = value
+  }
+  return { patch }
+}
+
 let _dir = DATA_DIR
 let _store: Conf<AppSettings> | null = null
 

--- a/server/data-dir.ts
+++ b/server/data-dir.ts
@@ -1,5 +1,5 @@
 // Single source of truth for the OS data dir holding moi's global state
-// (workspaces.json, thread-config.json, workspace-env.json, …).
+// (workspaces.json, settings.json, thread-config.json, workspace-env.json, …).
 //
 // MOI_DATA_DIR overrides it wholesale. This is the isolation seam for CLI
 // e2e tests: env-paths only honors XDG_DATA_HOME on Linux, so on macOS a


### PR DESCRIPTION
The skill auto-update preference now lives on the server instead of the browser. A new app-wide settings store — `conf`-backed `settings.json` in moi's data dir, exposed via `GET`/`PATCH /api/settings` — replaces the localStorage flag from the base PR, so opting into auto-updates from the workspace banner applies across every client. A PATCH also broadcasts a `settings:updated` live event carrying the new value, so already-open clients apply it immediately. Stacked on `design-guidelines` (recreates #64 against the right base).

```
PATCH /api/settings
{ "autoUpdateSkills": true }

→ 200 { "autoUpdateSkills": true }    # persisted to <data dir>/settings.json
→ ws  { "type": "settings:updated", "settings": { "autoUpdateSkills": true } }
```

A settings key is declared once: in the conf schema (type + default) and in the `API_UPDATABLE` whitelist if clients may change it. The PATCH route picks whitelisted keys and object-form `set()` validates the merged store against the schema before writing — a bad value rejects the whole patch with a 400 and persists nothing.

Worth a close look:

- `useWorkspaceSkillUpdates` gates the banner and the auto-update effect on the settings query resolving — without that gate, users who opted in would see the prompt flash (default `false`) before settings load.
- `conf` is a new runtime dependency and now owns the `settings.json` format and patch validation; verified schema defaults and validate-before-write behavior under Bun.
- The zustand store drops `skillAutoUpdateEnabled`. A stale key lingers harmlessly in existing localStorage; no migration since the flag never shipped outside the base PR.

Verified: `bun test` — 596 pass, 0 fail (includes `server/app-settings.test.ts`, which also asserts the broadcast); `bun run typecheck:client` and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gv9P3ecorjQnhL3ABFTYQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv9P3ecorjQnhL3ABFTYQU)_