### PR TITLE
Fix ACP replay: strip the moi-context envelope, keep every tool call

### DIFF
--- a/server/harness/acp/adapter.test.ts
+++ b/server/harness/acp/adapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 
+import { appendAttachmentNote } from '@/lib/attachment-note'
 import type { Turn } from '@/lib/format'
+import { appendMoiContext, renderMoiContext } from '@/lib/moi-context'
 
 import { rpcTimeoutMs } from './client'
 import type { AcpSessionListEntry } from './wire'
@@ -9,6 +11,7 @@ import {
   AssistantTurnAccumulator,
   acpSessionToSessionInfo,
   acpToolCallToTurn,
+  replayedUserParts,
   toolStatusToState
 } from './adapter'
 
@@ -239,5 +242,44 @@ describe('rpcTimeoutMs', () => {
     for (const method of ['initialize', 'session/new', 'session/load', 'session/list']) {
       expect(rpcTimeoutMs(method)).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('replayedUserParts', () => {
+  const envelope = renderMoiContext({ activeTab: 'agent' })
+
+  test('strips the appended moi-context envelope from replayed text', () => {
+    const stored = appendMoiContext('fix the login bug', envelope)
+    expect(replayedUserParts(stored)).toEqual([{ type: 'text', text: 'fix the login bug' }])
+  })
+
+  // An attachment-only send carries the envelope as its lone text block
+  // (sendAcpMessage unshifts it); the replay must not render an all-envelope
+  // bubble.
+  test('an envelope-only block folds to no parts', () => {
+    expect(replayedUserParts(envelope)).toEqual([])
+  })
+
+  test('folds the attachment note into file parts, envelope and all', () => {
+    const noted = appendAttachmentNote('see the report', [
+      { filename: 'report.pdf', path: '/tmp/up/report.pdf' }
+    ])
+    const stored = appendMoiContext(noted, envelope)
+    expect(replayedUserParts(stored)).toEqual([
+      {
+        type: 'file',
+        mediaType: 'application/octet-stream',
+        url: '/tmp/up/report.pdf',
+        filename: 'report.pdf'
+      },
+      { type: 'text', text: 'see the report' }
+    ])
+  })
+
+  // stripMoiContext is marker-guarded: quoting the bare tag without the
+  // envelope's marker sentence keeps the user's text intact.
+  test('keeps user text that merely quotes the tag', () => {
+    const typed = 'what does <moi-context> mean in this codebase?'
+    expect(replayedUserParts(typed)).toEqual([{ type: 'text', text: typed }])
   })
 })

--- a/server/harness/acp/adapter.ts
+++ b/server/harness/acp/adapter.ts
@@ -7,7 +7,9 @@
 // call both closes the open assistant turn and becomes a turn of its own —
 // the same item-per-turn model the Codex adapter produces.
 
+import { splitAttachmentNote } from '@/lib/attachment-note'
 import type { Part, ToolCall, ToolState, Turn, TurnMeta } from '@/lib/format'
+import { stripMoiContext } from '@/lib/moi-context'
 
 import {
   type AcpSessionListEntry,
@@ -105,6 +107,26 @@ export function acpUsageToTurnMeta(usage: Usage | null | undefined): TurnMeta['u
     return undefined
   }
   return { inputTokens, outputTokens, totalTokens }
+}
+
+// Replayed `user_message_chunk` text is the persisted prompt verbatim: the
+// typed text plus everything the sender appended to it — the attachment note
+// and the `<moi-context>` envelope (see sendAcpMessage in ./session.ts). Fold
+// that machinery back out so a reloaded bubble matches the live one. Envelope
+// first: it is appended after the note, and `splitAttachmentNote` parses the
+// note as the text's tail. An envelope-only block (an attachment-only send
+// carries the envelope as its lone text) folds to no parts — the caller skips
+// the bubble entirely.
+export function replayedUserParts(raw: string): Part[] {
+  const split = splitAttachmentNote(stripMoiContext(raw))
+  const parts: Part[] = split.files.map(f => ({
+    type: 'file',
+    mediaType: 'application/octet-stream',
+    url: f.path,
+    filename: f.filename
+  }))
+  if (split.text.trim()) parts.push({ type: 'text', text: split.text })
+  return parts
 }
 
 export function acpSessionToSessionInfo(entry: AcpSessionListEntry): SessionInfo {

--- a/server/harness/acp/run-durations.ts
+++ b/server/harness/acp/run-durations.ts
@@ -1,0 +1,68 @@
+// Per-run durations for ACP sessions. ACP replays carry no timestamps, so a
+// reloaded chat cannot compute how long each agent run took — but moi owns the
+// prompt lifecycle live (`session/prompt`'s promise IS the run), so it records
+// the durations itself and re-attaches them on replay. Without a recording the
+// label falls back to a plain "Worked".
+//
+// Stored OUTSIDE the workspace in ONE global JSON file in moi's data dir
+// (same choice, shape and locking as ./archived.ts), keyed by workspace path
+// then session id, one entry per prompt run in prompt order:
+//   { "<workspacePath>": { "<sessionId>": [12100, 3400, …] } }
+import { mkdir, rename } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { DATA_DIR } from '../../data-dir'
+
+type Store = Record<string, Record<string, number[]>>
+
+export const DEFAULT_RUN_DURATIONS_PATH = join(DATA_DIR, 'acp-run-durations.json')
+
+let storePath = DEFAULT_RUN_DURATIONS_PATH
+
+// Test seam: point the store at a scratch file (mirrors setArchivedSessionsPath).
+export function setRunDurationsPath(path: string): void {
+  storePath = path
+}
+
+async function readStore(): Promise<Store> {
+  try {
+    const parsed = JSON.parse(await Bun.file(storePath).text())
+    return parsed && typeof parsed === 'object' ? (parsed as Store) : {}
+  } catch {
+    return {}
+  }
+}
+
+async function writeStore(store: Store): Promise<void> {
+  await mkdir(join(storePath, '..'), { recursive: true })
+  const tmp = `${storePath}.${process.pid}.tmp`
+  await Bun.write(tmp, JSON.stringify(store, null, 2))
+  await rename(tmp, storePath)
+}
+
+// Serialize read-modify-write so concurrent run completions can't clobber the
+// single shared file.
+let writeChain: Promise<unknown> = Promise.resolve()
+function locked<T>(fn: () => Promise<T>): Promise<T> {
+  const run = writeChain.then(fn, fn)
+  writeChain = run.catch(() => {})
+  return run
+}
+
+export async function appendRunDuration(
+  workspacePath: string,
+  sessionId: string,
+  durationMs: number
+): Promise<void> {
+  if (!sessionId || !Number.isFinite(durationMs) || durationMs < 0) return
+  await locked(async () => {
+    const store = await readStore()
+    const sessions = (store[workspacePath] ??= {})
+    sessions[sessionId] = [...(sessions[sessionId] ?? []), Math.round(durationMs)]
+    await writeStore(store)
+  })
+}
+
+export async function runDurations(workspacePath: string, sessionId: string): Promise<number[]> {
+  return locked(async () => (await readStore())[workspacePath]?.[sessionId] ?? [])
+}

--- a/server/harness/acp/session.test.ts
+++ b/server/harness/acp/session.test.ts
@@ -1,0 +1,182 @@
+// Replay-path test for the ACP session layer: a mock ACP agent (a tiny
+// newline-JSON-RPC script) answers `initialize` and replays a canned history
+// as `session/update` notifications on `session/load`, exercising the REAL
+// client transport + session record + adapter — everything except a live
+// backend. This is the path a thread fetch takes after a server restart
+// (sessionEvents → ensureAcpSessionLive → resumeSession).
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { appendMoiContext, renderMoiContext } from '@/lib/moi-context'
+
+import { killAllAcpClients } from './client'
+import { type AcpProviderConfig, ensureAcpSessionLive, forgetAllAcpSessions } from './session'
+
+let seq = 0
+
+// The agent script speaks the same wire dialect client.ts does: one JSON
+// object per line on stdio. Replay updates ride in via MOCK_UPDATES so each
+// test controls its own history.
+const AGENT_SOURCE = `
+const updates = JSON.parse(process.env.MOCK_UPDATES ?? '[]')
+const send = o => process.stdout.write(JSON.stringify(o) + '\\n')
+let buf = ''
+process.stdin.on('data', chunk => {
+  buf += chunk
+  let nl
+  while ((nl = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, nl)
+    buf = buf.slice(nl + 1)
+    if (!line.trim()) continue
+    const msg = JSON.parse(line)
+    if (msg.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: 1, agentCapabilities: {} } })
+    } else if (msg.method === 'session/load') {
+      for (const update of updates) {
+        send({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: { sessionId: msg.params.sessionId, update }
+        })
+      }
+      send({ jsonrpc: '2.0', id: msg.id, result: {} })
+    } else if (msg.id !== undefined) {
+      send({ jsonrpc: '2.0', id: msg.id, result: {} })
+    }
+  }
+})
+`
+
+async function replayThroughMockAgent(updates: unknown[]) {
+  const dir = await mkdtemp(join(tmpdir(), 'acp-session-test-'))
+  const agentPath = join(dir, 'mock-acp-agent.js')
+  await Bun.write(agentPath, AGENT_SOURCE)
+  const config: AcpProviderConfig = {
+    id: 'hermes',
+    provider: 'hermes',
+    spawn: async () => ({
+      provider: 'hermes',
+      command: process.execPath,
+      args: [agentPath],
+      workspacePath: dir,
+      env: { MOCK_UPDATES: JSON.stringify(updates) }
+    })
+  }
+  // Session records key on (workspaceId, sessionId) in module state, so each
+  // call gets fresh ids or the second test would reuse the first's record.
+  seq++
+  return ensureAcpSessionLive(config, {
+    workspaceId: `ws-test-${seq}`,
+    workspacePath: dir,
+    sessionId: `sess-replay-${seq}`
+  })
+}
+
+afterAll(() => {
+  forgetAllAcpSessions()
+  killAllAcpClients()
+})
+
+describe('ACP session replay', () => {
+  test('a replayed history keeps its tool calls and strips the moi-context envelope', async () => {
+    const envelope = renderMoiContext({ activeTab: 'agent' })
+    const events = await replayThroughMockAgent([
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: appendMoiContext('run the tests', envelope) }
+      },
+      { sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'planning' } },
+      {
+        // Replay-shaped tool call: Hermes hands out `functions.<tool>:<index>`
+        // ids on replay, not the live `tc-<hash>` (NOTES.md §3.4).
+        sessionUpdate: 'tool_call',
+        toolCallId: 'functions.terminal:0',
+        title: 'terminal: bun test',
+        kind: 'execute',
+        status: 'pending'
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'functions.terminal:0',
+        status: 'completed',
+        content: [{ type: 'content', content: { type: 'text', text: '12 pass' } }]
+      },
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'All green.' } }
+    ])
+
+    const turns = events.flatMap(e => (e.kind === 'turn' ? [e.turn] : []))
+    expect(turns.map(t => t.parts[0]?.type)).toEqual(['text', 'reasoning', 'tool-call', 'text'])
+
+    const user = turns[0]
+    expect(user.role).toBe('user')
+    expect(user.parts).toEqual([{ type: 'text', text: 'run the tests' }])
+
+    const tool = turns[2].parts[0]
+    if (tool.type !== 'tool-call') throw new Error('expected a tool-call part')
+    expect(tool.call).toMatchObject({
+      name: 'terminal: bun test',
+      state: 'success',
+      output: '12 pass',
+      provider: 'hermes'
+    })
+  })
+
+  test('repeated replay tool-call ids stay separate turns', async () => {
+    // Hermes replay ids are `functions.<tool>:<index>` with the index scoped
+    // to one assistant message (NOTES.md §3.4), so a session that calls the
+    // same tool from several messages replays the same id repeatedly. Each
+    // pair must land as its own turn — upsert-by-id would collapse them all
+    // into the first one.
+    const pair = (output: string) => [
+      {
+        sessionUpdate: 'tool_call',
+        toolCallId: 'functions.terminal:0',
+        title: `terminal: echo ${output}`,
+        kind: 'execute',
+        status: 'pending'
+      },
+      {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'functions.terminal:0',
+        status: 'completed',
+        content: [{ type: 'content', content: { type: 'text', text: output } }]
+      }
+    ]
+    const events = await replayThroughMockAgent([
+      { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'first' } },
+      ...pair('one'),
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ran one' } },
+      { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'again' } },
+      ...pair('two'),
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ran two' } }
+    ])
+
+    const tools = events.flatMap(e =>
+      e.kind === 'turn' && e.turn.parts[0]?.type === 'tool-call' ? [e.turn] : []
+    )
+    expect(tools).toHaveLength(2)
+    expect(tools.map(t => t.parts[0].type === 'tool-call' && t.parts[0].call.output)).toEqual([
+      'one',
+      'two'
+    ])
+    // Each occurrence keeps its transcript position between its user message
+    // and the agent's reply.
+    const roles = events.flatMap(e =>
+      e.kind === 'turn' ? [e.turn.parts[0]?.type === 'tool-call' ? 'tool' : e.turn.role] : []
+    )
+    expect(roles).toEqual(['user', 'tool', 'assistant', 'user', 'tool', 'assistant'])
+  })
+
+  test('an envelope-only user block replays as no turn at all', async () => {
+    const envelope = renderMoiContext({ activeTab: 'agent' })
+    const events = await replayThroughMockAgent([
+      { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: envelope } },
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hi' } }
+    ])
+
+    const turns = events.flatMap(e => (e.kind === 'turn' ? [e.turn] : []))
+    expect(turns.map(t => t.role)).toEqual(['assistant'])
+  })
+})

