### PR TITLE
Fix chat sends failing with "No conversation found" after creating a view

### DIFF
--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -540,10 +540,11 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
       Icon: IconBrowserPlus,
       label: 'New view',
       onClick: () => {
-        void builderActions.create().then(builder => {
-          selectSession(builder.sessionId)
-          openTab(viewBuilderTabId(builder.id))
-        })
+        // Do NOT select the draft's pre-minted sessionId here: no session
+        // exists behind it until submit, so making it the chat selection turns
+        // the chat into a dead "New chat" whose sends try to resume a session
+        // that isn't there. Submit selects it once the chat actually starts.
+        void builderActions.create().then(builder => openTab(viewBuilderTabId(builder.id)))
       }
     }
   ]

--- a/server/harness/claude-code/session.ts
+++ b/server/harness/claude-code/session.ts
@@ -21,6 +21,7 @@ import {
 import { appendAttachmentNote, attachmentOnlyPlaceholder } from '@/lib/attachment-note'
 import { buildSessionTitleSource } from '../session-title'
 import { ClaudeAdapter } from './adapter'
+import { claudeSessionExists } from './sessions'
 import { generateClaudeSessionTitle, renameClaudeSessionIfUnchanged } from './session-title'
 import type { Part } from '@/lib/format'
 import type { SessionActivity } from '@/lib/types'
@@ -691,12 +692,6 @@ export async function sendCCMessage(input: {
     ? resolveUploads(input.workspaceId, input.attachments)
     : []
   if (!input.content && uploads.length === 0) return
-  const sessionTitleSource = input.isNew
-    ? buildSessionTitleSource(
-        input.content,
-        uploads.map(upload => upload.filename)
-      )
-    : undefined
   const { content: userContent, parts } = buildUserMessage(input.content, uploads)
   // The envelope goes in as its OWN leading text block, never merged into the
   // user's string: the SDK's first-prompt extraction (session titles,
@@ -758,16 +753,31 @@ export async function sendCCMessage(input: {
     }
   }
   if (!s) {
+    // Resuming a session with no file on disk hard-fails the CLI with "No
+    // conversation found" — and a dangling id can be selected forever (a
+    // brand-new chat whose first turn died before init persisted anything,
+    // or session files cleaned up externally), wedging the chat. Start fresh
+    // instead: the init rename then migrates this id to the real one
+    // everywhere (selected session, session config, view builders, client).
+    const isNew = input.isNew || !(await claudeSessionExists(input.sessionId, input.workspacePath))
+    if (isNew !== input.isNew) {
+      debug(`cc resume-missing ws=${input.workspaceId} session=${input.sessionId} — starting fresh`)
+    }
     s = createLiveSession({
       workspaceId: input.workspaceId,
       workspacePath: input.workspacePath,
       sessionId: input.sessionId,
-      isNew: input.isNew,
+      isNew,
       model: input.model,
       effort: input.effort,
       fastMode: input.fastMode,
       stream: wantStream,
-      sessionTitleSource,
+      sessionTitleSource: isNew
+        ? buildSessionTitleSource(
+            input.content,
+            uploads.map(upload => upload.filename)
+          )
+        : undefined,
       // The agent only sees secrets scoped to the 'agent' sink (plus .env).
       workspaceEnv: await resolveWorkspaceEnv(input.workspacePath)
     })

--- a/server/harness/claude-code/session.ts
+++ b/server/harness/claude-code/session.ts
@@ -753,13 +753,18 @@ export async function sendCCMessage(input: {
     }
   }
   if (!s) {
+    // The agent only sees secrets scoped to the 'agent' sink (plus .env).
+    // Resolved before the probe below so both see the same env.
+    const workspaceEnv = await resolveWorkspaceEnv(input.workspacePath)
     // Resuming a session with no file on disk hard-fails the CLI with "No
     // conversation found" — and a dangling id can be selected forever (a
     // brand-new chat whose first turn died before init persisted anything,
     // or session files cleaned up externally), wedging the chat. Start fresh
     // instead: the init rename then migrates this id to the real one
     // everywhere (selected session, session config, view builders, client).
-    const isNew = input.isNew || !(await claudeSessionExists(input.sessionId, input.workspacePath))
+    const isNew =
+      input.isNew ||
+      !(await claudeSessionExists(input.sessionId, input.workspacePath, workspaceEnv))
     if (isNew !== input.isNew) {
       debug(`cc resume-missing ws=${input.workspaceId} session=${input.sessionId} — starting fresh`)
     }
@@ -778,8 +783,7 @@ export async function sendCCMessage(input: {
             uploads.map(upload => upload.filename)
           )
         : undefined,
-      // The agent only sees secrets scoped to the 'agent' sink (plus .env).
-      workspaceEnv: await resolveWorkspaceEnv(input.workspacePath)
+      workspaceEnv
     })
   }
   // Streaming-input mode does NOT echo the pushed user message back in the

--- a/server/harness/claude-code/sessions.test.ts
+++ b/server/harness/claude-code/sessions.test.ts
@@ -107,6 +107,24 @@ describe('claudeSessionExists', () => {
       false
     )
   })
+
+  test('fails open when the workspace env redirects CLAUDE_CONFIG_DIR', async () => {
+    // The CLI subprocess would read a store this process can't see — the
+    // probe must not declare the session missing.
+    expect(
+      await claudeSessionExists('bb0dd21d-53bf-4910-b308-bcf3d2c67009', workspacePath, {
+        CLAUDE_CONFIG_DIR: join(scratchDir, 'elsewhere')
+      })
+    ).toBe(true)
+  })
+
+  test('probes normally when the workspace env matches the ambient config dir', async () => {
+    expect(
+      await claudeSessionExists('bb0dd21d-53bf-4910-b308-bcf3d2c67009', workspacePath, {
+        CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR!
+      })
+    ).toBe(false)
+  })
 })
 
 describe('visibleClaudeSessions', () => {

--- a/server/harness/claude-code/sessions.test.ts
+++ b/server/harness/claude-code/sessions.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { MOI_ARCHIVED_SESSION_TAG, claudeSessionSummary, visibleClaudeSessions } from './sessions'
+import {
+  MOI_ARCHIVED_SESSION_TAG,
+  claudeSessionExists,
+  claudeSessionSummary,
+  visibleClaudeSessions
+} from './sessions'
 
 describe('claudeSessionSummary', () => {
   test('uses the SDK display summary unchanged', () => {
@@ -38,6 +46,66 @@ describe('claudeSessionSummary', () => {
         firstPrompt: '(see attached files) chart.png, notes.pdf'
       })
     ).toBe('chart.png, notes.pdf')
+  })
+})
+
+describe('claudeSessionExists', () => {
+  let scratchDir = ''
+  let workspacePath = ''
+  let previousConfigDir: string | undefined
+
+  beforeEach(async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), 'moi-cc-sessions-'))
+    workspacePath = join(scratchDir, 'workspace')
+    previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = join(scratchDir, 'claude')
+  })
+
+  afterEach(async () => {
+    if (previousConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+    await rm(scratchDir, { recursive: true, force: true })
+  })
+
+  async function writeSessionFile(sessionId: string): Promise<void> {
+    // Mirrors the SDK's storage layout: one .jsonl per session under the
+    // project dir named after the workspace path with `/` → `-`.
+    const projectDir = join(
+      process.env.CLAUDE_CONFIG_DIR!,
+      'projects',
+      workspacePath.replaceAll('/', '-')
+    )
+    await mkdir(projectDir, { recursive: true })
+    const line = {
+      type: 'user',
+      uuid: 'turn-1',
+      parentUuid: null,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: workspacePath,
+      message: { role: 'user', content: 'hello' }
+    }
+    await writeFile(join(projectDir, `${sessionId}.jsonl`), `${JSON.stringify(line)}\n`)
+  }
+
+  test('finds a session persisted on disk', async () => {
+    await writeSessionFile('11111111-2222-3333-4444-555555555555')
+    expect(await claudeSessionExists('11111111-2222-3333-4444-555555555555', workspacePath)).toBe(
+      true
+    )
+  })
+
+  test('reports a dangling session id as missing', async () => {
+    await writeSessionFile('11111111-2222-3333-4444-555555555555')
+    expect(await claudeSessionExists('bb0dd21d-53bf-4910-b308-bcf3d2c67009', workspacePath)).toBe(
+      false
+    )
+  })
+
+  test('reports missing when the workspace has no sessions at all', async () => {
+    expect(await claudeSessionExists('bb0dd21d-53bf-4910-b308-bcf3d2c67009', workspacePath)).toBe(
+      false
+    )
   })
 })
 

