### PR TITLE
Upload annotations once per session and keep drawing out of screen renders

### DIFF
--- a/client/features/annotations/AnnotationToolbar.tsx
+++ b/client/features/annotations/AnnotationToolbar.tsx
@@ -4,13 +4,17 @@ import { Button } from '@/client/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/client/components/ui/tooltip'
 import { cn } from '@/client/lib/cn'
 
-import type { AnnotationControls } from './useAnnotationLayer'
+import { type AnnotationControls, useAnnotationHistoryState } from './useAnnotationLayer'
 
 type AnnotationToolbarProps = {
   controls: AnnotationControls
 }
 
 export function AnnotationToolbar({ controls }: AnnotationToolbarProps) {
+  // Subscribed here so a stroke commit re-renders only this toolbar, not the
+  // screen that owns the annotation hook.
+  const { canUndo, canRedo, hasStrokes } = useAnnotationHistoryState(controls)
+
   return (
     <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-2 rounded-lg bg-popover p-1.5 shadow-md">
       <span className="mr-2 ml-2 text-sm font-medium">Draw annotation</span>
@@ -23,7 +27,7 @@ export function AnnotationToolbar({ controls }: AnnotationToolbarProps) {
                 variant="outline"
                 size="icon-sm"
                 onClick={controls.undo}
-                disabled={controls.finishing || !controls.canUndo}
+                disabled={controls.finishing || !canUndo}
                 aria-label="Undo annotation"
               >
                 <IconArrowBackUp stroke={1.75} />
@@ -40,7 +44,7 @@ export function AnnotationToolbar({ controls }: AnnotationToolbarProps) {
                 variant="outline"
                 size="icon-sm"
                 onClick={controls.redo}
-                disabled={controls.finishing || !controls.canRedo}
+                disabled={controls.finishing || !canRedo}
                 aria-label="Redo annotation"
               >
                 <IconArrowForwardUp stroke={1.75} />
@@ -54,21 +58,21 @@ export function AnnotationToolbar({ controls }: AnnotationToolbarProps) {
           variant="outline"
           size="sm"
           onClick={controls.clear}
-          disabled={controls.finishing || !controls.hasStrokes}
+          disabled={controls.finishing || !hasStrokes}
         >
           Clear
         </Button>
       </div>
       <Button
         type="button"
-        variant={controls.hasStrokes ? 'default' : 'ghost'}
+        variant={hasStrokes ? 'default' : 'ghost'}
         size="icon-sm"
         onClick={() => void controls.finish()}
         disabled={controls.finishing}
         aria-label="Finish annotation"
-        className={cn(!controls.hasStrokes && 'text-muted-foreground')}
+        className={cn(!hasStrokes && 'text-muted-foreground')}
       >
-        {controls.hasStrokes ? <IconCheck stroke={1.75} /> : <IconX stroke={1.75} />}
+        {hasStrokes ? <IconCheck stroke={1.75} /> : <IconX stroke={1.75} />}
       </Button>
     </div>
   )

--- a/client/features/annotations/useAnnotationLayer.ts
+++ b/client/features/annotations/useAnnotationLayer.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore
+} from 'react'
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
@@ -120,19 +128,40 @@ type UseAnnotationLayerOptions = {
   onFinish?: (blob: Blob | null) => void | Promise<void>
 }
 
+// Undo/redo/clear availability. Deliberately NOT part of the controls object:
+// it changes on every stroke commit, so components that need it subscribe via
+// useAnnotationHistoryState and re-render alone — a pen-up must not re-render
+// the whole screen that hosts the hook.
+export type AnnotationHistoryState = {
+  canUndo: boolean
+  canRedo: boolean
+  hasStrokes: boolean
+}
+
+const EMPTY_HISTORY_STATE: AnnotationHistoryState = {
+  canUndo: false,
+  canRedo: false,
+  hasStrokes: false
+}
+
 export type AnnotationControls = {
   active: boolean
   starting: boolean
   finishing: boolean
-  canUndo: boolean
-  canRedo: boolean
-  hasStrokes: boolean
   open: () => Promise<boolean>
   undo: () => void
   redo: () => void
   clear: () => void
   finish: () => Promise<Blob | null>
   cancel: () => Promise<void>
+  subscribeHistory: (listener: () => void) => () => void
+  getHistoryState: () => AnnotationHistoryState
+}
+
+// Subscribe to the per-stroke history flags from the component that renders
+// them (the toolbar), keeping stroke commits out of the host screen's renders.
+export function useAnnotationHistoryState(controls: AnnotationControls): AnnotationHistoryState {
+  return useSyncExternalStore(controls.subscribeHistory, controls.getHistoryState)
 }
 
 export type AnnotationController = {
@@ -227,8 +256,9 @@ export function useAnnotationLayer({
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [session, setSession] = useState<AnnotationLayerSession | null>(null)
   const sessionRef = useRef(session)
-  const [history, setHistory] = useState<AnnotationHistory>(EMPTY_ANNOTATION_HISTORY)
   const historyRef = useRef<AnnotationHistory>(EMPTY_ANNOTATION_HISTORY)
+  const historyStateRef = useRef<AnnotationHistoryState>(EMPTY_HISTORY_STATE)
+  const historyListenersRef = useRef(new Set<() => void>())
   const historyVersionRef = useRef(0)
   const draftRef = useRef<AnnotationStroke | null>(null)
   const pointerIdRef = useRef<number | null>(null)
@@ -243,6 +273,36 @@ export function useAnnotationLayer({
   const onFinishRef = useRef(onFinish)
   onChangeRef.current = onChange
   onFinishRef.current = onFinish
+
+  // History flags live outside React state (see AnnotationHistoryState): only
+  // subscribed components re-render on a stroke commit, not the host screen.
+  const publishHistory = useCallback(() => {
+    const history = historyRef.current
+    const previous = historyStateRef.current
+    const next: AnnotationHistoryState = {
+      canUndo: history.past.length > 0,
+      canRedo: history.future.length > 0,
+      hasStrokes: history.present.length > 0
+    }
+    if (
+      next.canUndo === previous.canUndo &&
+      next.canRedo === previous.canRedo &&
+      next.hasStrokes === previous.hasStrokes
+    ) {
+      return
+    }
+    historyStateRef.current = next
+    for (const listener of historyListenersRef.current) listener()
+  }, [])
+
+  const subscribeHistory = useCallback((listener: () => void) => {
+    historyListenersRef.current.add(listener)
+    return () => {
+      historyListenersRef.current.delete(listener)
+    }
+  }, [])
+
+  const getHistoryState = useCallback(() => historyStateRef.current, [])
 
   const redraw = useCallback(
     (strokes: AnnotationStroke[], draft: AnnotationStroke | null = null) => {
@@ -322,13 +382,13 @@ export function useAnnotationLayer({
       const next = annotationHistoryReducer(historyRef.current, action)
       if (next === historyRef.current) return
       historyRef.current = next
-      setHistory(next)
+      publishHistory()
       draftRef.current = null
       const historyVersion = ++historyVersionRef.current
       redraw(next.present)
       void exportCommitted(current, next.present, historyVersion)
     },
-    [exportCommitted, redraw]
+    [exportCommitted, publishHistory, redraw]
   )
 
   const open = useCallback(async (): Promise<boolean> => {
@@ -358,7 +418,7 @@ export function useAnnotationLayer({
       pendingExportRef.current = null
       draftRef.current = null
       pointerIdRef.current = null
-      setHistory(EMPTY_ANNOTATION_HISTORY)
+      publishHistory()
       sessionRef.current = next
       setSession(next)
       return true
@@ -368,7 +428,7 @@ export function useAnnotationLayer({
         setStarting(false)
       }
     }
-  }, [])
+  }, [publishHistory])
 
   const cancel = useCallback((): Promise<void> => {
     const current = sessionRef.current
@@ -422,51 +482,57 @@ export function useAnnotationLayer({
   const redo = useCallback(() => apply({ type: 'redo' }), [apply])
   const clear = useCallback(() => apply({ type: 'clear' }), [apply])
 
-  const pointerProps: AnnotationCanvasPointerProps = {
-    onPointerDown: (event: ReactPointerEvent<HTMLCanvasElement>) => {
-      if (
-        finishingRef.current ||
-        !event.isPrimary ||
-        (event.pointerType === 'mouse' && event.button !== 0)
-      ) {
-        return
+  // Everything returned from here down is identity-stable across renders
+  // (callbacks hold state in refs), so hosts can memoize children that take
+  // these objects as props. Identities change only with the session lifecycle.
+  const pointerProps: AnnotationCanvasPointerProps = useMemo(
+    () => ({
+      onPointerDown: (event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (
+          finishingRef.current ||
+          !event.isPrimary ||
+          (event.pointerType === 'mouse' && event.button !== 0)
+        ) {
+          return
+        }
+        pointerIdRef.current = event.pointerId
+        event.currentTarget.setPointerCapture(event.pointerId)
+        draftRef.current = {
+          points: [pointOnCanvas(event.currentTarget, event.clientX, event.clientY)]
+        }
+        redraw(historyRef.current.present, draftRef.current)
+      },
+      onPointerMove: (event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (event.pointerId !== pointerIdRef.current || !draftRef.current) return
+        draftRef.current = {
+          points: [
+            ...draftRef.current.points,
+            ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
+          ]
+        }
+        redraw(historyRef.current.present, draftRef.current)
+      },
+      onPointerUp: (event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (event.pointerId !== pointerIdRef.current || !draftRef.current) return
+        const stroke = {
+          points: [
+            ...draftRef.current.points,
+            ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
+          ]
+        }
+        draftRef.current = null
+        pointerIdRef.current = null
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId)
+        }
+        apply({ type: 'commit', stroke })
+      },
+      onPointerCancel: (event: ReactPointerEvent<HTMLCanvasElement>) => {
+        if (event.pointerId === pointerIdRef.current) cancelStroke()
       }
-      pointerIdRef.current = event.pointerId
-      event.currentTarget.setPointerCapture(event.pointerId)
-      draftRef.current = {
-        points: [pointOnCanvas(event.currentTarget, event.clientX, event.clientY)]
-      }
-      redraw(historyRef.current.present, draftRef.current)
-    },
-    onPointerMove: (event: ReactPointerEvent<HTMLCanvasElement>) => {
-      if (event.pointerId !== pointerIdRef.current || !draftRef.current) return
-      draftRef.current = {
-        points: [
-          ...draftRef.current.points,
-          ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
-        ]
-      }
-      redraw(historyRef.current.present, draftRef.current)
-    },
-    onPointerUp: (event: ReactPointerEvent<HTMLCanvasElement>) => {
-      if (event.pointerId !== pointerIdRef.current || !draftRef.current) return
-      const stroke = {
-        points: [
-          ...draftRef.current.points,
-          ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
-        ]
-      }
-      draftRef.current = null
-      pointerIdRef.current = null
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-        event.currentTarget.releasePointerCapture(event.pointerId)
-      }
-      apply({ type: 'commit', stroke })
-    },
-    onPointerCancel: (event: ReactPointerEvent<HTMLCanvasElement>) => {
-      if (event.pointerId === pointerIdRef.current) cancelStroke()
-    }
-  }
+    }),
+    [apply, cancelStroke, redraw]
+  )
 
   const onKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -520,31 +586,46 @@ export function useAnnotationLayer({
     []
   )
 
-  const controls: AnnotationControls = {
-    active: session !== null,
-    starting,
-    finishing,
-    canUndo: history.past.length > 0,
-    canRedo: history.future.length > 0,
-    hasStrokes: history.present.length > 0,
-    open,
-    undo,
-    redo,
-    clear,
-    finish,
-    cancel
-  }
+  const controls: AnnotationControls = useMemo(
+    () => ({
+      active: session !== null,
+      starting,
+      finishing,
+      open,
+      undo,
+      redo,
+      clear,
+      finish,
+      cancel,
+      subscribeHistory,
+      getHistoryState
+    }),
+    [
+      session,
+      starting,
+      finishing,
+      open,
+      undo,
+      redo,
+      clear,
+      finish,
+      cancel,
+      subscribeHistory,
+      getHistoryState
+    ]
+  )
 
-  return {
-    targetRef,
-    controls,
-    layerProps: {
-      active: controls.active,
+  const layerProps: AnnotationLayerProps = useMemo(
+    () => ({
+      active: session !== null,
       canvasRef,
       width: session?.snapshot.width ?? 0,
       height: session?.snapshot.height ?? 0,
       pointerProps,
       onKeyDown
-    }
-  }
+    }),
+    [session, pointerProps, onKeyDown]
+  )
+
+  return useMemo(() => ({ targetRef, controls, layerProps }), [controls, layerProps])
 }

--- a/client/features/annotations/useChatAnnotation.ts
+++ b/client/features/annotations/useChatAnnotation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import { toast } from '@/client/components/ui/toast'
-import { stageAnnotation } from '@/client/features/chat/attachment-staging'
+import { stageAnnotation, stageAnnotationDraft } from '@/client/features/chat/attachment-staging'
 import { liveStore } from '@/client/features/chat/chat-store'
 import type { LayoutMode, WorkspaceTabId } from '@/lib/types'
 
@@ -43,28 +43,41 @@ export function useChatAnnotation({
   openPopup
 }: UseChatAnnotationOptions): ChatAnnotationController {
   const draftRef = useRef<ChatAnnotationDraft | null>(null)
+  const latestBlobRef = useRef<Blob | null>(null)
   const uploadRevisionsRef = useRef(new Map<string, number>())
-  const pendingStageRef = useRef<Promise<void> | null>(null)
   const closePopupRef = useRef(closePopup)
   const openPopupRef = useRef(openPopup)
   closePopupRef.current = closePopup
   openPopupRef.current = openPopup
 
+  // While drawing, every commit only refreshes the chip's local preview. The
+  // single upload happens when the session ends: finish/send (complete) or an
+  // implicit cancel that keeps the attachment.
   const change = useCallback((blob: Blob | null) => {
     const draft = draftRef.current
     if (!draft) return
 
-    const revision = (uploadRevisionsRef.current.get(draft.attachmentId) ?? 0) + 1
-    uploadRevisionsRef.current.set(draft.attachmentId, revision)
+    latestBlobRef.current = blob
     if (!blob) {
-      pendingStageRef.current = null
       liveStore
         .getState()
         .removeAttachment(draft.workspaceId, draft.sourceSessionId, draft.attachmentId)
       return
     }
 
-    pendingStageRef.current = stageAnnotation({
+    stageAnnotationDraft({
+      workspaceId: draft.workspaceId,
+      sessionId: draft.sourceSessionId,
+      localId: draft.attachmentId,
+      sourceTab: draft.sourceTab,
+      blob
+    })
+  }, [])
+
+  const upload = useCallback((draft: ChatAnnotationDraft, blob: Blob): Promise<void> => {
+    const revision = (uploadRevisionsRef.current.get(draft.attachmentId) ?? 0) + 1
+    uploadRevisionsRef.current.set(draft.attachmentId, revision)
+    return stageAnnotation({
       workspaceId: draft.workspaceId,
       sessionId: draft.sourceSessionId,
       localId: draft.attachmentId,
@@ -74,12 +87,18 @@ export function useChatAnnotation({
     })
   }, [])
 
-  const complete = useCallback(async () => {
-    const draft = draftRef.current
-    await pendingStageRef.current
-    if (draftRef.current === draft) draftRef.current = null
-    if (draft?.origin === 'popup') openPopupRef.current()
-  }, [])
+  const complete = useCallback(
+    async (blob: Blob | null) => {
+      const draft = draftRef.current
+      draftRef.current = null
+      latestBlobRef.current = null
+      // Awaited so a send that finishes the drawing only dispatches once the
+      // attachment is uploaded and ready.
+      if (draft && blob) await upload(draft, blob)
+      if (draft?.origin === 'popup') openPopupRef.current()
+    },
+    [upload]
+  )
 
   const annotation = useAnnotationLayer({ onChange: change, onFinish: complete })
   const { controls } = annotation
@@ -116,8 +135,14 @@ export function useChatAnnotation({
   const cancel = useCallback(async () => {
     const draft = draftRef.current
     await cancelLayer()
-    if (draftRef.current === draft) draftRef.current = null
-  }, [cancelLayer])
+    if (draftRef.current !== draft) return
+    draftRef.current = null
+    const blob = latestBlobRef.current
+    latestBlobRef.current = null
+    // An implicit cancel (tab/session switch) keeps the drawn-so-far
+    // annotation as an attachment, so it gets its one deferred upload here.
+    if (draft && blob) void upload(draft, blob)
+  }, [cancelLayer, upload])
 
   const remove = useCallback(
     (localId: string) => {
@@ -125,6 +150,7 @@ export function useChatAnnotation({
       uploadRevisionsRef.current.set(localId, revision)
       if (draftRef.current?.attachmentId === localId) {
         draftRef.current = null
+        latestBlobRef.current = null
         void cancelLayer()
       }
     },

--- a/client/features/annotations/useChatAnnotation.ts
+++ b/client/features/annotations/useChatAnnotation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { toast } from '@/client/components/ui/toast'
 import { stageAnnotation, stageAnnotationDraft } from '@/client/features/chat/attachment-staging'
@@ -188,25 +188,32 @@ export function useChatAnnotation({
     }
   }, [activeTab, available, cancel, mode, sessionId, workspaceId])
 
-  const commonControls = {
-    active: active || starting,
-    finish: finishDrawing,
-    onRemove: remove
-  }
+  // Identity-stable (all callbacks hold state in refs) so ChatPanel and
+  // ChatComposer can be memoized against the `annotation` prop.
+  const docked = useMemo<ChatAnnotationControls | undefined>(
+    () =>
+      available
+        ? {
+            active: active || starting,
+            finish: finishDrawing,
+            onRemove: remove,
+            onToggle: toggleDocked
+          }
+        : undefined,
+    [available, active, starting, finishDrawing, remove, toggleDocked]
+  )
+  const popup = useMemo<ChatAnnotationControls | undefined>(
+    () =>
+      available
+        ? {
+            active: active || starting,
+            finish: finishDrawing,
+            onRemove: remove,
+            onToggle: togglePopup
+          }
+        : undefined,
+    [available, active, starting, finishDrawing, remove, togglePopup]
+  )
 
-  return {
-    ...annotation,
-    docked: available
-      ? {
-          ...commonControls,
-          onToggle: toggleDocked
-        }
-      : undefined,
-    popup: available
-      ? {
-          ...commonControls,
-          onToggle: togglePopup
-        }
-      : undefined
-  }
+  return useMemo(() => ({ ...annotation, docked, popup }), [annotation, docked, popup])
 }

--- a/client/features/chat/attachment-staging.test.ts
+++ b/client/features/chat/attachment-staging.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 
-import { stageAnnotation } from './attachment-staging'
+import { stageAnnotation, stageAnnotationDraft } from './attachment-staging'
 import { attachmentKey, liveStore } from './chat-store'
 
 const workspaceId = 'workspace-1'
@@ -11,6 +11,68 @@ afterEach(() => {
   globalThis.fetch = originalFetch
   liveStore.getState().clearAttachments(workspaceId, sessionId)
   liveStore.setState({ attachments: {} })
+})
+
+describe('annotation draft staging', () => {
+  test('stages locally without uploading and refreshes the preview per commit', () => {
+    const revokeSpy = spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const fetchSpy = mock(() => Promise.reject(new Error('no network expected')))
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    stageAnnotationDraft({
+      workspaceId,
+      sessionId,
+      localId: 'annotation-1',
+      sourceTab: 'widgets',
+      blob: new Blob(['first'], { type: 'image/png' })
+    })
+    const first = liveStore.getState().attachments[attachmentKey(workspaceId, sessionId)][0]
+    expect(first.status).toBe('draft')
+    expect(first.previewUrl).toStartWith('blob:')
+
+    stageAnnotationDraft({
+      workspaceId,
+      sessionId,
+      localId: 'annotation-1',
+      sourceTab: 'widgets',
+      blob: new Blob(['second'], { type: 'image/png' })
+    })
+    const list = liveStore.getState().attachments[attachmentKey(workspaceId, sessionId)]
+    expect(list).toHaveLength(1)
+    expect(list[0].previewUrl).not.toBe(first.previewUrl)
+    expect(revokeSpy).toHaveBeenCalledWith(first.previewUrl)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    revokeSpy.mockRestore()
+  })
+
+  test('upload on finish reuses the draft attachment and marks it ready', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        Response.json([{ id: 'upload-1', kind: 'image', mediaType: 'image/png' }], { status: 200 })
+      )
+    ) as unknown as typeof fetch
+
+    stageAnnotationDraft({
+      workspaceId,
+      sessionId,
+      localId: 'annotation-1',
+      sourceTab: 'widgets',
+      blob: new Blob(['drawing'], { type: 'image/png' })
+    })
+    await stageAnnotation({
+      workspaceId,
+      sessionId,
+      localId: 'annotation-1',
+      sourceTab: 'widgets',
+      blob: new Blob(['drawing'], { type: 'image/png' }),
+      isCurrent: () => true
+    })
+
+    const list = liveStore.getState().attachments[attachmentKey(workspaceId, sessionId)]
+    expect(list).toHaveLength(1)
+    expect(list[0].status).toBe('ready')
+    expect(list[0].upload?.id).toBe('upload-1')
+  })
 })
 
 describe('annotation attachment staging', () => {

--- a/client/features/chat/attachment-staging.ts
+++ b/client/features/chat/attachment-staging.ts
@@ -42,13 +42,57 @@ export function stageComposerFiles(
   })
 }
 
-type StageAnnotationInput = ComposerTarget & {
+type StageAnnotationDraftInput = ComposerTarget & {
   localId: string
   sourceTab: WorkspaceTabId
   blob: Blob
+}
+
+// Local-only staging while the user is still drawing: the chip shows the
+// latest composite as its preview, but nothing is uploaded until the drawing
+// session ends (stageAnnotation).
+export function stageAnnotationDraft({
+  workspaceId,
+  sessionId,
+  localId,
+  sourceTab,
+  blob
+}: StageAnnotationDraftInput): void {
+  const previewUrl = URL.createObjectURL(blob)
+  const store = liveStore.getState()
+  const existing = store.attachments[attachmentKey(workspaceId, sessionId)]?.some(
+    attachment => attachment.localId === localId
+  )
+
+  if (existing) {
+    store.updateAttachment(workspaceId, sessionId, localId, {
+      previewUrl,
+      status: 'draft',
+      upload: undefined,
+      error: undefined
+    })
+  } else {
+    store.addAttachments(workspaceId, sessionId, [
+      {
+        kind: 'annotation',
+        localId,
+        sourceTab,
+        name: 'Annotation.png',
+        mediaType: 'image/png',
+        previewUrl,
+        status: 'draft'
+      }
+    ])
+  }
+}
+
+type StageAnnotationInput = StageAnnotationDraftInput & {
   isCurrent: () => boolean
 }
 
+// Upload an annotation once its drawing session ends (finish, send, or an
+// implicit cancel that keeps the attachment). `isCurrent` guards the result:
+// a stale upload must not resurrect an attachment the user has removed.
 export async function stageAnnotation({
   workspaceId,
   sessionId,

--- a/client/features/chat/chat-send.test.ts
+++ b/client/features/chat/chat-send.test.ts
@@ -183,13 +183,21 @@ describe('composer attachments', () => {
       name: 'big.mov',
       mediaType: 'video/quicktime',
       status: 'uploading'
+    },
+    {
+      kind: 'annotation',
+      localId: 'a3',
+      name: 'Annotation.png',
+      mediaType: 'image/png',
+      sourceTab: 'widgets',
+      status: 'draft'
     }
   ]
 
   const stage = () =>
     liveStore.setState({ attachments: { [attachmentKey(workspaceId, sessionId)]: staged } })
 
-  test('a composer send carries the uploaded ones and skips those still uploading', () => {
+  test('a composer send carries the uploaded ones and skips uploading and draft ones', () => {
     stage()
     expect(attachmentsForSend(workspaceId, sessionId, undefined).map(a => a.localId)).toEqual([
       'a1'

--- a/client/features/chat/chat-store.ts
+++ b/client/features/chat/chat-store.ts
@@ -9,16 +9,18 @@ import type {
   WorkspaceTabId
 } from '@/lib/types'
 
-// One composer attachment, tracked per session until the message is sent. It is
-// uploaded as soon as it's added (drop/paste/pick); `status` reflects that
-// in-flight upload, and `upload` holds the server handle once ready. `previewUrl`
-// is a local object URL for image thumbnails (revoked on remove/clear).
+// One composer attachment, tracked per session until the message is sent. A
+// file uploads as soon as it's added (drop/paste/pick); an annotation stays a
+// local `draft` while it's being drawn and uploads once when the drawing
+// session ends. `status` reflects that lifecycle, and `upload` holds the server
+// handle once ready. `previewUrl` is a local object URL for image thumbnails
+// (revoked on remove/clear).
 type ChatAttachmentBase = {
   localId: string
   name: string
   mediaType: string
   previewUrl?: string
-  status: 'uploading' | 'ready' | 'error'
+  status: 'draft' | 'uploading' | 'ready' | 'error'
   upload?: UploadInfo
   error?: string
 }

--- a/client/features/chat/composer/ChatComposer.tsx
+++ b/client/features/chat/composer/ChatComposer.tsx
@@ -63,19 +63,31 @@ export function ChatComposer({
   const [dragOver, setDragOver] = useState(false)
 
   const uploading = attachments.some(a => a.status === 'uploading')
-  const hasReady = attachments.some(a => a.status === 'ready')
-  const hasContent = value.trim().length > 0 || hasReady
+  // A draft annotation counts as sendable content: send() finishes the drawing
+  // first, which uploads it before the message goes out.
+  const hasSendable = attachments.some(a => a.status === 'ready' || a.status === 'draft')
+  const hasContent = value.trim().length > 0 || hasSendable
   const canSend = canSubmitComposerAction(hasContent, uploading, availability)
 
   const onChange = (next: string) => useUiStore.getState().setComposerDraft(workspaceId, next)
 
   const addFiles = (files: File[]) => stageComposerFiles({ workspaceId, sessionId }, files)
 
+  // Guards the await window while an annotation finishes: no re-entry from a
+  // second Enter, and the draft is re-read afterwards so text typed during the
+  // upload isn't lost.
+  const sendingRef = useRef(false)
   const send = async () => {
-    if (!canSend) return
-    await annotation?.finish()
-    onSend(value)
-    useUiStore.getState().setComposerDraft(workspaceId, '')
+    if (!canSend || sendingRef.current) return
+    sendingRef.current = true
+    try {
+      await annotation?.finish()
+      const text = useUiStore.getState().composerDrafts[workspaceId] ?? ''
+      onSend(text)
+      useUiStore.getState().setComposerDraft(workspaceId, '')
+    } finally {
+      sendingRef.current = false
+    }
   }
 
   return (


### PR DESCRIPTION
Follow-up to #93 from its CTO review. Annotations no longer re-upload the full screenshot PNG on every stroke — while drawing, the composer chip updates from a local preview only, and the single upload happens when the drawing session ends (finish, send, or a tab switch that keeps the attachment). Sending is now safe during that window: double-Enter can't dispatch twice, and text typed while the annotation uploads is kept. Drawing also stopped re-rendering the workspace screen — a pen-up now re-renders only the toolbar and the composer chip.

Attachment lifecycle before → after, for a 15-stroke annotation:

```
before: 15 × (PNG encode + POST /uploads)   status: uploading→ready per stroke
after:  15 × local preview (object URL)     status: draft
        1 × (PNG encode + POST /uploads)    at session end: uploading→ready
```

Worth a close look:

- `useChatAnnotation.cancel()` — an implicit cancel (tab/session switch) now performs the deferred upload from `latestBlobRef`. It relies on the pending export settling before `cancelLayer()` resolves, so the ref holds the final composite; if that ordering ever changes in `useAnnotationLayer`, cancels would upload a stale image.
- `ChatComposer.send()` — re-reads the draft from the store after `await annotation?.finish()` instead of using the closed-over value. If a failed upload removed the attachment and the text is empty, `useChat.send` early-returns, so nothing dispatches.
- `useAnnotationLayer` history pub/sub — undo/redo/clear flags left React state (`useAnnotationHistoryState` via `useSyncExternalStore`); the toolbar is the only subscriber. The returned `controls`/`layerProps` are now identity-stable, which future `React.memo` on chat/widget children depends on.

Not addressed (deliberate): silent failure UX on export/upload errors — needs a product decision on error surfacing.

Verified: `bun test client/` (301 pass), `tsc --noEmit` clean for `client/` (server errors pre-existing on base).

https://claude.ai/code/session_01GAJGzoLkEuAy6tPVpw1JgA