--- a/server/harness/acp/session.test.ts
+++ b/server/harness/acp/session.test.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path'
 import { appendMoiContext, renderMoiContext } from '@/lib/moi-context'
 
 import { killAllAcpClients } from './client'
+import { appendRunDuration, setRunDurationsPath } from './run-durations'
 import { type AcpProviderConfig, ensureAcpSessionLive, forgetAllAcpSessions } from './session'
 
 let seq = 0
@@ -49,10 +50,11 @@ process.stdin.on('data', chunk => {
 })
 `
 
-async function replayThroughMockAgent(updates: unknown[]) {
+async function replayThroughMockAgent(updates: unknown[], seedDurations: number[] = []) {
   const dir = await mkdtemp(join(tmpdir(), 'acp-session-test-'))
   const agentPath = join(dir, 'mock-acp-agent.js')
   await Bun.write(agentPath, AGENT_SOURCE)
+  setRunDurationsPath(join(dir, 'run-durations.json'))
   const config: AcpProviderConfig = {
     id: 'hermes',
     provider: 'hermes',
@@ -67,10 +69,12 @@ async function replayThroughMockAgent(updates: unknown[]) {
   // Session records key on (workspaceId, sessionId) in module state, so each
   // call gets fresh ids or the second test would reuse the first's record.
   seq++
+  const sessionId = `sess-replay-${seq}`
+  for (const ms of seedDurations) await appendRunDuration(dir, sessionId, ms)
   return ensureAcpSessionLive(config, {
     workspaceId: `ws-test-${seq}`,
     workspacePath: dir,
-    sessionId: `sess-replay-${seq}`
+    sessionId
   })
 }
 
@@ -172,6 +176,49 @@ describe('ACP session replay', () => {
       e.kind === 'turn' ? [e.turn.parts[0]?.type === 'tool-call' ? 'tool' : e.turn.role] : []
     )
     expect(roles).toEqual(['user', 'tool', 'assistant', 'user', 'tool', 'assistant'])
+  })
+
+  test('re-attaches recorded run durations to each run-final turn', async () => {
+    const events = await replayThroughMockAgent(
+      [
+        { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'build it' } },
+        {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'functions.terminal:0',
+          title: 'terminal: bun build',
+          kind: 'execute',
+          status: 'completed'
+        },
+        { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'built' } },
+        { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'thanks' } },
+        { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'anytime' } }
+      ],
+      [5000, 250]
+    )
+
+    const turns = events.flatMap(e => (e.kind === 'turn' ? [e.turn] : []))
+    expect(turns.map(t => t.meta?.durationMs)).toEqual([
+      undefined, // user
+      undefined, // tool call
+      5000, // run 1 final turn
+      undefined, // user
+      250 // run 2 final turn
+    ])
+  })
+
+  test('skips duration re-attach when the recording does not match the replay', async () => {
+    const events = await replayThroughMockAgent(
+      [
+        { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: 'one message' } },
+        { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'one reply' } }
+      ],
+      // Two recorded runs against one replayed run — a wrong label is worse
+      // than none, so nothing attaches.
+      [5000, 250]
+    )
+
+    const turns = events.flatMap(e => (e.kind === 'turn' ? [e.turn] : []))
+    expect(turns.every(t => t.meta?.durationMs === undefined)).toBe(true)
   })
 
   test('an envelope-only user block replays as no turn at all', async () => {

--- a/server/harness/acp/session.test.ts
+++ b/server/harness/acp/session.test.ts
@@ -121,6 +121,11 @@ describe('ACP session replay', () => {
       output: '12 pass',
       provider: 'hermes'
     })
+
+    // Replay carries no timestamps, and stamping turns with replay-time dates
+    // would make the client report the replay's own duration ("Worked for
+    // 1s"). Replayed turns must omit the timestamp entirely.
+    expect(turns.every(t => t.timestamp === undefined)).toBe(true)
   })
 
   test('repeated replay tool-call ids stay separate turns', async () => {

--- a/server/harness/acp/session.test.ts
+++ b/server/harness/acp/session.test.ts
@@ -231,4 +231,26 @@ describe('ACP session replay', () => {
     const turns = events.flatMap(e => (e.kind === 'turn' ? [e.turn] : []))
     expect(turns.map(t => t.role)).toEqual(['assistant'])
   })
+
+  test('an image-only send keeps its user turn on replay', async () => {
+    // An image-only send stores an image block plus an envelope-only text
+    // block (sendAcpMessage unshifts the envelope when no text block exists).
+    // Stripping the envelope must not drop the turn — the image survives as a
+    // data-URL file part, the same cold-reload fallback other adapters use.
+    const envelope = renderMoiContext({ activeTab: 'agent' })
+    const events = await replayThroughMockAgent([
+      { sessionUpdate: 'user_message_chunk', content: { type: 'text', text: envelope } },
+      {
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'image', mimeType: 'image/png', data: 'aGVsbG8=' }
+      },
+      { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'a red circle' } }
+    ])
+
+    const turns = events.flatMap(e => (e.kind === 'turn' ? [e.turn] : []))
+    expect(turns.map(t => t.role)).toEqual(['user', 'assistant'])
+    expect(turns[0].parts).toEqual([
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,aGVsbG8=' }
+    ])
+  })
 })

--- a/server/harness/acp/session.ts
+++ b/server/harness/acp/session.ts
@@ -32,6 +32,7 @@ import {
   toolTurnId
 } from './adapter'
 import { type AcpClient, type AcpSpawnSpec, getAcpClient } from './client'
+import { appendRunDuration, runDurations } from './run-durations'
 import type {
   AcpModelInfo,
   AcpNewSessionResult,
@@ -420,8 +421,45 @@ async function resumeSession(
     flushUserChunk(rec)
     rec.replaying = false
   }
+  await attachReplayDurations(rec)
   await applyNoPromptMode(client, config, input.sessionId)
   return rec
+}
+
+// Re-attach the live-recorded run durations to a replayed transcript: split
+// it into runs at user turns and stamp each run's FINAL turn — groupTurns'
+// meta merge carries the last turn's `durationMs` onto the merged run, which
+// is where the "Worked for Xs" label reads it. Only applied when the replayed
+// run count matches the recording exactly: a session also driven outside moi,
+// or a replayed user turn that folded to nothing, would misalign every later
+// run — and a missing label beats a wrong one.
+async function attachReplayDurations(rec: SessionRecord): Promise<void> {
+  const durations = await runDurations(rec.workspacePath, rec.sessionId)
+  if (durations.length === 0) return
+  const runEnds: number[] = []
+  let openRun = false
+  rec.view.turns.forEach((turn, i) => {
+    if (turn.role === 'user') {
+      openRun = true
+      return
+    }
+    // Every non-user turn (text, reasoning, tool call) extends the run that
+    // the last user turn opened; turns before any user turn belong to none.
+    if (openRun) {
+      runEnds.push(i)
+      openRun = false
+    } else if (runEnds.length > 0) {
+      runEnds[runEnds.length - 1] = i
+    }
+  })
+  if (runEnds.length !== durations.length) return
+  runEnds.forEach((endIndex, run) => {
+    const turn = rec.view.turns[endIndex]
+    emitTurnEvent(rec, {
+      kind: 'turn',
+      turn: { ...turn, meta: { ...turn.meta, durationMs: durations[run] } }
+    })
+  })
 }
 
 // Turn typed text + resolved uploads into ACP prompt blocks and the display
@@ -461,6 +499,10 @@ async function runPrompt(
   blocks: AcpPromptBlock[]
 ): Promise<void> {
   setProcessing(rec, true)
+  // The prompt promise IS the run, so its wall time is the "Worked for Xs"
+  // duration — recorded (settled or errored) for replay, which has no
+  // timestamps of its own (see ./run-durations.ts).
+  const startedAt = Date.now()
   try {
     const client = await getAcpClient(
       await config.spawn({
@@ -494,6 +536,7 @@ async function runPrompt(
     })
     refreshAvailability(rec, config.id)
   } finally {
+    void appendRunDuration(rec.workspacePath, rec.sessionId, Date.now() - startedAt)
     const next = rec.queue.shift()
     if (next) {
       void runPrompt(config, rec, next.blocks)

--- a/server/harness/acp/session.ts
+++ b/server/harness/acp/session.ts
@@ -96,7 +96,16 @@ type SessionRecord = {
   userChunk: string
   // Tool calls seen this turn that never reached a terminal status — closed
   // at turn end so their cards don't hang (see ../hermes/NOTES.md §3.4).
+  // Holds aliased ids (see toolCallSeq).
   openToolCalls: Set<string>
+  // How many times each wire toolCallId has STARTED. Hermes replay ids are
+  // `functions.<tool>:<index>` with the index scoped to one assistant message
+  // (NOTES.md §3.4), so a session calling the same tool from several messages
+  // repeats the id — upsert-by-id would collapse every occurrence into the
+  // first turn. Each start past the first gets an aliased id; updates attach
+  // to the latest start. Live `tc-<hash>` ids are unique, so the alias is a
+  // no-op there.
+  toolCallSeq: Map<string, number>
   model?: string
   queue: QueuedSend[]
   unsubscribe?: () => void
@@ -187,19 +196,32 @@ function flushUserChunk(rec: SessionRecord) {
   })
 }
 
-function ingestToolCall(rec: SessionRecord, update: ToolCallUpdate, provider: AcpProviderId) {
+function ingestToolCall(
+  rec: SessionRecord,
+  update: ToolCallUpdate,
+  provider: AcpProviderId,
+  isStart: boolean
+) {
   // A tool call closes the open assistant run: text before it and text after
   // it are separate turns, so the transcript reads in execution order.
   flushAssistant(rec)
   flushUserChunk(rec)
-  const id = toolTurnId(rec.sessionId, update.toolCallId)
+  // Repeated wire ids (see toolCallSeq) get a per-occurrence alias so each
+  // start is its own turn; a `tool_call_update` reuses the latest one.
+  if (isStart) {
+    rec.toolCallSeq.set(update.toolCallId, (rec.toolCallSeq.get(update.toolCallId) ?? 0) + 1)
+  }
+  const seen = rec.toolCallSeq.get(update.toolCallId) ?? 1
+  const aliasedId = seen > 1 ? `${update.toolCallId}#${seen}` : update.toolCallId
+  const aliased = aliasedId === update.toolCallId ? update : { ...update, toolCallId: aliasedId }
+  const id = toolTurnId(rec.sessionId, aliasedId)
   const previous = rec.view.turns.find(t => t.id === id)
