### PR TITLE
Fix broken install prompt URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Using Claude Code or Codex? Paste this prompt into an existing session and the
 agent will set everything up for you:
 
 ```
-Set up the moi workspace for this project. Fetch https://moi.computer/CC-INSTALL.md, and follow the steps.
+Set up the moi workspace for this project. Fetch https://moi.computer/INSTALL.md, and follow the steps.
 ```
 
 For OpenClaw or a manual setup, read on.


### PR DESCRIPTION
https://moi.computer/CC-INSTALL.md 404s; the install guide is served at
https://moi.computer/INSTALL.md.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LNAJFSZgEgW9AsHV5KXr3b