### PR TITLE
Dial the control server by IP so the CLI works without localhost

### DIFF
--- a/server/cli-env.ts
+++ b/server/cli-env.ts
@@ -9,7 +9,7 @@ import type { WorkspaceEntry, WorkspaceEnvView } from '@/lib/types'
 
 import pc from './cli-pc'
 import { columns } from './cli-ui'
-import { CONTROL_PORT } from './constants'
+import { CONTROL_URL } from './constants'
 import { findWorkspaceForPath, listWorkspaces } from './registry'
 import { discoverDotenvKeys, resolveWorkspaceEnv } from './workspace-env'
 
@@ -170,7 +170,7 @@ export function notifyEnvChanged(path: string): Promise<boolean> {
   return new Promise(resolve => {
     let ws: WebSocket
     try {
-      ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+      ws = new WebSocket(CONTROL_URL)
     } catch {
       resolve(false)
       return

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -40,7 +40,8 @@ import {
   resolveCwdWorkspace
 } from './cli-env'
 import { columns } from './cli-ui'
-import { CONTROL_PORT, PORT } from './constants'
+import { CONTROL_HOST, CONTROL_PORT, CONTROL_URL, PORT } from './constants'
+import { type ControlProbe, controlFailureMessage, probeControlServer } from './control-client'
 import { type OpenClawAgent, discoverOpenClawAgents } from './harness/openclaw/discovery'
 import { liftToWorkspaceRoot, registerWorkspace } from './registry'
 import { serverCwd } from './server-cwd'
@@ -83,22 +84,15 @@ import { provisionWorkspace } from './workspace-init'
 // ---- helpers ----------------------------------------------------------------
 
 async function isServerRunning(): Promise<boolean> {
-  return new Promise(resolve => {
-    const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
-    const timer = setTimeout(() => {
-      ws.close()
-      resolve(false)
-    }, 600)
-    ws.onopen = () => {
-      clearTimeout(timer)
-      ws.close()
-      resolve(true)
-    }
-    ws.onerror = () => {
-      clearTimeout(timer)
-      resolve(false)
-    }
-  })
+  return (await probeControlServer()).status === 'running'
+}
+
+// Print why the control socket could not be opened, then exit. Classifies the
+// failure first, so "no server is listening" and "the server is up but the
+// address is unreachable" no longer read as the same problem.
+async function exitControlUnreachable(): Promise<never> {
+  console.error(controlFailureMessage(await probeControlServer()))
+  process.exit(1)
 }
 
 async function waitForServer(timeoutMs = 10_000): Promise<boolean> {
@@ -112,7 +106,7 @@ async function waitForServer(timeoutMs = 10_000): Promise<boolean> {
 
 async function registerViaControl(absPath: string): Promise<string> {
   return new Promise((res, rej) => {
-    const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+    const ws = new WebSocket(CONTROL_URL)
     ws.onopen = () => ws.send(JSON.stringify({ type: 'workspace:register', path: absPath }))
     ws.onmessage = event => {
       const data = JSON.parse(String(event.data))
@@ -121,7 +115,7 @@ async function registerViaControl(absPath: string): Promise<string> {
         res(data.id)
       }
     }
-    ws.onerror = () => rej(new Error('Could not connect to control server'))
+    ws.onerror = () => void probeControlServer().then(p => rej(new Error(controlFailureMessage(p))))
   })
 }
 
@@ -486,7 +480,7 @@ const bundle = defineCommand({
     // Computed locally up front so it can ride along in the success output; the
     // agent reads this and knows to run `moi skill update`.
     const notice = await staleSkillNotice(path)
-    const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+    const ws = new WebSocket(CONTROL_URL)
 
     ws.onopen = () =>
       ws.send(
@@ -567,10 +561,7 @@ const bundle = defineCommand({
       process.exit(failed.length > 0 ? 1 : 0)
     }
 
-    ws.onerror = () => {
-      console.error('Could not connect to control server. Is the main process running?')
-      process.exit(1)
-    }
+    ws.onerror = () => void exitControlUnreachable()
   }
 })
 
@@ -594,7 +585,7 @@ const builderSet = defineCommand({
   },
   run({ args }) {
     const path = resolve(args.dir)
-    const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+    const ws = new WebSocket(CONTROL_URL)
     ws.onopen = () =>
       ws.send(
         JSON.stringify({
@@ -625,10 +616,7 @@ const builderSet = defineCommand({
       ws.close()
       process.exit(0)
     }
-    ws.onerror = () => {
-      console.error('Could not connect to control server. Is the main process running?')
-      process.exit(1)
-    }
+    ws.onerror = () => void exitControlUnreachable()
   }
 })
 
@@ -659,7 +647,7 @@ const refresh = defineCommand({
       process.exit(1)
     }
     const notice = await staleSkillNotice(process.cwd())
-    const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+    const ws = new WebSocket(CONTROL_URL)
 
     ws.onopen = () => ws.send(JSON.stringify({ type: 'applets:refresh', only: args.only }))
 
@@ -678,10 +666,7 @@ const refresh = defineCommand({
       process.exit(0)
     }
 
-    ws.onerror = () => {
-      console.error('Could not connect to control server. Is the main process running?')
-      process.exit(1)
-    }
+    ws.onerror = () => void exitControlUnreachable()
   }
 })
 
@@ -720,7 +705,7 @@ const theme = defineCommand({
   async run({ args }) {
     const path = resolve(args.dir)
     const notice = await staleSkillNotice(path)
-    const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+    const ws = new WebSocket(CONTROL_URL)
 
     ws.onopen = () =>
       ws.send(
@@ -834,10 +819,7 @@ const theme = defineCommand({
       process.exit(0)
     }
 
-    ws.onerror = () => {
-      console.error('Could not connect to control server. Is the main process running?')
-      process.exit(1)
-    }
+    ws.onerror = () => void exitControlUnreachable()
   }
 })
 
@@ -858,13 +840,22 @@ function versionMismatchNotice(serverVersion: string): string | null {
 const status = defineCommand({
   meta: { name: 'status', description: 'Show server status and registered workspaces' },
   async run() {
-    const running = await isServerRunning()
+    const probe: ControlProbe = await probeControlServer()
     const notice = await staleSkillNotice(process.cwd())
 
-    if (!running) {
+    if (probe.status === 'not-running') {
       console.log('\n' + pc.dim('○') + ' Server is ' + pc.bold('not running'))
       console.log(pc.dim(`  cli version ${VERSION}`) + '\n')
       process.exit(0)
+    }
+
+    // The dial failed for a reason other than an empty port, so the server may
+    // be up and healthy. Name the real obstacle instead of blaming the process.
+    if (probe.status === 'unreachable') {
+      console.log('\n' + pc.yellow('◆') + ' Server is ' + pc.bold('unreachable'))
+      console.log(pc.dim(`  control port ${CONTROL_HOST}:${CONTROL_PORT} — ${probe.reason}`))
+      console.log(pc.dim(`  cli version ${VERSION}`) + '\n')
+      process.exit(1)
     }
 
     const info = await queryServerInfo()
@@ -890,7 +881,7 @@ const status = defineCommand({
     if (mismatch) console.log('\n' + mismatch)
 
     await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+      const ws = new WebSocket(CONTROL_URL)
 
       ws.onopen = () => ws.send(JSON.stringify({ type: 'workspace:list' }))
 
@@ -904,7 +895,8 @@ const status = defineCommand({
         resolve()
       }
 
-      ws.onerror = () => reject(new Error('Could not connect to control server'))
+      ws.onerror = () =>
+        void probeControlServer().then(p => reject(new Error(controlFailureMessage(p))))
     })
 
     if (notice) console.log(pc.yellow(notice) + '\n')
@@ -1207,7 +1199,7 @@ async function sendConfig(payload: {
   clearIcon?: boolean
 }) {
   const notice = await staleSkillNotice(payload.path)
-  const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+  const ws = new WebSocket(CONTROL_URL)
   ws.onopen = () => ws.send(JSON.stringify({ type: 'config', ...payload }))
   ws.onmessage = event => {
     const res = JSON.parse(String(event.data))
@@ -1240,10 +1232,7 @@ async function sendConfig(payload: {
     ws.close()
     process.exit(0)
   }
-  ws.onerror = () => {
-    console.error('Could not connect to control server. Is the main process running?')
-    process.exit(1)
-  }
+  ws.onerror = () => void exitControlUnreachable()
 }
 
 // A terse cheat sheet — one line per command — so an agent can grasp the
@@ -1482,7 +1471,7 @@ function sendControl(
   payload: Record<string, unknown>,
   onResult: (res: Record<string, unknown>) => void | Promise<void>
 ) {
-  const ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+  const ws = new WebSocket(CONTROL_URL)
   ws.onopen = () => ws.send(JSON.stringify(payload))
   ws.onmessage = async event => {
     const res = JSON.parse(String(event.data))
@@ -1499,10 +1488,7 @@ function sendControl(
     ws.close()
     process.exit(0)
   }
-  ws.onerror = () => {
-    console.error('Could not connect to control server. Is the main process running?')
-    process.exit(1)
-  }
+  ws.onerror = () => void exitControlUnreachable()
 }
 
 function sendScratch(

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -1,3 +1,11 @@
 export const PORT = Number(process.env.PORT) || 13337
 // M=13, E=5, I=9 -> 13059
 export const CONTROL_PORT = 13059
+// The address the control server binds AND the one every client dials — never
+// the name `localhost`. Resolution of that name is not guaranteed: container
+// images ship an /etc/hosts without a `localhost` entry (Bun's resolver, unlike
+// glibc, does not special-case it), and where it does resolve it may prefer
+// ::1 while the control server listens on IPv4 only. Bind and dial read this
+// same constant so the two can never drift apart.
+export const CONTROL_HOST = '127.0.0.1'
+export const CONTROL_URL = `ws://${CONTROL_HOST}:${CONTROL_PORT}`

--- a/server/control-client.test.ts
+++ b/server/control-client.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, expect, test } from 'bun:test'
+
+import { CONTROL_HOST } from './constants'
+import { controlFailureMessage, probeControlServer } from './control-client'
+
+// A stand-in control server: same shape as `control.ts` (upgrade or 426), on an
+// ephemeral port so the test never collides with a real `moi start`.
+const server = Bun.serve({
+  port: 0,
+  hostname: CONTROL_HOST,
+  fetch: (req, s) =>
+    s.upgrade(req) ? new Response(null, { status: 101 }) : new Response('', { status: 426 }),
+  websocket: { message() {} }
+})
+
+afterAll(() => server.stop(true))
+
+test('reports a listening control server as running', async () => {
+  expect(await probeControlServer({ port: server.port })).toEqual({ status: 'running' })
+})
+
+test('reports an empty port as not-running, not as unreachable', async () => {
+  const free = Bun.serve({ port: 0, hostname: CONTROL_HOST, fetch: () => new Response('') })
+  const port = free.port
+  free.stop(true)
+
+  expect(await probeControlServer({ port })).toEqual({ status: 'not-running' })
+})
+
+test('an unresolvable host is unreachable, not "no server running"', async () => {
+  const probe = await probeControlServer({
+    host: 'moi-control-does-not-resolve.invalid',
+    port: server.port
+  })
+
+  expect(probe.status).toBe('unreachable')
+  if (probe.status !== 'unreachable') throw new Error('unreachable')
+  expect(probe.reason).toContain('could not resolve')
+})
+
+test('a port held by a non-WebSocket listener is unreachable', async () => {
+  const plain = Bun.serve({ port: 0, hostname: CONTROL_HOST, fetch: () => new Response('nope') })
+
+  const probe = await probeControlServer({ port: plain.port })
+  plain.stop(true)
+
+  expect(probe.status).toBe('unreachable')
+  if (probe.status !== 'unreachable') throw new Error('unreachable')
+  expect(probe.reason).toContain('another process may hold it')
+})
+
+test('failure messages distinguish an absent server from an unreachable one', () => {
+  expect(controlFailureMessage({ status: 'not-running' })).toContain('Is the main process running?')
+
+  const unreachable = controlFailureMessage({
+    status: 'unreachable',
+    reason: 'could not resolve "x"'
+  })
+  expect(unreachable).toContain('could not resolve "x"')
+  expect(unreachable).toContain('may still be running')
+})

--- a/server/control-client.ts
+++ b/server/control-client.ts
@@ -1,0 +1,124 @@
+import { connect } from 'node:net'
+
+import { CONTROL_HOST, CONTROL_PORT, CONTROL_URL } from './constants'
+
+// Why the CLI probes the control port instead of just asking "did the socket
+// open?": a failed dial has more than one cause, and they need different
+// answers. Nothing listening means the server is not running (`moi start`).
+// Anything else — the name or address not resolving, the host unreachable, a
+// stranger squatting on the port — means the server may well be running and
+// fine, and the fix is not to restart it. Bun's WebSocket collapses all of
+// these into a single "Failed to connect" error, so the classification is
+// recovered with a second probe at the TCP layer, where the real errno
+// survives (`node:net` reports it; `Bun.connect` reports ECONNREFUSED for
+// everything, so it cannot be used here).
+
+export type ControlProbe =
+  // A control socket opened — the server is up.
+  | { status: 'running' }
+  // Connection refused: the port is free, so no server is listening.
+  | { status: 'not-running' }
+  // Anything else. `reason` names the actual failure for the user.
+  | { status: 'unreachable'; reason: string }
+
+export type ControlProbeOptions = {
+  host?: string
+  port?: number
+  timeoutMs?: number
+}
+
+function closeQuietly(ws: WebSocket): void {
+  try {
+    ws.close()
+  } catch {}
+}
+
+// Re-dial the same address at the TCP layer to recover the errno the WebSocket
+// error swallowed. Reaching this means the WebSocket already failed, so a
+// successful TCP connect is itself a finding: something holds the control port
+// but does not speak our protocol.
+function classifyDialFailure(host: string, port: number, timeoutMs: number): Promise<ControlProbe> {
+  return new Promise(resolve => {
+    let settled = false
+    const settle = (probe: ControlProbe) => {
+      if (settled) return
+      settled = true
+      resolve(probe)
+    }
+    const socket = connect({ host, port })
+    socket.setTimeout(timeoutMs)
+    socket.on('connect', () => {
+      socket.destroy()
+      settle({
+        status: 'unreachable',
+        reason:
+          'the port accepted a connection but refused the control WebSocket — another process may hold it'
+      })
+    })
+    socket.on('timeout', () => {
+      socket.destroy()
+      settle({ status: 'unreachable', reason: `no answer within ${timeoutMs}ms` })
+    })
+    socket.on('error', (err: NodeJS.ErrnoException) => {
+      socket.destroy()
+      if (err.code === 'ECONNREFUSED') {
+        settle({ status: 'not-running' })
+        return
+      }
+      if (err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN') {
+        settle({ status: 'unreachable', reason: `could not resolve "${host}" (${err.code})` })
+        return
+      }
+      settle({
+        status: 'unreachable',
+        reason: err.code ?? err.message
+      })
+    })
+  })
+}
+
+// Open a control socket and report what happened. The happy path is one
+// WebSocket connect; the extra TCP probe only runs when that fails.
+export function probeControlServer(options: ControlProbeOptions = {}): Promise<ControlProbe> {
+  const { host = CONTROL_HOST, port = CONTROL_PORT, timeoutMs = 1500 } = options
+  const url = host === CONTROL_HOST && port === CONTROL_PORT ? CONTROL_URL : `ws://${host}:${port}`
+  return new Promise(resolve => {
+    let settled = false
+    const settle = (probe: ControlProbe) => {
+      if (settled) return
+      settled = true
+      resolve(probe)
+    }
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(url)
+    } catch (err) {
+      settle({ status: 'unreachable', reason: err instanceof Error ? err.message : String(err) })
+      return
+    }
+    const timer = setTimeout(() => {
+      closeQuietly(ws)
+      // A hung dial is not evidence of an absent server — say so rather than
+      // reporting it as "not running" the way a bare timeout used to.
+      void classifyDialFailure(host, port, timeoutMs).then(settle)
+    }, timeoutMs)
+    ws.onopen = () => {
+      clearTimeout(timer)
+      closeQuietly(ws)
+      settle({ status: 'running' })
+    }
+    ws.onerror = () => {
+      clearTimeout(timer)
+      void classifyDialFailure(host, port, timeoutMs).then(settle)
+    }
+  })
+}
+
+// The one-line explanation the CLI prints when a command could not reach the
+// control server. `running` never reaches here.
+export function controlFailureMessage(probe: ControlProbe): string {
+  if (probe.status === 'unreachable') {
+    return `Could not reach the control server at ${CONTROL_HOST}:${CONTROL_PORT} — ${probe.reason}. The server may still be running.`
+  }
+  return 'Could not connect to control server. Is the main process running?'
+}

--- a/server/control.ts
+++ b/server/control.ts
@@ -7,7 +7,7 @@ import { isParamsRecord } from '@/lib/workspace-tabs'
 
 import { clearAppletLog, getAppletLog, getAppletLogCount } from './applet-log'
 import { serializeWorkspaceBundle } from './bundle-queue'
-import { CONTROL_PORT, PORT } from './constants'
+import { CONTROL_HOST, CONTROL_PORT, PORT } from './constants'
 import { applyEnvChanged } from './env-apply'
 import { callFunctionEphemeral, parseFunctionPath } from './functions'
 import { processIcon } from './icon'
@@ -63,7 +63,7 @@ async function resolveWorkspace(
 
 export const control = Bun.serve({
   port: CONTROL_PORT,
-  hostname: '127.0.0.1',
+  hostname: CONTROL_HOST,
   fetch(req, server) {
     return server.upgrade(req)
       ? new Response(null, { status: 101 })

--- a/server/service.ts
+++ b/server/service.ts
@@ -21,7 +21,7 @@ import { copyFile, mkdir, readFile, rm, stat, truncate, writeFile } from 'node:f
 import { homedir, userInfo } from 'node:os'
 import { dirname, join } from 'node:path'
 
-import { CONTROL_PORT } from './constants'
+import { CONTROL_URL } from './constants'
 import { DATA_DIR } from './data-dir'
 import { mergeSearchPaths } from './harness/shell-path'
 import { PACKAGE_ROOT } from './version'
@@ -357,7 +357,7 @@ export function queryServerInfo(timeoutMs = 1500): Promise<ServerInfo | null> {
     }
     let ws: WebSocket
     try {
-      ws = new WebSocket(`ws://localhost:${CONTROL_PORT}`)
+      ws = new WebSocket(CONTROL_URL)
     } catch {
       settle(null)
       return


### PR DESCRIPTION
Every CLI control command dialed `ws://localhost:13059` while the control server binds the literal `127.0.0.1`. Where that name doesn't resolve — container images whose `/etc/hosts` has no `localhost` entry, or hosts preferring `::1` while we listen on IPv4 only — every control command failed and blamed the server process, which was running fine the whole time. `CONTROL_HOST`/`CONTROL_URL` now sit next to `CONTROL_PORT`, and both the bind and all 11 dial sites read them, so the two addresses can't drift apart again.

Secondarily, `isServerRunning()` collapsed refused, unresolvable, and timed-out into "not running". `probeControlServer()` classifies instead: an empty port is `not-running`, anything else is `unreachable` with the reason named.

With the `localhost` line removed from `/etc/hosts`, before → after:

```
$ moi status
- ○ Server is not running                    # …it was up the whole time
+ ● Server is running  (http port: 13337, control port: 13059, pid: 15875)

$ moi tabs
- ✗ Could not connect to control server. Is the main process running?
+ ●  agent / widgets / scratchpad            # full tab table
```

The third state is new — here with a stray listener squatting :13059:

```
◆ Server is unreachable
  control port 127.0.0.1:13059 — the port accepted a connection but refused the control WebSocket
```

Worth a close look:

- `control-client.ts` reaches for `node:net`, against the repo's Bun-first rule. Bun's WebSocket reports `Failed to connect` for every cause and `Bun.connect` reports `ECONNREFUSED` even for DNS failures; `node:net` is the only one that preserves the real errno.
- `moi status` now exits 1 on `unreachable`, where the old code exited 0 as "not running" — a behavior change for anything reading that exit code.
- The probe timeout went 600ms → 1500ms. Refused connects still return instantly, so `waitForServer`'s polling loop is unaffected.

Verified by reproducing the reported environment: removed the `localhost` line from the container's `/etc/hosts` (`Bun.dns.lookup("localhost")` then threw `ENOTFOUND`), started the server, and confirmed all three acceptance cases above, plus `moi status` still reporting "not running" with no server. `bun test`: 1126 pass, 0 fail across 127 files, including 5 new tests in `server/control-client.test.ts`. `oxlint` and `oxfmt --check` clean.

https://claude.ai/code/session_01RaT2x3MJPLKmtJWFF3kiF4