--- a/server/harness/claude-code/sessions.ts
+++ b/server/harness/claude-code/sessions.ts
@@ -98,12 +98,20 @@ export async function getSessionWorkspacePreview(
 
 // Whether the session's file exists on disk in this workspace's project dir —
 // i.e. whether `resume` can possibly succeed. Reads only that session's file
-// (unlike listSessions). A probe failure counts as existing, so a transient
-// fs error still attempts the resume instead of silently forking a new chat.
+// (unlike listSessions). Fails open — a probe that can't answer reliably
+// counts as existing, so the resume is still attempted instead of silently
+// forking a new chat:
+// - a transient fs error, and
+// - a workspace env that redirects CLAUDE_CONFIG_DIR: the CLI subprocess gets
+//   workspaceEnv on top of process.env, so its session store is somewhere
+//   this process (and the SDK's ambient-env resolution) can't see.
 export async function claudeSessionExists(
   sessionId: string,
-  workspacePath: string
+  workspacePath: string,
+  workspaceEnv: Record<string, string> = {}
 ): Promise<boolean> {
+  const override = workspaceEnv.CLAUDE_CONFIG_DIR
+  if (override && override !== process.env.CLAUDE_CONFIG_DIR) return true
   try {
     return (await getSessionInfo(sessionId, { dir: workspacePath })) !== undefined
   } catch {

--- a/server/harness/claude-code/sessions.ts
+++ b/server/harness/claude-code/sessions.ts
@@ -1,6 +1,11 @@
 // Session discovery + history replay for Claude Code workspaces, backed by
 // the Agent SDK's persisted `.jsonl` session files.
-import { getSessionMessages, listSessions, tagSession } from '@anthropic-ai/claude-agent-sdk'
+import {
+  getSessionInfo,
+  getSessionMessages,
+  listSessions,
+  tagSession
+} from '@anthropic-ai/claude-agent-sdk'
 import type { SDKSessionInfo } from '@anthropic-ai/claude-agent-sdk'
 
 import {
@@ -88,6 +93,21 @@ export async function getSessionWorkspacePreview(
   return {
     ...(firstUserMessage ? { firstUserMessage } : {}),
     ...(updatedAt !== undefined ? { updatedAt } : {})
+  }
+}
+
+// Whether the session's file exists on disk in this workspace's project dir —
+// i.e. whether `resume` can possibly succeed. Reads only that session's file
+// (unlike listSessions). A probe failure counts as existing, so a transient
+// fs error still attempts the resume instead of silently forking a new chat.
+export async function claudeSessionExists(
+  sessionId: string,
+  workspacePath: string
+): Promise<boolean> {
+  try {
+    return (await getSessionInfo(sessionId, { dir: workspacePath })) !== undefined
+  } catch {
+    return true
   }
 }
 


### PR DESCRIPTION
Since #69, "New view" selected the draft builder's pre-minted `sessionId` as the workspace's chat selection. No session exists behind that id until the builder is submitted, so the chat rendered as a dead "New chat" and every send spawned the CLI with `--resume <id>`, failing with the error below. The same wedge appears whenever the persisted selection points at a session with no file on disk (first turn died before init, session files cleaned up, workspace folder moved) — and it persists across restarts.

Reproduced in-browser against a dev server (start chat → New view → back to chat → send):

```
before  error: Claude Code returned an error result:
               No conversation found with session ID: 02daff99-9747-4fcf-8795-5cc1548377b3
after   session_renamed 02daff99-… → <real id>
        turn(assistant) "pong" · result: success
```

Fixed from both ends:

- Root cause: creating a view no longer touches the chat selection — it only opens the builder tab (pre-#69 behavior). Submit still selects the builder's session once its chat actually starts. This closes the trigger for every provider (the selection/builder machinery is shared).
- Self-heal (Claude Code harness): before resuming, the harness probes for the session file (`getSessionInfo`, reads just that file). Missing → start fresh; the existing init rename then migrates the stale id everywhere (selected session, session config, view builders, client caches), so already-wedged workspaces recover on their next send.

Worth a close look:

- `claudeSessionExists` fails open — on a probe *error*, and when the workspace env redirects `CLAUDE_CONFIG_DIR` (the CLI's store is then somewhere the server process can't see) — so those sends attempt the resume exactly as before, rather than silently forking a fresh chat.
- On a heal, `renameViewBuilderSession` can rebind a dangling id held by a draft builder to the new chat's real session. Only reachable from an already-wedged state, and the root-cause fix stops new wedges from forming.
- Codex/OpenClaw keep their current behavior on a dangling resume (error frame, no heal) — their not-found error signatures need verifying against real servers before a resume→start fallback is safe there.

Verified: browser repro above (error pre-fix, healed + selection stable post-fix, builder submit still starts its build); `bun test` 805 pass with 5 new tests for the probe; `typecheck:client`, oxlint, oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCV3s3frdaFEQieZ5mnv9d