### PR TITLE
Serve applet entries at an extensionless url so proxies stop pinning them

### DIFF
--- a/client/features/applets/applet-cache.test.ts
+++ b/client/features/applets/applet-cache.test.ts
@@ -27,14 +27,24 @@ describe('appletUrl + version', () => {
     const seg = 'views'
     const ws = `wsv-${crypto.randomUUID()}`
     expect(appletVersion(seg, ws, 'a')).toBe(0)
-    expect(appletUrl(seg, ws, 'a')).toBe(`/api/workspaces/${ws}/views/a/index.js?v=0`)
+    expect(appletUrl(seg, ws, 'a')).toBe(`/api/workspaces/${ws}/views/a/module?v=0`)
 
     invalidateApplet(seg, ws, 'a')
     expect(appletVersion(seg, ws, 'a')).toBe(1)
-    expect(appletUrl(seg, ws, 'a')).toBe(`/api/workspaces/${ws}/views/a/index.js?v=1`)
+    expect(appletUrl(seg, ws, 'a')).toBe(`/api/workspaces/${ws}/views/a/module?v=1`)
 
     invalidateApplet(seg, ws, 'a')
-    expect(appletUrl(seg, ws, 'a')).toBe(`/api/workspaces/${ws}/views/a/index.js?v=2`)
+    expect(appletUrl(seg, ws, 'a')).toBe(`/api/workspaces/${ws}/views/a/module?v=2`)
+  })
+
+  test('the entry url carries no file extension', () => {
+    // Load-bearing, not cosmetic: proxies (Cloudflare) decide cacheability from
+    // the url extension, and a `.js` entry gets its `no-cache` overwritten by the
+    // zone's Browser Cache TTL — which pins a stale bundle in the browser.
+    const ws = `wsv-${crypto.randomUUID()}`
+    const path = new URL(appletUrl('widgets', ws, 'clock'), 'http://h').pathname
+    expect(path).toBe(`/api/workspaces/${ws}/widgets/clock/module`)
+    expect(path).not.toMatch(/\.\w+$/)
   })
 
   test('versions are independent per applet', () => {
@@ -58,6 +68,6 @@ describe('invalidateApplet drops the cached module', () => {
     invalidateApplet('views', ws, 'board')
     expect(getCachedApplet(key)).toBeUndefined()
     // And the URL the next load uses is now a fresh version.
-    expect(appletUrl('views', ws, 'board')).toBe(`/api/workspaces/${ws}/views/board/index.js?v=1`)
+    expect(appletUrl('views', ws, 'board')).toBe(`/api/workspaces/${ws}/views/board/module?v=1`)
   })
 })

--- a/client/features/applets/applet-cache.ts
+++ b/client/features/applets/applet-cache.ts
@@ -30,11 +30,20 @@ export function appletVersion(segment: AppletSegment, workspaceId: string, name:
   return versions.get(appletKey(segment, workspaceId, name)) ?? 0
 }
 
+// The url segment the entry is served at. NOT `index.js`, which is only its name
+// on disk: proxies in front of moi (Cloudflare, notably) pick cacheability from
+// the url's extension rather than the content type, and on a `.js` url the
+// zone's Browser Cache TTL — 4 hours by default — gets stamped over the server's
+// `no-cache`, pinning a stale bundle in the browser with no way to revalidate it
+// away. Extensionless keeps the server's headers intact. `parseAppletTail` in
+// `server/applets.ts` maps this back to `index.js`; the two must agree.
+const ENTRY_ROUTE = 'module'
+
 // The cache-busting import URL for an applet's entry at its current version.
 // Assets + chunks resolve module-relative from the entry (via import.meta.url),
 // so they don't inherit `?v` and aren't re-fetched needlessly.
 export function appletUrl(segment: AppletSegment, workspaceId: string, name: string): string {
-  return `/api/workspaces/${workspaceId}/${segment}/${name}/index.js?v=${appletVersion(segment, workspaceId, name)}`
+  return `/api/workspaces/${workspaceId}/${segment}/${name}/${ENTRY_ROUTE}?v=${appletVersion(segment, workspaceId, name)}`
 }
 
 // The key an applet bundle registers its CSS under (`window.__moiAppletCss`):