-  const turn = acpToolCallToTurn({ update, sessionId: rec.sessionId, provider, previous })
+  const turn = acpToolCallToTurn({ update: aliased, sessionId: rec.sessionId, provider, previous })
   const state = turn.parts.find(p => p.type === 'tool-call')
   const settled =
     state?.type === 'tool-call' && (state.call.state === 'success' || state.call.state === 'error')
-  if (settled) rec.openToolCalls.delete(update.toolCallId)
-  else rec.openToolCalls.add(update.toolCallId)
+  if (settled) rec.openToolCalls.delete(aliasedId)
+  else rec.openToolCalls.add(aliasedId)
   emitTurnEvent(rec, { kind: 'turn', turn })
 }
 
@@ -257,7 +279,12 @@ function handleSessionUpdate(rec: SessionRecord, update: SessionUpdate, provider
     }
     case 'tool_call':
     case 'tool_call_update': {
-      ingestToolCall(rec, update as unknown as ToolCallUpdate, provider)
+      ingestToolCall(
+        rec,
+        update as unknown as ToolCallUpdate,
+        provider,
+        update.sessionUpdate === 'tool_call'
+      )
       return
     }
     case 'session_info_update': {
@@ -329,6 +356,7 @@ function createRecord(input: {
     acc: new AssistantTurnAccumulator(input.sessionId, input.model, input.config.id),
     userChunk: '',
     openToolCalls: new Set(),
+    toolCallSeq: new Map(),
     model: input.model,
     queue: []
   }

--- a/server/harness/acp/session.ts
+++ b/server/harness/acp/session.ts
@@ -33,13 +33,15 @@ import {
 } from './adapter'
 import { type AcpClient, type AcpSpawnSpec, getAcpClient } from './client'
 import { appendRunDuration, runDurations } from './run-durations'
-import type {
-  AcpModelInfo,
-  AcpNewSessionResult,
-  AcpPromptBlock,
-  PromptResponse,
-  SessionUpdate,
-  ToolCallUpdate
+import {
+  type AcpModelInfo,
+  type AcpNewSessionResult,
+  type AcpPromptBlock,
+  type ContentChunk,
+  type PromptResponse,
+  type SessionUpdate,
+  type ToolCallUpdate,
+  isTextBlock
 } from './wire'
 import { agentStore } from '../../agent'
 import { debug } from '../../debug'
@@ -95,6 +97,10 @@ type SessionRecord = {
   // Open user-message run, only ever populated during replay (ACP does not
   // echo live sends).
   userChunk: string
+  // Image blocks of the open replayed user message. An image-only send has no
+  // user text besides the envelope, so these are what keep its replayed turn
+  // alive once the envelope strips away.
+  userImageParts: Part[]
   // Tool calls seen this turn that never reached a terminal status — closed
   // at turn end so their cards don't hang (see ../hermes/NOTES.md §3.4).
   // Holds aliased ids (see toolCallSeq).
@@ -189,12 +195,14 @@ function flushAssistant(
 }
 
 function flushUserChunk(rec: SessionRecord) {
-  if (!rec.userChunk) return
+  if (!rec.userChunk && rec.userImageParts.length === 0) return
   // The chunk is the persisted prompt verbatim; fold the appended machinery
   // (moi-context envelope, attachment note) back out before the text becomes
-  // a bubble, and drop the turn when nothing typed remains.
-  const parts = replayedUserParts(rec.userChunk)
+  // a bubble. Replayed images render above the text like the live bubble, and
+  // a turn with nothing left (no typed text, no images) drops entirely.
+  const parts = [...rec.userImageParts, ...replayedUserParts(rec.userChunk)]
   rec.userChunk = ''
+  rec.userImageParts = []
   if (parts.length === 0) return
   emitTurnEvent(rec, {
     kind: 'turn',
@@ -285,8 +293,18 @@ function handleSessionUpdate(rec: SessionRecord, update: SessionUpdate, provider
     case 'user_message_chunk': {
       // Replay only — live sends are echoed by moi itself.
       flushAssistant(rec)
-      const block = (update as { content?: { text?: string } }).content
-      rec.userChunk += block?.text ?? ''
+      const content = (update as Partial<ContentChunk>).content
+      if (isTextBlock(content)) {
+        rec.userChunk += content.text
+      } else if (content?.type === 'image' && content.data) {
+        // Rebuilt as a data URL — the cold-reload fallback (live bubbles point
+        // at moi's served upload URL, but that store is gone after a restart).
+        rec.userImageParts.push({
+          type: 'file',
+          mediaType: content.mimeType,
+          url: `data:${content.mimeType};base64,${content.data}`
+        })
+      }
       return
     }
     case 'tool_call':
@@ -367,6 +385,7 @@ function createRecord(input: {
     replaying: false,
     acc: new AssistantTurnAccumulator(input.sessionId, input.model, input.config.id),
     userChunk: '',
+    userImageParts: [],
     openToolCalls: new Set(),
     toolCallSeq: new Map(),
     model: input.model,

--- a/server/harness/acp/session.ts
+++ b/server/harness/acp/session.ts
@@ -153,6 +153,17 @@ function setProcessing(rec: SessionRecord, processing: boolean) {
 }
 
 function emitTurnEvent(rec: SessionRecord, ev: StreamEvent) {
+  // ACP replay updates carry no timestamps, so replayed turns would get
+  // stamped with replay-time `new Date()`s — and the client's duration label
+  // (groupTurns: assistant timestamp minus the preceding user turn's) would
+  // report how long the REPLAY took, "Worked for 1s" on every reloaded run.
+  // The real duration is unrecoverable, so drop the timestamp instead; the
+  // client falls back to a plain "Worked" label.
+  if (ev.kind === 'turn' && rec.replaying && ev.turn.timestamp !== undefined) {
+    const turn = { ...ev.turn }
+    delete turn.timestamp
+    ev = { kind: 'turn', turn }
+  }
   rec.view = applyEvent(rec.view, ev)
   broadcast(rec.workspaceId, { ...ev, sessionId: rec.sessionId })
 }

--- a/server/harness/acp/session.ts
+++ b/server/harness/acp/session.ts
@@ -28,6 +28,7 @@ import {
   AssistantTurnAccumulator,
   acpToolCallToTurn,
   acpUsageToTurnMeta,
+  replayedUserParts,
   toolTurnId
 } from './adapter'
 import { type AcpClient, type AcpSpawnSpec, getAcpClient } from './client'
@@ -168,15 +169,19 @@ function flushAssistant(
 
 function flushUserChunk(rec: SessionRecord) {
   if (!rec.userChunk) return
-  const text = rec.userChunk
+  // The chunk is the persisted prompt verbatim; fold the appended machinery
+  // (moi-context envelope, attachment note) back out before the text becomes
+  // a bubble, and drop the turn when nothing typed remains.
+  const parts = replayedUserParts(rec.userChunk)
   rec.userChunk = ''
+  if (parts.length === 0) return
   emitTurnEvent(rec, {
     kind: 'turn',
     turn: {
       id: `${rec.sessionId}:user:${rec.view.turns.length}`,
       role: 'user',
       origin: { kind: 'user-input' },
-      parts: [{ type: 'text', text }],
+      parts,
       timestamp: new Date().toISOString()
     }
   })
@@ -487,7 +492,9 @@ export async function sendAcpMessage(
   if (blocks.length === 0) return
 
   // ACP has no native ambient-context channel, so the envelope rides in the
-  // text block (stripped from display by lib/system-messages.ts rules).
+  // text block. The backend persists that text verbatim and echoes it on
+  // `session/load`, so the replay side strips it back out (replayedUserParts
+  // via flushUserChunk) before the text reaches a bubble.
   if (input.context) {
     const envelope = renderMoiContext(input.context)
     const first = blocks[0]


### PR DESCRIPTION
Stacked on #89. Fixes the ACP replay path — after a server restart, reopening a Hermes chat showed the raw `<moi-context>` envelope in every user bubble, most tool calls were missing from the transcript, and every reloaded run read "Worked for 1s".

**Envelope leak.** ACP has no ambient-context channel, so the envelope (and the attachment note) ride inside the prompt's text block; Hermes persists that text verbatim and echoes it back on `session/load`. A new `replayedUserParts` mapping folds the machinery back out: envelope stripped (marker-guarded, so typed text quoting the tag survives), attachment note folded into file chips, envelope-only blocks dropped entirely.

```
fix the login bug

<moi-context>
You are running in a `moi` workspace — a shared UI…
</moi-context>
```
→
```
fix the login bug
```

**Tool calls collapsing.** Hermes replay hands out `functions.<tool>:<index>` tool-call ids with the index scoped to one assistant message (NOTES.md §3.4), so a session calling the same tool from several messages replays the same id repeatedly — and the view's upsert-by-id collapsed every occurrence into the first turn. Each tool-call *start* now mints a per-occurrence alias for a repeated wire id; a `tool_call_update` still attaches to the latest start. Live `tc-<hash>` ids are unique, so the alias is a no-op live.

**"Worked for 1s" on every reload.** Replay updates carry no timestamps, so replayed turns were stamped at replay time and the duration label measured the replay itself. Real durations are now recorded live — `session/prompt`'s promise IS the run, so its wall time lands in a DATA_DIR sidecar (`acp-run-durations.json`, same shape/locking as the archived-sessions store) and gets re-attached on replay via each run-final turn's `meta.durationMs`. Sessions recorded before this change fall back to a plain "Worked".

Worth a close look:

- **Strip order** — envelope before `splitAttachmentNote`, because the send path appends the envelope *after* the note and the note parser reads the text's tail.
- **Alias pairing** — an update pairing with the *latest* start assumes starts/updates interleave in transcript order, which `session/load` guarantees.
- **Duration re-attach bails on mismatch** — durations only attach when the replayed run count matches the recording exactly; a session also driven outside moi would misalign every later run, and a missing label beats a wrong one.

Verified with a mock-ACP-agent test rig (`session.test.ts`) that drives the real stdio transport + session stack the way `session/load` does — envelope strip, tool-call collapse (red before the fix), duration re-attach and its mismatch bail are all covered. `bun test`: 1202 pass; `oxlint` clean; tsc error set unchanged vs base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKkzZCEJZ8ydJ3A17zD7ZP