### PR TITLE
Move agent availability and login ownership to the server

### DIFF
--- a/client/api/workspace-keys.ts
+++ b/client/api/workspace-keys.ts
@@ -12,8 +12,7 @@ export const workspaceKeys = {
   sessionConfig: (id: string, sessionId: string) =>
     ['workspaces', 'sessionConfig', id, sessionId] as const,
   mcp: (id: string) => ['workspaces', 'mcp', id] as const,
-  models: (id: string) => ['workspaces', 'models', id] as const,
-  availability: (id: string) => ['workspaces', 'availability', id] as const,
+  agent: (id: string) => ['workspaces', 'agent', id] as const,
   skills: (id: string) => ['workspaces', 'skills', id] as const,
   env: (id: string) => ['workspaces', 'env', id] as const
 }

--- a/client/features/chat/ChatSelector.tsx
+++ b/client/features/chat/ChatSelector.tsx
@@ -1,7 +1,8 @@
 import { useRef, useState } from 'react'
 import { IconArchive, IconChevronDown, IconEdit } from '@tabler/icons-react'
 
-import { useArchiveWorkspaceSession, useWorkspaceModels, useWorkspaceSessions } from './api'
+import { useArchiveWorkspaceSession, useWorkspaceSessions } from './api'
+import { useWorkspaceAgent } from '@/client/features/workspace/api'
 import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import { cn } from '@/client/lib/cn'
 import {
@@ -221,7 +222,7 @@ export function ChatSelector({ onSelectSession, selectedSessionId }: ChatSelecto
   const workspaceId = useWorkspaceId()
   const [confirmingSessionId, setConfirmingSessionId] = useState<string | null>(null)
   const { data: sessions = [] } = useWorkspaceSessions(workspaceId)
-  const canArchive = useWorkspaceModels(workspaceId).data?.supportsArchiving === true
+  const canArchive = useWorkspaceAgent(workspaceId).data?.supportsArchiving === true
   const archiveSession = useArchiveWorkspaceSession(workspaceId)
   const hasRunningBackgroundChat = useLive(state =>
     hasRunningBackgroundSession(state.activity, workspaceId, selectedSessionId)

--- a/client/features/chat/ModelPicker.tsx
+++ b/client/features/chat/ModelPicker.tsx
@@ -4,7 +4,8 @@ import { AnimatePresence, motion } from 'motion/react'
 
 import { IconBolt, IconBoltFilled } from '@tabler/icons-react'
 
-import { useSaveSessionConfig, useSessionConfig, useWorkspaceModels } from './api'
+import { useSaveSessionConfig, useSessionConfig } from './api'
+import { useWorkspaceAgent } from '@/client/features/workspace/api'
 import {
   hasEffortChoice,
   resolveDisplayedEffort,
@@ -271,7 +272,7 @@ type ModelPickerProps = {
 }
 
 // Model selector for composer surfaces. The workspace's available models come
-// from `/api/workspaces/:id/models`; effort options follow the selected model.
+// from `/api/workspaces/:id/agent`; effort options follow the selected model.
 // Model, effort, and Fast mode persist per chat once one exists. A new chat
 // edits the workspace defaults that seed it. All values are sent with each chat
 // frame. The workspace scope gives new-chat surfaces such as the view builder
@@ -279,7 +280,7 @@ type ModelPickerProps = {
 export const ModelPicker = memo(function ModelPicker({ scope = 'active-chat' }: ModelPickerProps) {
   const { workspaceId, layout, setLayout } = useWorkspaceLayoutCtx()
   const [selectedSessionId] = useSelectedSession()
-  const { data } = useWorkspaceModels(workspaceId)
+  const { data } = useWorkspaceAgent(workspaceId)
 
   // The SDK prepends a synthetic "default" entry ("Use the default model
   // (currently …)"). Drop it and name the concrete model it resolves to.

--- a/client/features/chat/api.ts
+++ b/client/features/chat/api.ts
@@ -4,13 +4,7 @@ import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { WORKSPACE_RESOURCE_OPTIONS } from '@/client/api/query-options'
 import { workspaceKeys } from '@/client/api/workspace-keys'
 import { applyEvents } from '@/lib/format'
-import type {
-  SessionConfig,
-  SessionInfo,
-  StreamEvent,
-  ViewState,
-  WorkspaceModels
-} from '@/lib/types'
+import type { SessionConfig, SessionInfo, StreamEvent, ViewState } from '@/lib/types'
 
 export function useWorkspaceSessions(workspaceId: string) {
   return useQuery<SessionInfo[]>({
@@ -58,17 +52,6 @@ export function useSessionView(workspaceId: string, sessionId: string | null) {
     enabled: Boolean(sessionId),
     staleTime: Infinity,
     gcTime: 5 * 60_000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false
-  })
-}
-
-export function useWorkspaceModels(workspaceId: string) {
-  return useQuery<WorkspaceModels>({
-    queryKey: workspaceKeys.models(workspaceId),
-    queryFn: () => requestJson(`/api/workspaces/${workspaceId}/models`),
-    staleTime: Infinity,
-    gcTime: Infinity,
     refetchOnMount: false,
     refetchOnWindowFocus: false
   })

--- a/client/features/chat/chat-send.test.ts
+++ b/client/features/chat/chat-send.test.ts
@@ -11,7 +11,7 @@ import {
   startOptimisticTurn
 } from '@/client/features/chat/chat-send'
 import { attachmentKey, type ChatAttachment, liveStore } from '@/client/features/chat/chat-store'
-import type { SessionInfo, ViewState, WorkspaceModels } from '@/lib/types'
+import type { SessionInfo, ViewState, WorkspaceAgent } from '@/lib/types'
 
 const workspaceId = 'workspace-1'
 const sessionId = 'session-1'
@@ -74,8 +74,9 @@ describe('startOptimisticSession', () => {
 })
 
 describe('resolveChatRunOptions', () => {
-  const models: WorkspaceModels = {
+  const models: WorkspaceAgent = {
     provider: 'claude-code',
+    availability: { available: true },
     supportsStreaming: true,
     models: [
       {

--- a/client/features/chat/chat-send.ts
+++ b/client/features/chat/chat-send.ts
@@ -6,7 +6,7 @@ import type { MoiUserMessageOptions } from '@/client/features/workspace/moi-cont
 import { STREAM_RESPONSES } from '@/client/lib/flags'
 import { formatChatTitle } from '@/lib/chat-title'
 import { applyEvent, emptyViewState } from '@/lib/format'
-import type { Part, SessionInfo, ViewState, WorkspaceModels } from '@/lib/types'
+import type { Part, SessionInfo, ViewState, WorkspaceAgent } from '@/lib/types'
 
 // What a caller may attach to one message beyond its text. All of it is
 // envelope material — the agent sees it, the chat bubble does not.
@@ -87,7 +87,7 @@ export function startOptimisticSession({
 }
 
 export function resolveChatRunOptions(
-  modelsData: WorkspaceModels | undefined,
+  modelsData: WorkspaceAgent | undefined,
   pickedModel: string | undefined,
   pickedEffort: string | undefined,
   pickedFastMode?: boolean

--- a/client/features/chat/composer/banners/WorkspaceAgentAvailabilityBanner.test.tsx
+++ b/client/features/chat/composer/banners/WorkspaceAgentAvailabilityBanner.test.tsx
@@ -19,3 +19,37 @@ test('offers login when the agent supports it', () => {
   expect(html).toContain('Log in to your agent provider to send messages')
   expect(html).toContain('>Log in</button>')
 })
+
+test('shows the shared ceremony state while a login is pending', () => {
+  const html = renderToStaticMarkup(
+    createElement(WorkspaceAgentAvailabilityBanner, {
+      availability: {
+        available: false,
+        reason: 'Codex is signed out. Sign in to send messages',
+        loginCommand: 'codex login'
+      },
+      login: { state: 'pending', url: 'https://example.com/login' },
+      onStartLogin: async () => ({})
+    })
+  )
+
+  expect(html).toContain('Waiting for log in…')
+  expect(html).toContain('disabled')
+})
+
+test('surfaces a failed ceremony and offers login again', () => {
+  const html = renderToStaticMarkup(
+    createElement(WorkspaceAgentAvailabilityBanner, {
+      availability: {
+        available: false,
+        reason: 'Codex is signed out. Sign in to send messages',
+        loginCommand: 'codex login'
+      },
+      login: { state: 'failed', reason: 'Sign-in did not complete. Try again' },
+      onStartLogin: async () => ({})
+    })
+  )
+
+  expect(html).toContain('Sign-in did not complete. Try again')
+  expect(html).toContain('>Log in</button>')
+})

--- a/client/features/chat/composer/banners/WorkspaceAgentAvailabilityBanner.tsx
+++ b/client/features/chat/composer/banners/WorkspaceAgentAvailabilityBanner.tsx
@@ -1,41 +1,58 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { IconLoader2, IconLogin } from '@tabler/icons-react'
 
 import { Button } from '@/client/components/ui/button'
-import type { HarnessAvailability, HarnessLogin } from '@/lib/types'
+import type { AgentLoginState, HarnessAvailability, HarnessLogin } from '@/lib/types'
 
 import { ComposerBannerShell } from './ComposerBanner'
 
 type WorkspaceAgentAvailabilityBannerProps = {
   availability: Extract<HarnessAvailability, { available: false }>
+  // The server-owned ceremony. `pending` means some tab (maybe this one)
+  // started a login and the server is watching for it to land; `failed` means
+  // the last ceremony timed out or errored.
+  login?: AgentLoginState
   onStartLogin: () => Promise<HarnessLogin>
 }
 
 export function WorkspaceAgentAvailabilityBanner({
   availability,
+  login,
   onStartLogin
 }: WorkspaceAgentAvailabilityBannerProps) {
-  const [state, setState] = useState<'idle' | 'starting' | 'waiting'>('idle')
+  // Local phase only bridges the gap between the POST resolving and the
+  // server's `agent:updated` event landing; the ceremony state is the truth.
+  const [phase, setPhase] = useState<'idle' | 'starting' | 'waiting'>('idle')
   const [error, setError] = useState<string | null>(null)
+
+  // A settled ceremony (failed, or replaced by a fresh signed-out state)
+  // re-enables the button.
+  useEffect(() => {
+    if (login?.state !== 'pending') setPhase('idle')
+  }, [login?.state])
+
+  const waiting = login?.state === 'pending' || phase === 'waiting'
+  const failure = login?.state === 'failed' ? login.reason : null
+  const busy = waiting || phase === 'starting'
 
   const startLogin = async () => {
     const authWindow = window.open('about:blank', 'moi-agent-login')
     if (authWindow) authWindow.opener = null
-    setState('starting')
+    setPhase('starting')
     setError(null)
     try {
-      const login = await onStartLogin()
-      if (login.url) {
+      const result = await onStartLogin()
+      if (result.url) {
         if (!authWindow) throw new Error('Allow pop-ups, then try again')
-        authWindow.location.href = login.url
+        authWindow.location.href = result.url
       } else {
         authWindow?.close()
       }
-      setState('waiting')
+      setPhase('waiting')
     } catch (err) {
       authWindow?.close()
-      setState('idle')
+      setPhase('idle')
       setError(err instanceof Error ? err.message : 'Could not start sign-in')
     }
   }
@@ -48,7 +65,9 @@ export function WorkspaceAgentAvailabilityBanner({
       <IconLogin size={20} stroke={1.5} />
       <div className="min-w-0 space-y-1">
         <div className="wrap-break-word">Log in to your agent provider to send messages</div>
-        {error && <div className="wrap-break-word text-destructive">{error}</div>}
+        {(error ?? failure) && (
+          <div className="wrap-break-word text-destructive">{error ?? failure}</div>
+        )}
       </div>
 
       {availability.loginCommand && (
@@ -56,13 +75,13 @@ export function WorkspaceAgentAvailabilityBanner({
           type="button"
           size="sm"
           onClick={() => void startLogin()}
-          disabled={state !== 'idle'}
+          disabled={busy}
           className="col-span-2 w-fit @xl:col-span-1"
         >
-          {state !== 'idle' && <IconLoader2 stroke={1.75} className="animate-spin" />}
-          {state === 'starting'
+          {busy && <IconLoader2 stroke={1.75} className="animate-spin" />}
+          {phase === 'starting'
             ? 'Opening browser to sign in…'
-            : state === 'waiting'
+            : waiting
               ? 'Waiting for log in…'
               : 'Log in'}
         </Button>

--- a/client/features/chat/composer/useWorkspaceComposerState.tsx
+++ b/client/features/chat/composer/useWorkspaceComposerState.tsx
@@ -1,5 +1,5 @@
 import type { ComposerAvailability } from '@/client/components/shared/Composer'
-import { startWorkspaceLogin, useWorkspaceAvailability } from '@/client/features/workspace/api'
+import { startWorkspaceLogin, useWorkspaceAgent } from '@/client/features/workspace/api'
 
 import { ChatErrorBanner } from './banners/ChatErrorBanner'
 import { resolveComposerBanner, type ComposerBanner } from './banners/ComposerBanner'
@@ -21,7 +21,8 @@ export function useWorkspaceComposerState(
   workspaceId: string,
   { chatError, onDismissChatError }: WorkspaceComposerStateOptions
 ): WorkspaceComposerState {
-  const { data: availability, error } = useWorkspaceAvailability(workspaceId)
+  const { data: agent, error } = useWorkspaceAgent(workspaceId)
+  const availability = agent?.availability
   const { bannerProps: skillUpdateBanner } = useWorkspaceSkillUpdates(workspaceId)
 
   let unavailable = availability?.available === false ? availability : undefined
@@ -45,6 +46,7 @@ export function useWorkspaceComposerState(
         content: (
           <WorkspaceAgentAvailabilityBanner
             availability={unavailable}
+            login={agent?.login}
             onStartLogin={() => startWorkspaceLogin(workspaceId)}
           />
         )

--- a/client/features/chat/useChat.ts
+++ b/client/features/chat/useChat.ts
@@ -3,12 +3,8 @@ import { useCallback, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { workspaceKeys } from '@/client/api/workspace-keys'
-import {
-  useSessionConfig,
-  useSessionView,
-  useWorkspaceModels,
-  useWorkspaceSessions
-} from '@/client/features/chat/api'
+import { useSessionConfig, useSessionView, useWorkspaceSessions } from '@/client/features/chat/api'
+import { useWorkspaceAgent } from '@/client/features/workspace/api'
 import { useSelectedSession } from '@/client/features/chat/useSelectedSession'
 import {
   type WorkspaceTabAddress,
@@ -51,7 +47,7 @@ export function useChat(address: WorkspaceTabAddress) {
   const { layout } = useWorkspaceLayoutCtx()
   const [selectedSession, selectSession] = useSelectedSession()
   const selectedSessionId = selectedSession ?? null
-  const modelsData = useWorkspaceModels(workspaceId).data
+  const modelsData = useWorkspaceAgent(workspaceId).data
   const sessions = useWorkspaceSessions(workspaceId).data
   // Snapshot of the workspace's ambient UI state + queued one-shot
   // directives, taken when the message actually goes out.

--- a/client/features/dev/HarnessDebugPage.tsx
+++ b/client/features/dev/HarnessDebugPage.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'wouter'
 import { Button } from '@/client/components/ui/button'
 import { cn } from '@/client/lib/cn'
 import { wsUrl } from '@/client/lib/ws-url'
-import type { Model, WorkspaceEntry, WorkspaceModels } from '@/lib/types'
+import type { Model, WorkspaceAgent, WorkspaceEntry } from '@/lib/types'
 
 // Scratch route for driving any harness end to end: pick a workspace, fire
 // canned scenarios (or your own prompt), and watch three synchronized logs —
@@ -235,9 +235,9 @@ export function HarnessDebugPage() {
   // Model list for the selected workspace.
   useEffect(() => {
     if (!workspaceId) return
-    fetch(`/api/workspaces/${workspaceId}/models`)
+    fetch(`/api/workspaces/${workspaceId}/agent`)
       .then(r => r.json())
-      .then((m: WorkspaceModels) => setModels(m.models))
+      .then((m: WorkspaceAgent) => setModels(m.models))
       .catch(() => setModels([]))
   }, [workspaceId])
 

--- a/client/features/views/useViewBuilderActions.ts
+++ b/client/features/views/useViewBuilderActions.ts
@@ -1,9 +1,9 @@
 import { useQueryClient } from '@tanstack/react-query'
 
-import { useWorkspaceModels } from '@/client/features/chat/api'
 import { resolveChatRunOptions, startOptimisticTurn } from '@/client/features/chat/chat-send'
 import { liveStore } from '@/client/features/chat/chat-store'
 import { useSelectedSession } from '@/client/features/chat/useSelectedSession'
+import { useWorkspaceAgent } from '@/client/features/workspace/api'
 import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
 import {
   useCreateViewBuilder,
@@ -17,7 +17,7 @@ export function useViewBuilderActions() {
   const queryClient = useQueryClient()
   const { workspaceId, layout } = useWorkspaceLayoutCtx()
   const [, selectSession] = useSelectedSession()
-  const modelData = useWorkspaceModels(workspaceId).data
+  const modelData = useWorkspaceAgent(workspaceId).data
   const createMutation = useCreateViewBuilder(workspaceId)
   const saveMutation = useSaveViewBuilder(workspaceId)
   const submitMutation = useSubmitViewBuilder(workspaceId)

--- a/client/features/workspace/api.ts
+++ b/client/features/workspace/api.ts
@@ -3,11 +3,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
 import { WORKSPACE_RESOURCE_OPTIONS } from '@/client/api/query-options'
 import { workspaceKeys } from '@/client/api/workspace-keys'
+import { useWorkspaceEvent } from '@/client/runtime/useWorkspaceEvents'
 import type {
-  HarnessAvailability,
   HarnessLogin,
   ViewInfo,
   WidgetInfo,
+  WorkspaceAgent,
   WorkspaceLayout,
   WorkspaceSkillsStatus,
   WorkspaceSkillsUpdateFailure,
@@ -29,17 +30,29 @@ export function useWorkspaceLayout(workspaceId: string) {
   })
 }
 
-// Is the workspace's agent executable installed? Drives the Send button's
-// disabled state and tooltip. Refetches on window focus so installing the
-// missing runtime and returning to the tab unlocks the composer.
-export function useWorkspaceAvailability(workspaceId: string) {
-  return useQuery<HarnessAvailability>({
-    queryKey: workspaceKeys.availability(workspaceId),
-    queryFn: () => requestJson(`/api/workspaces/${workspaceId}/availability`),
+// The workspace's agent backend in one snapshot: availability (runtime
+// presence + auth), any in-flight login ceremony, the model catalog, and
+// capabilities. Fetched once at workspace open; afterwards the volatile parts
+// (`availability`, `login`) are patched in place by `agent:updated` events —
+// the server owns the login watch loop, so the client never polls. Focus
+// refetch stays as a cheap safety net (the server serves its cache).
+export function useWorkspaceAgent(workspaceId: string) {
+  const queryClient = useQueryClient()
+  useWorkspaceEvent(event => {
+    if (event.type === 'agent:updated' && event.workspaceId === workspaceId) {
+      queryClient.setQueryData<WorkspaceAgent>(workspaceKeys.agent(workspaceId), prev =>
+        prev ? { ...prev, availability: event.availability, login: event.login } : prev
+      )
+    }
+    // Env can swap credentials; the server dropped its cache — refetch.
+    if (event.type === 'env:updated' && event.workspaceId === workspaceId) {
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.agent(workspaceId) })
+    }
+  })
+  return useQuery<WorkspaceAgent>({
+    queryKey: workspaceKeys.agent(workspaceId),
+    queryFn: () => requestJson(`/api/workspaces/${workspaceId}/agent`),
     staleTime: 30_000,
-    // Poll only while signed out so a completed browser login unlocks Send.
-    refetchInterval: query =>
-      query.state.data?.available === false && query.state.data.loginCommand ? 2_000 : false,
     refetchOnWindowFocus: true
   })
 }

--- a/client/runtime/useWorkspaceEvents.ts
+++ b/client/runtime/useWorkspaceEvents.ts
@@ -1,7 +1,15 @@
 import { useEffect, useRef } from 'react'
 
 import { wsUrl } from '@/client/lib/ws-url'
-import type { AppSettings, ViewBuilder, ViewInfo, WidgetInfo, WorkspaceTabId } from '@/lib/types'
+import type {
+  AgentLoginState,
+  AppSettings,
+  HarnessAvailability,
+  ViewBuilder,
+  ViewInfo,
+  WidgetInfo,
+  WorkspaceTabId
+} from '@/lib/types'
 
 export type WorkspaceEvent =
   | { type: 'widget:updated'; name: string }
@@ -21,6 +29,15 @@ export type WorkspaceEvent =
   | { type: 'workspaces-list:updated' }
   // A workspace's env changed outside the UI — refetch the env view.
   | { type: 'env:updated'; workspaceId: string }
+  // The agent backend's availability or login ceremony changed (login landed,
+  // ceremony timed out, auth probe flipped). Carries the new state so caches
+  // patch without a refetch.
+  | {
+      type: 'agent:updated'
+      workspaceId: string
+      availability: HarnessAvailability
+      login?: AgentLoginState
+    }
   // The Scratchpad canvas for `workspaceId` was saved — open tabs reload from
   // disk. `origin` is the tab that wrote it, so that tab can skip its own echo.
   | { type: 'scratchpad:updated'; workspaceId: string; origin?: string }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -401,6 +401,14 @@ export type HarnessAvailability =
 // Codex returns a URL for the browser. Claude opens it from its own CLI.
 export type HarnessLogin = { url?: string }
 
+// The server-owned login ceremony, one per workspace. `pending` means a watch
+// loop is re-probing the provider until the login lands or the deadline
+// passes; transitions arrive as `agent:updated` events, so every tab shows
+// the same ceremony without polling.
+export type AgentLoginState =
+  | { state: 'pending'; url?: string }
+  | { state: 'failed'; reason: string }
+
 // One MCP server's connection status, as surfaced by GET /api/workspaces/:id/mcp
 // (a subset of the agent SDK's McpServerStatus — only what the UI renders).
 export type McpServerState = 'connected' | 'failed' | 'needs-auth' | 'pending' | 'disabled'
@@ -623,10 +631,19 @@ export type Model = {
   supportsAutoMode?: boolean
 }
 
-// GET /api/workspaces/:id/models payload.
-export type WorkspaceModels = {
-  // The agent backend that produced this list — matches the workspace provider.
+// GET /api/workspaces/:id/agent payload — everything the client needs to know
+// about the workspace's agent backend in one request at workspace open.
+// `models` and capabilities are stable per process; `availability` and `login`
+// are the volatile part, kept fresh after load by `agent:updated` events
+// instead of refetches.
+export type WorkspaceAgent = {
+  // The agent backend that produced this snapshot — matches the workspace
+  // provider.
   provider: WorkspaceType
+  // Runtime presence and provider auth state, from the server-side cache.
+  availability: HarnessAvailability
+  // Present while a login ceremony is in flight or after one failed.
+  login?: AgentLoginState
   models: Model[]
   // Whether this provider supports live token-by-token streaming (the picker
   // shows the "Live typing" toggle only when true). Provider-wide, not per-model

--- a/server/agent.test.ts
+++ b/server/agent.test.ts
@@ -1,0 +1,160 @@
+import { expect, test } from 'bun:test'
+
+import type { HarnessAvailability, WorkspaceEntry } from '@/lib/types'
+
+import type { AgentUpdatedEvent } from './agent'
+import { createAgentStore } from './agent'
+
+const ws: WorkspaceEntry = { id: 'w1', path: '/tmp/w1', addedAt: '2026-01-01T00:00:00.000Z' }
+
+const signedOut: HarnessAvailability = {
+  available: false,
+  reason: 'Signed out',
+  loginCommand: 'codex login'
+}
+
+async function until(cond: () => boolean, ms = 2_000) {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error('condition not met in time')
+    await Bun.sleep(5)
+  }
+}
+
+test('serves the cached availability within the TTL and re-probes after invalidate', async () => {
+  let probes = 0
+  const store = createAgentStore({
+    probe: async () => {
+      probes++
+      return { available: true }
+    },
+    startLogin: async () => ({}),
+    publish: () => {},
+    availabilityTtlMs: 60_000
+  })
+
+  expect(await store.getAvailability(ws)).toEqual({ available: true })
+  expect(await store.getAvailability(ws)).toEqual({ available: true })
+  expect(probes).toBe(1)
+
+  store.invalidate(ws.id)
+  expect(await store.getAvailability(ws)).toEqual({ available: true })
+  expect(probes).toBe(2)
+})
+
+test('concurrent reads share one in-flight probe', async () => {
+  let probes = 0
+  const store = createAgentStore({
+    probe: async () => {
+      probes++
+      await Bun.sleep(20)
+      return { available: true }
+    },
+    startLogin: async () => ({}),
+    publish: () => {}
+  })
+
+  const [a, b] = await Promise.all([store.getAvailability(ws), store.getAvailability(ws)])
+  expect(a).toEqual({ available: true })
+  expect(b).toEqual({ available: true })
+  expect(probes).toBe(1)
+})
+
+test('a second login start joins the pending ceremony', async () => {
+  let starts = 0
+  const store = createAgentStore({
+    probe: async () => signedOut,
+    startLogin: async () => {
+      starts++
+      return { url: 'https://example.com/login' }
+    },
+    publish: () => {},
+    loginPollMs: 10_000
+  })
+
+  const [first, second] = await Promise.all([store.startLogin(ws), store.startLogin(ws)])
+  const third = await store.startLogin(ws)
+  expect(first).toEqual({ url: 'https://example.com/login' })
+  expect(second).toEqual({ url: 'https://example.com/login' })
+  expect(third).toEqual({ url: 'https://example.com/login' })
+  expect(starts).toBe(1)
+  expect(store.getLogin(ws.id)).toEqual({ state: 'pending', url: 'https://example.com/login' })
+})
+
+test('publishes the completed login and clears the ceremony', async () => {
+  const events: AgentUpdatedEvent[] = []
+  let loggedIn = false
+  const store = createAgentStore({
+    probe: async () => (loggedIn ? { available: true } : signedOut),
+    startLogin: async () => ({ url: 'https://example.com/login' }),
+    publish: event => events.push(event),
+    availabilityTtlMs: 0,
+    loginPollMs: 10,
+    loginDeadlineMs: 60_000
+  })
+
+  await store.getAvailability(ws)
+  await store.startLogin(ws)
+  expect(events.at(-1)?.login).toEqual({ state: 'pending', url: 'https://example.com/login' })
+
+  loggedIn = true
+  await until(() => events.at(-1)?.availability.available === true)
+  expect(events.at(-1)?.login).toBeUndefined()
+  expect(store.getLogin(ws.id)).toBeUndefined()
+  expect(await store.getAvailability(ws)).toEqual({ available: true })
+})
+
+test('a ceremony that never lands fails at the deadline', async () => {
+  const events: AgentUpdatedEvent[] = []
+  const store = createAgentStore({
+    probe: async () => signedOut,
+    startLogin: async () => ({ url: 'https://example.com/login' }),
+    publish: event => events.push(event),
+    availabilityTtlMs: 0,
+    loginPollMs: 10,
+    loginDeadlineMs: 30
+  })
+
+  await store.startLogin(ws)
+  await until(() => store.getLogin(ws.id)?.state === 'failed')
+  expect(events.at(-1)?.login).toEqual({
+    state: 'failed',
+    reason: 'Sign-in did not complete. Try again'
+  })
+
+  // A failed ceremony does not block a fresh start.
+  let starts = 0
+  const restarted = createAgentStore({
+    probe: async () => signedOut,
+    startLogin: async () => {
+      starts++
+      return {}
+    },
+    publish: () => {},
+    loginPollMs: 10,
+    loginDeadlineMs: 30
+  })
+  await restarted.startLogin(ws)
+  await until(() => restarted.getLogin(ws.id)?.state === 'failed')
+  await restarted.startLogin(ws)
+  expect(starts).toBe(2)
+})
+
+test('a failed provider start clears the ceremony for retry', async () => {
+  let starts = 0
+  const store = createAgentStore({
+    probe: async () => signedOut,
+    startLogin: async () => {
+      starts++
+      if (starts === 1) throw new Error('Codex did not return a browser login URL')
+      return { url: 'https://example.com/retry' }
+    },
+    publish: () => {},
+    loginPollMs: 10_000
+  })
+
+  await expect(store.startLogin(ws)).rejects.toThrow('Codex did not return a browser login URL')
+  expect(store.getLogin(ws.id)).toBeUndefined()
+  expect(await store.startLogin(ws)).toEqual({ url: 'https://example.com/retry' })
+  expect(starts).toBe(2)
+})

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -1,0 +1,184 @@
+// Server-owned agent state: the availability cache and the login ceremony.
+//
+// The client never polls for auth. `GET /api/workspaces/:id/agent` serves the
+// snapshot from this store (one probe per workspace inside the TTL, however
+// many tabs are open); `POST .../auth/login` starts — or joins — the single
+// ceremony per workspace. While a ceremony is pending, a watch loop re-probes
+// the provider until the login lands or the deadline passes, and every
+// transition is pushed to all tabs as an `agent:updated` event on the
+// workspace events socket.
+import type {
+  AgentLoginState,
+  HarnessAvailability,
+  HarnessLogin,
+  WorkspaceEntry
+} from '@/lib/types'
+
+import { publishEvent } from './events'
+import { harnessFor } from './harness/registry'
+
+export type AgentUpdatedEvent = {
+  type: 'agent:updated'
+  workspaceId: string
+  availability: HarnessAvailability
+  login?: AgentLoginState
+}
+
+export type AgentStoreOptions = {
+  probe: (ws: WorkspaceEntry) => Promise<HarnessAvailability>
+  startLogin: (ws: WorkspaceEntry) => Promise<HarnessLogin>
+  publish: (event: AgentUpdatedEvent) => void
+  availabilityTtlMs?: number
+  loginPollMs?: number
+  loginDeadlineMs?: number
+}
+
+type LoginCeremony = {
+  state: AgentLoginState
+  // The in-flight provider call; joiners await it instead of starting a
+  // second flow. Cleared once settled.
+  starting?: Promise<HarnessLogin>
+  stop: () => void
+}
+
+type AgentEntry = {
+  cached?: { value: HarnessAvailability; checkedAt: number }
+  // In-flight probe, shared by concurrent callers.
+  probe?: Promise<HarnessAvailability>
+  login?: LoginCeremony
+}
+
+export function createAgentStore(options: AgentStoreOptions) {
+  const ttlMs = options.availabilityTtlMs ?? 30_000
+  const pollMs = options.loginPollMs ?? 2_000
+  const deadlineMs = options.loginDeadlineMs ?? 3 * 60_000
+  const entries = new Map<string, AgentEntry>()
+
+  function entryFor(workspaceId: string): AgentEntry {
+    let entry = entries.get(workspaceId)
+    if (!entry) {
+      entry = {}
+      entries.set(workspaceId, entry)
+    }
+    return entry
+  }
+
+  function publish(workspaceId: string, availability: HarnessAvailability) {
+    const login = entries.get(workspaceId)?.login?.state
+    options.publish({
+      type: 'agent:updated',
+      workspaceId,
+      availability,
+      ...(login ? { login } : {})
+    })
+  }
+
+  async function probeFresh(ws: WorkspaceEntry): Promise<HarnessAvailability> {
+    const entry = entryFor(ws.id)
+    if (!entry.probe) {
+      entry.probe = options.probe(ws).finally(() => {
+        entry.probe = undefined
+      })
+    }
+    const value = await entry.probe
+    entry.cached = { value, checkedAt: Date.now() }
+    return value
+  }
+
+  async function getAvailability(ws: WorkspaceEntry): Promise<HarnessAvailability> {
+    const entry = entryFor(ws.id)
+    if (entry.cached && Date.now() - entry.cached.checkedAt < ttlMs) {
+      return entry.cached.value
+    }
+    return probeFresh(ws)
+  }
+
+  function getLogin(workspaceId: string): AgentLoginState | undefined {
+    return entries.get(workspaceId)?.login?.state
+  }
+
+  // Re-probe until the login lands or the deadline passes. One loop per
+  // ceremony; a replaced or completed ceremony stops its loop.
+  function watch(ws: WorkspaceEntry, login: LoginCeremony) {
+    const deadline = Date.now() + deadlineMs
+    let stopped = false
+    let timer: ReturnType<typeof setTimeout>
+    login.stop = () => {
+      stopped = true
+      clearTimeout(timer)
+    }
+    const tick = async () => {
+      let value: HarnessAvailability
+      try {
+        value = await probeFresh(ws)
+      } catch {
+        value = { available: false, reason: 'Could not verify the login' }
+      }
+      if (stopped) return
+      const entry = entryFor(ws.id)
+      if (value.available) {
+        entry.login = undefined
+        publish(ws.id, value)
+        return
+      }
+      if (Date.now() >= deadline) {
+        // Keep the failed state so the composer can show it; the next
+        // startLogin replaces it.
+        login.state = { state: 'failed', reason: 'Sign-in did not complete. Try again' }
+        publish(ws.id, value)
+        return
+      }
+      timer = setTimeout(tick, pollMs)
+      timer.unref?.()
+    }
+    // Unref'd so a pending ceremony never keeps the process alive on its own.
+    timer = setTimeout(tick, pollMs)
+    timer.unref?.()
+  }
+
+  async function startLogin(ws: WorkspaceEntry): Promise<HarnessLogin> {
+    const entry = entryFor(ws.id)
+    // Join the in-flight ceremony instead of starting a second provider flow
+    // (two tabs, a remount, a double-click — all land here).
+    const current = entry.login
+    if (current?.starting) return current.starting
+    if (current?.state.state === 'pending') return { url: current.state.url }
+
+    current?.stop()
+    const starting = options.startLogin(ws)
+    const login: LoginCeremony = { state: { state: 'pending' }, starting, stop: () => {} }
+    entry.login = login
+    try {
+      const result = await starting
+      login.starting = undefined
+      login.state = { state: 'pending', ...(result.url ? { url: result.url } : {}) }
+      publish(ws.id, entry.cached?.value ?? { available: false, reason: 'Waiting for sign-in' })
+      watch(ws, login)
+      return result
+    } catch (err) {
+      entry.login = undefined
+      throw err
+    }
+  }
+
+  // Drop the cached snapshot so the next read re-probes (e.g. after an env
+  // change swaps credentials).
+  function invalidate(workspaceId: string) {
+    const entry = entries.get(workspaceId)
+    if (entry) entry.cached = undefined
+  }
+
+  return { getAvailability, getLogin, startLogin, invalidate }
+}
+
+export type AgentStore = ReturnType<typeof createAgentStore>
+
+export const agentStore = createAgentStore({
+  probe: async ws => (await harnessFor(ws).availability?.(ws)) ?? { available: true },
+  startLogin: ws => {
+    const start = harnessFor(ws).startLogin
+    if (!start) throw new Error('This agent requires terminal sign-in')
+    return start(ws)
+  },
+  publish: publishEvent
+})

--- a/server/api-archive.test.ts
+++ b/server/api-archive.test.ts
@@ -23,6 +23,8 @@ const originalClaudeInterrupt = claudeCodeHarness.interrupt
 const originalClaudeArchive = claudeCodeHarness.archiveSession
 const originalClaudeListModels = claudeCodeHarness.listModels
 const originalCodexListModels = codexHarness.listModels
+const originalClaudeAvailability = claudeCodeHarness.availability
+const originalCodexAvailability = codexHarness.availability
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), 'moi-api-archive-'))
@@ -35,6 +37,8 @@ afterEach(async () => {
   claudeCodeHarness.archiveSession = originalClaudeArchive
   claudeCodeHarness.listModels = originalClaudeListModels
   codexHarness.listModels = originalCodexListModels
+  claudeCodeHarness.availability = originalClaudeAvailability
+  codexHarness.availability = originalCodexAvailability
   setRegistryPath(DEFAULT_REGISTRY_PATH)
   setSelectedSessionPath(DEFAULT_SELECTED_SESSION_PATH)
   await rm(tempDir, { recursive: true, force: true })
@@ -113,14 +117,16 @@ test('archive support is provider-specific', async () => {
   const openclaw = await registerWorkspace(join(tempDir, 'openclaw'), { type: 'openclaw' })
   claudeCodeHarness.listModels = async () => []
   codexHarness.listModels = async () => []
+  claudeCodeHarness.availability = async () => ({ available: true })
+  codexHarness.availability = async () => ({ available: true })
 
-  const [claudeModels, codexModels, openclawArchive] = await Promise.all([
-    api.request(`/api/workspaces/${claude.id}/models`),
-    api.request(`/api/workspaces/${codex.id}/models`),
+  const [claudeAgent, codexAgent, openclawArchive] = await Promise.all([
+    api.request(`/api/workspaces/${claude.id}/agent`),
+    api.request(`/api/workspaces/${codex.id}/agent`),
     api.request(`/api/workspaces/${openclaw.id}/sessions/chat/archive`, { method: 'POST' })
   ])
 
-  expect((await claudeModels.json()).supportsArchiving).toBe(true)
-  expect((await codexModels.json()).supportsArchiving).toBe(true)
+  expect((await claudeAgent.json()).supportsArchiving).toBe(true)
+  expect((await codexAgent.json()).supportsArchiving).toBe(true)
   expect(openclawArchive.status).toBe(501)
 })

--- a/server/api-import.test.ts
+++ b/server/api-import.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import type { WorkspaceEntry } from '@/lib/types'
+import type { WorkspaceAgent, WorkspaceEntry } from '@/lib/types'
 
 import { api } from './api'
 import { claudeCodeHarness } from './harness/claude-code'
@@ -14,18 +14,25 @@ let tempDir: string
 const originalClaudeAvailability = claudeCodeHarness.availability
 const originalCodexAvailability = codexHarness.availability
 const originalCodexStartLogin = codexHarness.startLogin
+const originalClaudeListModels = claudeCodeHarness.listModels
+const originalCodexListModels = codexHarness.listModels
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), 'moi-api-import-'))
   setRegistryPath(join(tempDir, 'workspaces.json'))
   claudeCodeHarness.availability = async () => ({ available: true })
   codexHarness.availability = async () => ({ available: true })
+  // /agent bundles the model catalog; keep the probe out of these tests.
+  claudeCodeHarness.listModels = async () => []
+  codexHarness.listModels = async () => []
 })
 
 afterEach(async () => {
   claudeCodeHarness.availability = originalClaudeAvailability
   codexHarness.availability = originalCodexAvailability
   codexHarness.startLogin = originalCodexStartLogin
+  claudeCodeHarness.listModels = originalClaudeListModels
+  codexHarness.listModels = originalCodexListModels
   setRegistryPath(DEFAULT_REGISTRY_PATH)
   await rm(tempDir, { recursive: true, force: true })
 })
@@ -104,10 +111,12 @@ describe('workspace import provider', () => {
     harness.availability = async () => ({ available: false, reason })
     const entry = await registerWorkspace(join(tempDir, type), { type })
 
-    const response = await api.request(`/api/workspaces/${entry.id}/availability`)
+    const response = await api.request(`/api/workspaces/${entry.id}/agent`)
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ available: false, reason })
+    const agent = (await response.json()) as WorkspaceAgent
+    expect(agent.provider).toBe(type)
+    expect(agent.availability).toEqual({ available: false, reason })
   })
 
   test('reports a signed-out workspace and starts its login', async () => {
@@ -122,8 +131,8 @@ describe('workspace import provider', () => {
     codexHarness.startLogin = async () => ({ url: 'https://example.com/login' })
     const entry = await registerWorkspace(join(tempDir, 'codex-login'), { type: 'codex' })
 
-    const availability = await api.request(`/api/workspaces/${entry.id}/availability`)
-    expect(await availability.json()).toEqual({
+    const response = await api.request(`/api/workspaces/${entry.id}/agent`)
+    expect(((await response.json()) as WorkspaceAgent).availability).toEqual({
       available: false,
       reason: 'Codex is signed out. Sign in to send messages',
       loginCommand: 'codex login'
@@ -131,5 +140,15 @@ describe('workspace import provider', () => {
 
     const login = await api.request(`/api/workspaces/${entry.id}/auth/login`, { method: 'POST' })
     expect(await login.json()).toEqual({ url: 'https://example.com/login' })
+
+    // A second start joins the pending ceremony instead of opening another
+    // provider flow, and the agent snapshot reports it.
+    const rejoin = await api.request(`/api/workspaces/${entry.id}/auth/login`, { method: 'POST' })
+    expect(await rejoin.json()).toEqual({ url: 'https://example.com/login' })
+    const pending = await api.request(`/api/workspaces/${entry.id}/agent`)
+    expect(((await pending.json()) as WorkspaceAgent).login).toEqual({
+      state: 'pending',
+      url: 'https://example.com/login'
+    })
   })
 })

--- a/server/api.ts
+++ b/server/api.ts
@@ -11,13 +11,14 @@ import type {
   SessionInfo,
   UploadInfo,
   ViewBuilderInput,
+  WorkspaceAgent,
   WorkspaceEntry,
-  WorkspaceModels,
   WorkspaceType
 } from '@/lib/types'
 import type { MoiContext } from '@/lib/moi-context'
 import { viewBuilderDirectives } from '@/lib/view-builder-directives'
 
+import { agentStore } from './agent'
 import { getAppSettings, pickAppSettingsPatch, saveAppSettings } from './app-settings'
 import { appletForModule, recordAppletError } from './applet-log'
 import { apiBaseFor, parseAppletTail, serveWorkspaceFile } from './applets'
@@ -638,23 +639,15 @@ one.put('/env', async c => {
   return c.json(await getWorkspaceEnvView(ws.path, requiredEnvFor(ws.path)))
 })
 
-// Is the workspace's agent backend usable right now? This covers both runtime
-// presence and provider state such as authentication. The chat surfaces the
-// recovery state before the first send can fail cold.
-one.get('/availability', async c => {
-  const ws = c.get('ws')
-  const availability = (await harnessFor(ws).availability?.(ws)) ?? { available: true as const }
-  return c.json(availability satisfies HarnessAvailability)
-})
-
 // Start a provider login ceremony. Codex returns a browser OAuth URL for the
 // host to open; Claude launches its browser flow through the CLI itself.
+// Idempotent per workspace: a second call joins the pending ceremony instead
+// of starting another provider flow. Completion is pushed as `agent:updated`.
 one.post('/auth/login', async c => {
   const ws = c.get('ws')
-  const startLogin = harnessFor(ws).startLogin
-  if (!startLogin) return c.text('This agent requires terminal sign-in', 409)
+  if (!harnessFor(ws).startLogin) return c.text('This agent requires terminal sign-in', 409)
   try {
-    return c.json(await startLogin(ws))
+    return c.json(await agentStore.startLogin(ws))
   } catch (err) {
     return c.text(err instanceof Error ? err.message : 'Could not start sign-in', 500)
   }
@@ -671,25 +664,33 @@ one.post('/skills/update', async c => {
   return c.json(result.status)
 })
 
-// Models the workspace's agent backend can run, normalized across providers.
-// OpenClaw queries the gateway catalog; everything else (Claude Code) reads the
-// account-wide Agent SDK model list.
-one.get('/models', async c => {
+// The workspace's agent backend in one snapshot: provider, availability
+// (runtime presence + auth, from the server-side cache), any in-flight login
+// ceremony, the model catalog, and capabilities. One request at workspace
+// open; the volatile parts stay fresh afterwards via `agent:updated` events,
+// not refetches.
+one.get('/agent', async c => {
   const ws = c.get('ws')
   const harness = harnessFor(ws)
   // A backend that can't answer (codex CLI missing, gateway down) degrades to
   // an empty catalog — the picker hides and chat surfaces the real problem via
   // the availability banner, instead of this endpoint 500ing on page load.
-  const models = await harness.listModels(ws).catch(err => {
-    console.error(`[api] listModels failed for ${harness.id}`, err)
-    return []
-  })
+  const [availability, models] = await Promise.all([
+    agentStore.getAvailability(ws),
+    harness.listModels(ws).catch(err => {
+      console.error(`[api] listModels failed for ${harness.id}`, err)
+      return []
+    })
+  ])
+  const login = agentStore.getLogin(ws.id)
   return c.json({
     provider: harness.id,
+    availability,
+    ...(login ? { login } : {}),
     models,
     supportsStreaming: harness.capabilities.supportsStreaming,
     supportsArchiving: Boolean(harness.archiveSession)
-  } satisfies WorkspaceModels)
+  } satisfies WorkspaceAgent)
 })
 
 // Workspace identity (name). GET returns the current {name, icon}; PUT a JSON

--- a/server/env-apply.ts
+++ b/server/env-apply.ts
@@ -3,6 +3,7 @@
 // relayed over the control port — the workspace's processes must be reaped and
 // every connected client told to refetch. Both entry points call this so the
 // side effects can never drift apart.
+import { agentStore } from './agent'
 import { publishEvent } from './events'
 import { restartWorker } from './functions'
 import { allHarnesses } from './harness/registry'
@@ -12,5 +13,8 @@ export function applyEnvChanged(workspace: { id: string; path: string }): void {
   // down idle agent sessions (busy ones keep their snapshot until turn end).
   restartWorker(workspace.path)
   for (const h of allHarnesses()) h.onEnvChanged?.(workspace.path)
+  // Env can carry credentials (ANTHROPIC_API_KEY, provider config) — drop the
+  // cached availability so the next agent snapshot re-probes.
+  agentStore.invalidate(workspace.id)
   publishEvent({ type: 'env:updated', workspaceId: workspace.id })
 }

--- a/server/harness/README.md
+++ b/server/harness/README.md
@@ -152,8 +152,12 @@ Workspace availability also checks provider authentication when a workspace is
 given. Claude Code is probed with `claude auth status` under the effective
 workspace env; `claude auth login` launches its browser sign-in from the composer. Codex
 uses app-server `account/read` and returns a browser OAuth URL through
-`account/login/start`. The composer polls while it is signed out and keeps each
-provider's Sign in action available.
+`account/login/start`. The server owns the recovery loop (`server/agent.ts`):
+`GET /api/workspaces/:id/agent` serves a cached availability snapshot alongside
+the model catalog, `POST .../auth/login` starts (or joins) the one ceremony per
+workspace, and a server-side watch loop re-probes until the login lands or times
+out, pushing `agent:updated` events to every tab. The composer renders that
+state; it never polls.
 
 ## What a harness adapter must support
 
@@ -229,8 +233,9 @@ doubles as the evaluation rubric for new harnesses.
 - Compaction trigger/observe.
 - Queued-message semantics: does the backend queue natively or must the
   server?
-- Push health/auth status events (availability is currently probed on load, focus,
-  a one-minute interval, and before sends).
+- Push health/auth status events from the backend itself (the server watch
+  loop still discovers login completion by re-probing; a provider callback
+  would let `agent:updated` fire without polling anywhere).
 
 ## Capability comparison
 


### PR DESCRIPTION
Reworks #82's auth recovery per the architecture discussion there: the server now owns availability and the login ceremony, and the client stops polling entirely. One `GET /api/workspaces/:id/agent` request at workspace open replaces `/availability` + `/models`, and afterwards the volatile parts arrive as `agent:updated` pushes on the existing events socket — a completed login unlocks every tab at once, and a ceremony that never lands fails visibly after 3 minutes instead of spinning forever.

```jsonc
// GET /api/workspaces/:id/agent
{ "provider": "codex",
  "availability": { "available": false, "reason": "Codex is signed out…", "loginCommand": "codex login" },
  "login": { "state": "pending", "url": "https://auth.openai.com/…" },
  "models": [...], "supportsStreaming": true, "supportsArchiving": true }
// then, over /api/workspaces/ws:
{ "type": "agent:updated", "workspaceId": "…", "availability": { "available": true } }
```

The composer renders that server-owned ceremony instead of its own timer:

| Ceremony state | Composer banner |
| --- | --- |
| signed out | "Log in to your agent provider to send messages" · **Log in** |
| `pending` (in every open tab) | · **Waiting for log in…**, disabled |
| `failed` (deadline passed) | · "Sign-in did not complete. Try again" · **Log in** re-enabled |

`POST /auth/login` is now idempotent per workspace — a second tab joins the pending ceremony and gets the same OAuth URL instead of spawning a second `claude auth login` / `account/login/start`. Availability probes are cached server-side (30s TTL, in-flight dedup), so N open tabs no longer mean N subprocess spawns. Env changes drop the cache since credentials can arrive via `ANTHROPIC_API_KEY`.

Worth a close look:

- `server/agent.ts` — the ceremony watch loop: unref'd timers, replacement of a failed ceremony, and the completion path that clears `login` before publishing.
- `WorkspaceAgentAvailabilityBanner.tsx` — a local `phase` bridges the gap between the POST resolving and the `agent:updated` event landing; the `useEffect` reset on ceremony settle is what prevents a stuck "Waiting" button.
- `useWorkspaceAgent` drops `useWorkspaceModels`' `staleTime: Infinity` for 30s + focus refetch. Both model catalogs are cached process-wide server-side, but `getCodexModels` also issues an uncached `config/read` (service tier) on every call, so focus refetches now reach the Codex app-server.

Verified: `bun test` — 960 pass, 0 fail (6 new store tests, 2 new banner tests); `bun run lint`, `format:check`, `typecheck:client` clean. The three banner states above were driven in a real browser against a stubbed signed-out harness, with the `failed` row arriving as a server push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qjw2AS6bran9Vpni7U4f9