--- a/client/features/applets/applet-log.test.ts
+++ b/client/features/applets/applet-log.test.ts
@@ -27,7 +27,9 @@ describe('matchBundleUrl', () => {
   })
 
   test('matches inside a Firefox-style stack frame (fn@url)', () => {
-    const stack = `onClick@http://localhost:13337/api/workspaces/${WS}/views/crm/index.js:10:5`
+    // The entry is requested at the extensionless `…/<name>/module` alias, so
+    // that — not `index.js` — is what the browser prints in real stack frames.
+    const stack = `onClick@http://localhost:13337/api/workspaces/${WS}/views/crm/module?v=1:10:5`
     expect(matchBundleUrl(stack)).toEqual({ workspaceId: WS, kind: 'view', name: 'crm' })
   })
 

--- a/client/features/applets/useApplet.ts
+++ b/client/features/applets/useApplet.ts
@@ -66,7 +66,7 @@ function loadApplet(
   const existing = getCachedApplet(key) as Promise<ComponentType<AppletComponentProps>> | undefined
   if (existing) return existing
 
-  // Import the bundle dir's `index.js` at its current `?v`; the version is bumped
+  // Import the bundle dir's entry at its current `?v`; the version is bumped
   // (and this entry dropped) by `invalidateApplet` on every rebuild — including
   // while this applet is unmounted — so a backgrounded tab never serves stale.
   const promise = import(/* @vite-ignore */ appletUrl(segment, workspaceId, name)).then(mod => {

--- a/docs/applet-assets.md
+++ b/docs/applet-assets.md
@@ -21,10 +21,13 @@ self-locate via `import.meta.url`. This replaces the `window.__MEI_WS__` global.
 
 ```
 .moi/.build/views/editor/      served at  /api/workspaces/<id>/views/editor/
-  index.js          entry      ← served, sentinel-swapped
+  index.js          entry      ← served at `module`, sentinel-swapped
   chunk-<hash>.js   chunk      ← served, sentinel-swapped
   img-<hash>.png    asset      ← streamed raw
 ```
+
+The entry is the one file whose route name differs from its disk name — see
+[Why the entry url has no extension](#why-the-entry-url-has-no-extension).
 
 Two route families — applet files (per applet) and workspace I/O (per workspace).
 Kind is a **literal** segment (`widgets`/`views`), not a param — a param would
@@ -40,12 +43,56 @@ POST /api/workspaces/:id/rpc/<module>/<fn> → workspace worker (run server fn)
 Example paths (widget `clips`, workspace `wsab12`):
 
 ```
-entry   /api/workspaces/wsab12/widgets/clips/index.js
+entry   /api/workspaces/wsab12/widgets/clips/module?v=0
 asset   /api/workspaces/wsab12/widgets/clips/logo-9f3a2b1c.png
 chunk   /api/workspaces/wsab12/widgets/clips/chunk-7d4e1a09.js
 fs      /api/workspaces/wsab12/fs/clips/001_copenhagen.mp4
 rpc     /api/workspaces/wsab12/rpc/widgets/clips/listClips
 ```
+
+## Why the entry url has no extension
+
+The entry is served at `…/<name>/module`, not `…/<name>/index.js`. That is a
+proxy workaround, not a naming preference.
+
+Cloudflare — which sits between many users and their moi, typically as a tunnel
+— decides whether a response is **cache-eligible from the url's file extension**,
+not from its content type, and [`JS` is on its default cached-extension
+list](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#default-cached-file-extensions).
+Once a response is cache-eligible, the zone's [Browser Cache
+TTL](https://developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/#browser-cache-ttl)
+applies, and it **overrides the origin's `Cache-Control`** on the way to the
+browser whenever the origin's freshness is lower than the TTL. The default is
+4 hours on every plan, so moi's `no-cache` reached the browser as
+`max-age=14400`.
+
+The entry lives at one stable url across rebuilds, so that rewrite pinned a
+stale bundle in the user's browser for hours. Neither existing defence helped:
+the browser had been told not to revalidate, so the ETag never got to fire, and
+`?v` is an in-memory counter that resets to `0` on reload — a full refresh lands
+straight back on the poisoned url.
+
+An extensionless path isn't cache-eligible by default (`CF-Cache-Status:
+DYNAMIC`), so the response reaches the browser with the headers moi actually
+sent. Chunks and assets keep their extensions on purpose: they're content-hashed
+and _want_ the edge cache.
+
+Consequences to keep in mind when touching this:
+
+- `parseAppletTail` (`server/applets.ts`) maps `module` → `index.js` **before**
+  `serveApplet` runs, so content-type and the sentinel swap keep keying off the
+  real `.js` name. Deciding those from the requested url would ship the entry as
+  `application/octet-stream` and fail the browser's module MIME check.
+- `appletUrl` (`client/features/applets/applet-cache.ts`) and `parseAppletTail`
+  must agree on the spelling; both sides pin it in tests.
+- The entry carries `Cache-Control: private, no-cache` + an ETag. `private` is
+  the one directive Cloudflare preserves through the Browser Cache TTL rewrite,
+  so it's cheap insurance for any shared cache that stores the response anyway.
+  `no-cache` (not `no-store`) is deliberate — the browser keeps the bytes and
+  revalidates, which the origin answers with a bodyless 304.
+- Other stable-url routes on cacheable extensions (`/fs/*`, `/preview/*`,
+  `/vendor/react/*.js`) have the same exposure and are **not** fixed by this;
+  their urls can't drop the extension as cheaply.
 
 ## Three ways out
 
@@ -121,9 +168,10 @@ declare module '*.png' {
   emits the entry's CSS sibling as an "entry" output too, so a literal `index.js`
   collides; we inject that CSS and drop the file.
 - **Serve** (`applets.ts` `serveApplet`): the `…/widgets/*` / `…/views/*` routes
-  (literal kind) parse the tail as `<name>/<file>`; `.js` is sentinel-swapped and
-  sent as `text/javascript`, anything else streams raw (`Bun.file` infers
-  content-type). `…/<id>/rpc/<module>/<fn>` reuses the existing worker call.
+  (literal kind) parse the tail as `<name>/<file>`, resolving the entry alias
+  `module` to `index.js`; `.js` is sentinel-swapped and sent as `text/javascript`,
+  anything else streams raw (`Bun.file` infers content-type).
+  `…/<id>/rpc/<module>/<fn>` reuses the existing worker call.
 - **`/fs`** (`applets.ts` `serveWorkspaceFile`): reject empty/`.`/`..`/dotfile
   segments and anything resolving outside the root, allowlist media extensions —
   the secret-leak guard, not the localhost bind. Range is handled **explicitly**

--- a/server/applets.ts
+++ b/server/applets.ts
@@ -7,8 +7,9 @@
 //
 // Each applet builds into its OWN directory `.build/<kind>/<name>/`, holding a
 // fixed `index.js` entry plus any code chunks and bundled assets (hashed
-// images/fonts). The client dynamic-imports `<name>/index.js`; assets and
-// chunks resolve module-relative from there. `.js` files carry the
+// images/fonts). The client dynamic-imports that entry at `<name>/module` — an
+// extensionless alias, see `ENTRY_ROUTE_FILE` — and assets and chunks resolve
+// module-relative from there. `.js` files carry the
 // `%%MOI_APPLET_API_BASE%%` sentinel (for RPC + `fileUrl`), swapped to the real
 // `/api/workspaces/<id>` base when served — so the on-disk bundle is
 // workspace-agnostic.
@@ -271,12 +272,21 @@ const HASHED_FILE_RE = /^chunk-[0-9a-z]+\.\w+$|-[0-9a-f]{6,}\.\w+$/i
 // prefix — substituted for the build-time sentinel in every `.js` so RPC and
 // `fileUrl` calls hit the right workspace. Assets stream untouched.
 //
+// `file` is the ON-DISK name (the route's extensionless entry alias is already
+// mapped back to `index.js` by `parseAppletTail`), so the content-type and
+// sentinel-swap decisions below key off the real `.js` — do not switch them to
+// the requested url, or the entry would ship as `application/octet-stream` and
+// fail the browser's module MIME check.
+//
 // Caching turns on the hashed-vs-stable split. A content-hashed chunk/asset gets
 // a new url whenever its bytes change, so it's cached forever. The `index.js`
 // entry (and anything not recognizably hashed) lives at ONE url across rebuilds,
 // so a shared cache (e.g. Cloudflare) that stored it once would hand back a
 // STALE copy after the next `moi bundle` — it gets an ETag (size+mtime) +
-// `no-cache` instead, so an unchanged file costs a 304 and a rebuilt one busts.
+// `private, no-cache` instead, so an unchanged file costs a 304 and a rebuilt
+// one busts. `private` keeps it out of any shared cache that would store it
+// anyway, and is the one directive Cloudflare preserves when its Browser Cache
+// TTL rewrites the header (see `ENTRY_ROUTE_FILE` for the rest of that story).
 export async function serveApplet(
   kind: AppletKind,
   name: string,
@@ -306,7 +316,7 @@ export async function serveApplet(
     cache = { 'Cache-Control': IMMUTABLE_CACHE }
   } else {
     const etag = `"${bunFile.size}-${Math.trunc(bunFile.lastModified)}"`
-    cache = { ETag: etag, 'Cache-Control': 'no-cache' }
+    cache = { ETag: etag, 'Cache-Control': 'private, no-cache' }
     if (ifNoneMatch === etag) return new Response(null, { status: 304, headers: cache })
   }
 
@@ -329,8 +339,36 @@ export function apiBaseFor(id: string): string {
   return `/api/workspaces/${id}`
 }
 
+// The entry's real name in the bundle dir (`.build/<kind>/<name>/index.js`).
+const ENTRY_DISK_FILE = 'index.js'
+
+// …and the url the client asks for it at: `…/<segment>/<name>/module`. The route
+// name and the disk name differ ON PURPOSE, and the reason is proxies.
+//
+// Cloudflare — which sits between many users and their moi, usually as a tunnel
+// — decides whether a response is cache-eligible from the url's FILE EXTENSION,
+// not from its content type, and `JS` is on its default cached-extension list.
+// Once a response is cache-eligible, the zone's Browser Cache TTL applies, and
+// that setting overrides the origin's `Cache-Control` on the way to the browser
+// whenever the origin's freshness is lower than the TTL. Its default is 4 hours
+// on every plan, so our `no-cache` came back to the browser as `max-age=14400`.
+// The entry lives at ONE url across rebuilds, so that rewrite pinned a stale
+// bundle in the user's browser for hours: no revalidation, so the ETag never got
+// a chance to bust it, and `?v` couldn't either (it's an in-memory counter that
+// resets to 0 on reload, landing right back on the poisoned url).
+//
+// An extensionless path isn't cache-eligible by default, so it reaches the
+// browser with the headers we actually sent. Chunks and assets keep their
+// extensions deliberately — they're content-hashed and WANT the edge cache.
+// The build only ever emits `index.js`, `chunk-<hash>.js` and hashed assets, so
+// this name can never collide with a real bundle file. Mirrors `appletUrl` in
+// `client/features/applets/applet-cache.ts`.
+const ENTRY_ROUTE_FILE = 'module'
+
 // Split an applet file request `…/<segment>/<name>/<file>` into name + file. A
-// bare `…/<segment>/<name>` (or legacy `…/<name>.js`) targets the entry.
+// bare `…/<segment>/<name>` (or legacy `…/<name>.js`) targets the entry, as does
+// the extensionless `…/<name>/module` alias. `file` is always the on-disk name,
+// so `serveApplet` never has to know the route spelling.
 export function parseAppletTail(
   url: string,
   id: string,
@@ -338,8 +376,12 @@ export function parseAppletTail(
 ): { name: string; file: string } {
   const tail = new URL(url).pathname.split(`/api/workspaces/${id}/${segment}/`)[1] ?? ''
   const slash = tail.indexOf('/')
-  if (slash === -1) return { name: tail.replace(/\.js$/, ''), file: 'index.js' }
-  return { name: tail.slice(0, slash), file: tail.slice(slash + 1) }
+  if (slash === -1) return { name: tail.replace(/\.js$/, ''), file: ENTRY_DISK_FILE }
+  const file = tail.slice(slash + 1)
+  return {
+    name: tail.slice(0, slash),
+    file: file === ENTRY_ROUTE_FILE ? ENTRY_DISK_FILE : file
+  }
 }
 
 // Extensions `fileUrl()` may stream from the workspace. Media + image/doc

--- a/server/test/applets.test.ts
+++ b/server/test/applets.test.ts
@@ -75,14 +75,15 @@ describe('serveApplet', () => {
     expect(res.status).toBe(200)
   })
 
-  test('entry index.js revalidates: ETag + no-cache, 304 on match', async () => {
+  test('entry index.js revalidates: ETag + private, no-cache, 304 on match', async () => {
     // The entry's url is stable across rebuilds, so an edge cache must revalidate
-    // it or it serves a stale bundle. It carries an ETag + `no-cache`; a request
-    // echoing that ETag gets a bodyless 304.
+    // it or it serves a stale bundle. It carries an ETag + `private, no-cache`; a
+    // request echoing that ETag gets a bodyless 304. `private` is what Cloudflare
+    // preserves when its Browser Cache TTL rewrites the header.
     seedApplet('views', 'editor', { 'index.js': 'export default 1' })
     const res = await serveApplet('view', 'editor', 'index.js', WS, BASE)
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('no-cache')
+    expect(res.headers.get('cache-control')).toBe('private, no-cache')
     const etag = res.headers.get('etag')
     expect(etag).toBeTruthy()
 
@@ -126,7 +127,7 @@ describe('serveApplet', () => {
     })
     for (const f of ['banner.png', 'sprite-map.png']) {
       const res = await serveApplet('widget', 'clock', f, WS, BASE)
-      expect(res.headers.get('cache-control')).toBe('no-cache')
+      expect(res.headers.get('cache-control')).toBe('private, no-cache')
       expect(res.headers.get('etag')).toBeTruthy()
     }
   })
@@ -182,6 +183,19 @@ describe('parseAppletTail', () => {
     expect(
       parseAppletTail('http://h/api/workspaces/w1/widgets/clips/logo-x.png', 'w1', 'widgets')
     ).toEqual({ name: 'clips', file: 'logo-x.png' })
+  })
+
+  test('the extensionless `module` alias resolves to the on-disk entry', () => {
+    // The client asks for `…/<name>/module` so proxies that key cacheability off
+    // the url extension leave the response's headers alone; the bundle dir still
+    // holds `index.js`, and mapping here keeps serveApplet's content-type and
+    // sentinel-swap keyed off the real `.js` name.
+    expect(
+      parseAppletTail('http://h/api/workspaces/w1/views/editor/module?v=2', 'w1', 'views')
+    ).toEqual({ name: 'editor', file: 'index.js' })
+    expect(
+      parseAppletTail('http://h/api/workspaces/w1/widgets/clock/module', 'w1', 'widgets')
+    ).toEqual({ name: 'clock', file: 'index.js' })
   })
 
   test('a bare name (or legacy <name>.js) targets the entry', () => {


### PR DESCRIPTION
Cloudflare decides cache-eligibility from a url's file extension rather than
its content type, and `JS` is on its default cached-extension list. Once a
response is eligible, the zone's Browser Cache TTL (4 hours by default on every
plan) overrides the origin's `Cache-Control` on the way to the browser whenever
the origin's freshness is lower — so moi's `no-cache` reached the browser as
`max-age=14400`. The entry lives at one stable url across rebuilds, so that
rewrite pinned a stale bundle for hours: the browser had been told not to
revalidate, so the ETag never fired, and `?v` is an in-memory counter that
resets to 0 on reload, landing right back on the poisoned url.

The client now imports the entry at `…/<segment>/<name>/module`, which isn't
cache-eligible by default, so the response reaches the browser with the headers
moi actually sent. The bundle dir is untouched: `parseAppletTail` maps the alias
back to `index.js` before `serveApplet` runs, keeping the content-type and
sentinel-swap decisions on the real `.js` name. Chunks and assets keep their
extensions on purpose — they're content-hashed and want the edge cache. The
entry also gains `private`, the one directive Cloudflare preserves through that
rewrite. `?v` and the legacy `/index.js` route both stay.

Rationale and the routes still exposed to this (`/fs/*`, `/preview/*`,
`/vendor/react/*.js`) are written up in docs/applet-assets.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WVJZMnhLA3DcsV2urnzqmm