### PR TITLE
Replace the broken folder picker with a console hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ moi start        # http://localhost:13337
 Then bring in your project, either way works:
 
 - open [http://localhost:13337](http://localhost:13337) and create a workspace
-  (or import an existing folder) right from the web UI;
+  (or import one moi found on this computer) right from the web UI;
 - or run `moi init` inside a folder to turn it into a workspace.
 
 ## Run as a service

--- a/client/features/home/api.ts
+++ b/client/features/home/api.ts
@@ -70,7 +70,6 @@ export type ImportWorkspaceInput = {
 export type WorkspaceSetupInfo = {
   root: string
   displayRoot: string
-  canChooseFolder: boolean
   // Per-backend runtime availability (are the Claude/Codex CLIs installed?),
   // keyed by workspace type. Missing entries mean available.
   availability?: Partial<Record<WorkspaceType, HarnessAvailability>>
@@ -84,15 +83,6 @@ export function useWorkspaceSetupInfo() {
     queryFn: () => requestJson('/api/workspaces/create'),
     staleTime: 30_000,
     refetchOnMount: 'always'
-  })
-}
-
-export type ChooseFolderResult = DiscoveredWorkspace | { canceled: true }
-
-export function useChooseFolder() {
-  return useMutation<ChooseFolderResult, Error, void>({
-    mutationFn: () =>
-      requestJson('/api/workspaces/choose-folder', { method: 'POST' }, 'Failed to choose folder')
   })
 }
 

--- a/client/features/home/workspace-setup/CreateWorkspaceDialog.tsx
+++ b/client/features/home/workspace-setup/CreateWorkspaceDialog.tsx
@@ -2,7 +2,7 @@ import { type FormEvent, type ReactElement, useState } from 'react'
 
 import { useLocation } from 'wouter'
 
-import { useChooseFolder, useCreateWorkspace, useWorkspaceSetupInfo } from '../api'
+import { useCreateWorkspace, useWorkspaceSetupInfo } from '../api'
 import { Button } from '@/client/components/ui/button'
 import {
   Dialog,
@@ -12,15 +12,12 @@ import {
 } from '@/client/components/ui/dialog'
 import { Input } from '@/client/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/client/components/ui/tooltip'
-import { cn } from '@/client/lib/cn'
 import { validateWorkspaceFolderName } from '@/lib/workspace-name'
 import { WORKSPACE_TYPE_ORDER } from '@/lib/workspace-types'
 import type { WorkspaceType } from '@/lib/types'
 
-import { ImportWorkspaceStep } from './ImportWorkspaceDialog'
 import { WorkspaceAgentStep } from './WorkspaceAgentStep'
 import { WorkspaceDialogContent } from './WorkspaceDialogContent'
-import { useWorkspaceImport } from './useWorkspaceImport'
 
 type CreateWorkspaceDialogProps = {
   trigger: ReactElement
@@ -34,8 +31,6 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
   const [, navigate] = useLocation()
   const info = useWorkspaceSetupInfo()
   const createMutation = useCreateWorkspace()
-  const chooseFolder = useChooseFolder()
-  const importFlow = useWorkspaceImport({ onSuccess: entry => finish(entry.id) })
 
   const [open, setOpen] = useState(false)
   const [step, setStep] = useState<CreateWorkspaceStep>('agent')
@@ -44,8 +39,6 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
 
   const trimmedName = name.trim()
   const nameError = trimmedName ? validateWorkspaceFolderName(trimmedName) : null
-  const canChooseFolder = info.data?.canChooseFolder ?? true
-  const isImporting = chooseFolder.isPending || importFlow.isPending
   const isCreating = createMutation.isPending
 
   function finish(workspaceId: string) {
@@ -57,21 +50,7 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
     setStep('agent')
     setType(DEFAULT_WORKSPACE_TYPE)
     setName('')
-    chooseFolder.reset()
-    importFlow.reset()
     createMutation.reset()
-  }
-
-  async function chooseExistingFolder() {
-    if (isImporting) return
-    chooseFolder.reset()
-
-    try {
-      const result = await chooseFolder.mutateAsync()
-      if (!('canceled' in result)) importFlow.startImport(result)
-    } catch {
-      // The agent step renders the folder-picker error.
-    }
   }
 
   function continueToName() {
@@ -95,30 +74,13 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
     >
       <DialogTrigger render={trigger} />
       <WorkspaceDialogContent>
-        {importFlow.choice ? (
-          <ImportWorkspaceStep
-            choice={importFlow.choice}
-            availability={info.data?.availability}
-            isPending={importFlow.isPending}
-            errorMessage={importFlow.error?.message}
-            onTypeChange={importFlow.selectType}
-            onCancel={importFlow.reset}
-            onSubmit={importFlow.submit}
-          />
-        ) : step === 'agent' ? (
+        {step === 'agent' ? (
           <WorkspaceAgentStep
             title="Create new workspace"
             selectedType={type}
             availability={info.data?.availability}
-            isPending={isImporting}
-            errorMessage={(chooseFolder.error ?? importFlow.error)?.message}
-            secondaryAction={
-              <ExistingFolderButton
-                available={canChooseFolder}
-                disabled={isImporting}
-                onClick={chooseExistingFolder}
-              />
-            }
+            isPending={false}
+            secondaryAction={<ExistingFolderButton />}
             primaryLabel="Next"
             onTypeChange={setType}
             onSubmit={continueToName}
@@ -204,39 +166,34 @@ function WorkspaceNameStep({
   )
 }
 
-type ExistingFolderButtonProps = {
-  available: boolean
-  disabled: boolean
-  onClick: () => void
-}
-
-function ExistingFolderButton({ available, disabled, onClick }: ExistingFolderButtonProps) {
+// Importing a folder from the app is on hold: the native picker only ever ran on
+// macOS and cannot work at all when moi is opened from another device. The
+// button stays as the signpost for the console route.
+function ExistingFolderButton() {
   const button = (
     <Button
       variant="secondary"
-      disabled={available && disabled}
-      aria-disabled={!available || undefined}
-      onClick={event => {
-        if (!available) {
-          event.preventDefault()
-          return
-        }
-        onClick()
-      }}
-      className={cn(!available && 'cursor-not-allowed opacity-50')}
+      aria-disabled
+      onClick={event => event.preventDefault()}
+      className="cursor-not-allowed opacity-50"
     >
       Use existing folder
     </Button>
   )
 
-  if (available) return button
-
   return (
     <Tooltip>
       <TooltipTrigger render={button} />
-      <TooltipContent>
-        Run <code className="rounded-xs bg-accent px-1 py-0.5 font-mono">moi init</code> in the
-        folder to add it manually
+      <TooltipContent className="max-w-64">
+        {/* The popup lays its children out in a row — one span keeps the copy
+            flowing as a sentence with the command inline. */}
+        <span className="text-center">
+          Not supported yet — run{' '}
+          <code className="rounded-xs bg-accent px-1 py-0.5 font-mono whitespace-nowrap">
+            moi init
+          </code>{' '}
+          in the folder from your console to add it
+        </span>
       </TooltipContent>
     </Tooltip>
   )

--- a/client/features/home/workspace-setup/ImportWorkspaceDialog.tsx
+++ b/client/features/home/workspace-setup/ImportWorkspaceDialog.tsx
@@ -19,7 +19,7 @@ type ImportWorkspaceStepProps = {
   onSubmit: () => void
 }
 
-export function ImportWorkspaceStep({
+function ImportWorkspaceStep({
   choice,
   availability,
   isPending,

--- a/server/api-order.test.ts
+++ b/server/api-order.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import type { WorkspaceEntry } from '@/lib/types'
 
-import { api, isSameOriginRequest } from './api'
+import { api } from './api'
 import { setEventServer } from './events'
 import { DEFAULT_REGISTRY_PATH, registerWorkspace, setRegistryPath } from './registry'
 
@@ -44,57 +44,4 @@ test('reordering workspaces broadcasts a workspace update', async () => {
     second.id
   ])
   expect(published).toEqual([JSON.stringify({ type: 'workspaces-list:updated' })])
-})
-
-test('native folder picker rejects cross-origin requests before spawning OS UI', async () => {
-  const response = await api.request('/api/workspaces/choose-folder', {
-    method: 'POST',
-    headers: {
-      Origin: 'https://example.test'
-    }
-  })
-
-  expect(response.status).toBe(403)
-  expect(await response.text()).toBe('Forbidden')
-})
-
-test('same-origin detection survives TLS-terminating proxies', () => {
-  // Modern browser behind Cloudflare Tunnel / nginx / ngrok: Origin is https://
-  // while the server's own URL is plain http — sec-fetch-site decides.
-  expect(
-    isSameOriginRequest(
-      new Request('http://moi.example.com/api/workspaces/choose-folder', {
-        method: 'POST',
-        headers: { Origin: 'https://moi.example.com', 'sec-fetch-site': 'same-origin' }
-      })
-    )
-  ).toBe(true)
-
-  // Older browser, no sec-fetch-site: hosts match even though schemes differ.
-  expect(
-    isSameOriginRequest(
-      new Request('http://moi.example.com/api/workspaces/choose-folder', {
-        method: 'POST',
-        headers: { Origin: 'https://moi.example.com' }
-      })
-    )
-  ).toBe(true)
-
-  // Cross-site stays rejected, with or without sec-fetch-site.
-  expect(
-    isSameOriginRequest(
-      new Request('http://localhost:13337/api/workspaces/choose-folder', {
-        method: 'POST',
-        headers: { Origin: 'https://evil.test', 'sec-fetch-site': 'cross-site' }
-      })
-    )
-  ).toBe(false)
-  expect(
-    isSameOriginRequest(
-      new Request('http://localhost:13337/api/workspaces/choose-folder', {
-        method: 'POST',
-        headers: { Origin: 'https://evil.test' }
-      })
-    )
-  ).toBe(false)
 })

--- a/server/api.ts
+++ b/server/api.ts
@@ -36,7 +36,6 @@ import { getClientFrameLog, getWireLog } from './harness/debug'
 import { allHarnesses, harnessFor, isHarnessType } from './harness/registry'
 import { broadcast } from './state'
 import {
-  discoverWorkspace,
   discoverWorkspaces,
   getWorkspace,
   listWorkspaces,
@@ -933,14 +932,12 @@ async function harnessAvailability(): Promise<Record<string, HarnessAvailability
 }
 
 // Where `/workspace/create` places new folders — the client shows the resolved
-// location while the user types a name. `canChooseFolder` tells the UI whether
-// the native folder picker is available (macOS only for now). `availability`
-// lets the dialog disable backends whose runtime is missing.
+// location while the user types a name. `availability` lets the dialog disable
+// backends whose runtime is missing.
 workspaces.get('/create', async c =>
   c.json({
     root: CREATED_WORKSPACES_ROOT,
     displayRoot: tildify(CREATED_WORKSPACES_ROOT),
-    canChooseFolder: process.platform === 'darwin',
     availability: await harnessAvailability()
   })
 )
@@ -974,74 +971,6 @@ workspaces.post('/create', async c => {
   // Nudge every connected client (the sidebar list) to refetch.
   publishEvent({ type: 'workspaces-list:updated' })
   return c.json(entry, 201)
-})
-
-// Guards against opening a second native picker while one is already up — a
-// duplicate request (e.g. a quick re-click) resolves as canceled instead of
-// spawning a second Finder dialog on top of the first.
-let folderPickerOpen = false
-
-export function isSameOriginRequest(req: Request): boolean {
-  const site = req.headers.get('sec-fetch-site')
-  if (site === 'cross-site') return false
-  // Modern browsers state the relationship directly — trust it. Reaching the
-  // Origin fallback below with a full-origin comparison would 403 every request
-  // behind a TLS-terminating proxy (Cloudflare Tunnel, nginx, ngrok — see
-  // client/lib/ws-url.ts): the browser sends `https://…` while `req.url` is
-  // built from the plain-HTTP listener.
-  if (site === 'same-origin') return true
-  const origin = req.headers.get('origin')
-  if (!origin) return true
-  // Older browsers without sec-fetch-site: compare hosts only, since the
-  // scheme the browser saw is unknowable behind TLS termination.
-  try {
-    return new URL(origin).host === new URL(req.url).host
-  } catch {
-    return false
-  }
-}
-
-// Open the OS-native folder picker so the user can choose an existing folder to
-// import (the create dialog's "Use existing folder"). The server runs on the
-// user's machine, so it can drive the real system dialog — the browser can't.
-// Returns the same grouped provider discovery shape as `/discover`, or
-// `{ canceled: true }` if the dialog is dismissed. macOS only for now.
-workspaces.post('/choose-folder', async c => {
-  if (!isSameOriginRequest(c.req.raw)) return c.text('Forbidden', 403)
-  if (process.platform !== 'darwin') {
-    return c.text('Choosing a folder is only supported on macOS for now', 400)
-  }
-  if (folderPickerOpen) return c.json({ canceled: true })
-  folderPickerOpen = true
-  try {
-    // The picker is spawned by osascript, a background helper, so macOS won't
-    // give it focus by default. `tell me to activate` forces the script runner
-    // frontmost, and the short delay lets that settle before the panel opens so
-    // it appears focused rather than behind other windows.
-    const proc = Bun.spawn(
-      [
-        'osascript',
-        '-e',
-        'tell me to activate',
-        '-e',
-        'delay 0.2',
-        '-e',
-        'POSIX path of (choose folder with prompt "Select a project folder")'
-      ],
-      { stdout: 'pipe', stderr: 'pipe' }
-    )
-    const exitCode = await proc.exited
-    // osascript exits non-zero when the user presses Cancel.
-    if (exitCode !== 0) return c.json({ canceled: true })
-    const path = (await new Response(proc.stdout).text()).trim()
-    if (!path) return c.json({ canceled: true })
-    return c.json(await discoverWorkspace(path))
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    return c.text(`Could not open the folder picker: ${message}`, 500)
-  } finally {
-    folderPickerOpen = false
-  }
 })
 
 // `/:id` is registered after the static `/discover` so the literal path wins.

--- a/server/registry.test.ts
+++ b/server/registry.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from 'node:os'
 import { join } from 'path'
 
 import {
-  discoveredWorkspaceForPath,
   findWorkspaceForPath,
   getWorkspace,
   groupDiscoveredWorkspaces,
@@ -88,25 +87,6 @@ describe('workspace discovery grouping', () => {
     )
 
     expect(grouped).toEqual([])
-  })
-
-  test('returns zero, one, or multiple types for one chosen folder', () => {
-    const path = '/Users/foo/project'
-
-    expect(discoveredWorkspaceForPath(path, [])).toEqual({ path, types: [] })
-    expect(discoveredWorkspaceForPath(path, [{ path, type: 'codex' }])).toEqual({
-      path,
-      types: ['codex']
-    })
-    expect(
-      discoveredWorkspaceForPath(path, [
-        { path, type: 'openclaw' },
-        { path, type: 'claude-code' }
-      ])
-    ).toEqual({
-      path,
-      types: ['claude-code', 'openclaw']
-    })
   })
 })
 

--- a/server/registry.ts
+++ b/server/registry.ts
@@ -173,30 +173,10 @@ export function groupDiscoveredWorkspaces(
   }))
 }
 
-export function discoveredWorkspaceForPath(
-  path: string,
-  candidates: DiscoveredWorkspaceCandidate[]
-): DiscoveredWorkspace {
-  const normalizedPath = resolve(path)
-  return (
-    groupDiscoveredWorkspaces(candidates).find(workspace => workspace.path === normalizedPath) ?? {
-      path: normalizedPath,
-      types: []
-    }
-  )
-}
-
 // Ask every harness for workspaces it knows about that aren't registered yet,
 // then combine providers that claim the same normalized folder.
 export async function discoverWorkspaces(): Promise<DiscoveredWorkspace[]> {
   const registeredPaths = new Set((await readRegistry()).map(e => e.path))
   const found = await collectDiscoveredWorkspaces(registeredPaths)
   return groupDiscoveredWorkspaces(found, registeredPaths).map(withDisplayPath)
-}
-
-// Inspect one folder through the same provider discovery used by the home
-// suggestions. An empty types list means no provider recognized the folder.
-export async function discoverWorkspace(path: string): Promise<DiscoveredWorkspace> {
-  const found = await collectDiscoveredWorkspaces(new Set())
-  return withDisplayPath(discoveredWorkspaceForPath(path, found))
 }


### PR DESCRIPTION
"Use existing folder" opened a native macOS-only picker over an osascript
call, which cannot work when moi is served to another device — in the web
UI it was simply broken. The button stays as the signpost, permanently
inert, with a tooltip pointing at `moi init` in the console.

Removes the whole picker path: the `/api/workspaces/choose-folder` route
and its same-origin guard, the `canChooseFolder` setup flag, the
`useChooseFolder` hook, the create dialog's import branch, and the
single-folder discovery helper that only fed the picker.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LWqAg4T2q7n46i7jdo7nNY