### PR TITLE
Fix builder draft re-renders, per-stroke uploads, and the drawing hot path

### DIFF
--- a/client/features/chat/ChatPanel.tsx
+++ b/client/features/chat/ChatPanel.tsx
@@ -28,7 +28,11 @@ import { useUiStore } from '@/client/store/ui'
 
 export type ViewBuilderChatDraft = {
   sessionId: string
-  value: string
+  builderId: string
+  // Server-saved requirements the composer falls back to; the live draft text
+  // is subscribed from the UI store by builder id inside ChatComposer, so
+  // typing never re-renders this panel or the screen hosting it.
+  initialValue: string
   onChange: (value: string) => void
   onRemoveDrawing: (localId: string) => void
   onSubmit: (value: string) => Promise<void>
@@ -252,7 +256,8 @@ export function ChatPanel({
             draft={
               builderDraft
                 ? {
-                    value: builderDraft.value,
+                    id: builderDraft.builderId,
+                    initialValue: builderDraft.initialValue,
                     onChange: builderDraft.onChange
                   }
                 : undefined

--- a/client/features/chat/composer/ChatComposer.tsx
+++ b/client/features/chat/composer/ChatComposer.tsx
@@ -41,7 +41,11 @@ export type ComposerAnnotationControls = {
 }
 
 type ChatComposerDraft = {
-  value: string
+  // The UI-store key the composer subscribes to for live text; `initialValue`
+  // is the builder's server-saved requirements, used until a local draft
+  // exists.
+  id: string
+  initialValue: string
   onChange: (value: string) => void
 }
 
@@ -60,9 +64,10 @@ type ChatComposerProps = {
   draft?: ChatComposerDraft
 }
 
-// Draft text is persisted per workspace, while attachments remain ephemeral and
-// follow the selected chat. Both stores are subscribed here so a keystroke or
-// upload re-renders only the composer.
+// Draft text is persisted per workspace (or per view builder, when the
+// composer is fronting one), while attachments remain ephemeral and follow the
+// selected chat. Both stores are subscribed here so a keystroke or upload
+// re-renders only the composer.
 export function ChatComposer({
   composerRef,
   onSend,
@@ -80,7 +85,8 @@ export function ChatComposer({
   const fileRef = useRef<HTMLInputElement>(null)
   const workspaceId = useWorkspaceId()
   const workspaceDraft = useUiStore(s => s.composerDrafts[workspaceId] ?? '')
-  const value = draft?.value ?? workspaceDraft
+  const builderDraft = useUiStore(s => (draft ? (s.viewBuilderDrafts ?? {})[draft.id] : undefined))
+  const value = draft ? (builderDraft ?? draft.initialValue) : workspaceDraft
   const valueRef = useRef(value)
   valueRef.current = value
   const attachments = useLive(s => s.attachments[attachmentKey(workspaceId, sessionId)] ?? EMPTY)

--- a/client/features/drawings/useDrawingLayer.ts
+++ b/client/features/drawings/useDrawingLayer.ts
@@ -13,6 +13,8 @@ import type {
   RefObject
 } from 'react'
 
+import { toast } from '@/client/components/ui/toast'
+
 import type { DrawingCanvasPointerProps, DrawingLayerProps } from './DrawingLayer'
 import { captureElement, drawingCaptureScale } from './capture-element'
 
@@ -191,7 +193,10 @@ function drawPath(
   context.lineWidth = width
   context.strokeStyle = color
   context.moveTo(first.x, first.y)
-  for (const point of stroke.points.slice(1)) context.lineTo(point.x, point.y)
+  for (let index = 1; index < stroke.points.length; index++) {
+    const point = stroke.points[index]
+    context.lineTo(point.x, point.y)
+  }
   if (stroke.points.length === 1) context.lineTo(first.x + 0.01, first.y + 0.01)
   context.stroke()
 }
@@ -306,6 +311,7 @@ export function useDrawingLayer({
   const historyVersionRef = useRef(0)
   const draftRef = useRef<DrawingStroke | null>(null)
   const pointerIdRef = useRef<number | null>(null)
+  const frameRef = useRef(0)
   const lifecycleRevisionRef = useRef(0)
   const latestExportRef = useRef<DrawingExport | null>(null)
   const pendingExportRef = useRef<PendingDrawingExport | null>(null)
@@ -351,10 +357,25 @@ export function useDrawingLayer({
   const getHistoryState = useCallback(() => historyStateRef.current, [])
 
   const redraw = useCallback((strokes: DrawingStroke[], draft: DrawingStroke | null = null) => {
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current)
+      frameRef.current = 0
+    }
     const canvas = canvasRef.current
     const current = sessionRef.current
     if (canvas && current) renderDrawingLayer(canvas, current, strokes, draft)
   }, [])
+
+  // Pointer moves arrive faster than frames paint. Batching their redraws to
+  // one per frame keeps the cost of a move at "append points", so the surface
+  // stays smooth as strokes accumulate.
+  const scheduleRedraw = useCallback(() => {
+    if (frameRef.current) return
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = 0
+      redraw(historyRef.current.present, draftRef.current)
+    })
+  }, [redraw])
 
   const exportCommitted = useCallback(
     (
@@ -395,7 +416,18 @@ export function useDrawingLayer({
           onChangeRef.current?.(blob)
           return blob
         })
-        .catch(() => latestExportRef.current?.blob ?? null)
+        .catch(() => {
+          // Never fall back to an earlier export: a stale image that doesn't
+          // match the canvas is worse than no image. Surface the failure only
+          // if this export is still the current one.
+          if (
+            sessionRef.current?.id === current.id &&
+            historyVersionRef.current === historyVersion
+          ) {
+            toast.add({ title: 'Couldn’t export the drawing', type: 'error' })
+          }
+          return null
+        })
         .finally(() => {
           if (pendingExportRef.current?.promise === promise) pendingExportRef.current = null
         })
@@ -594,22 +626,17 @@ export function useDrawingLayer({
       },
       onPointerMove: (event: ReactPointerEvent<HTMLCanvasElement>) => {
         if (event.pointerId !== pointerIdRef.current || !draftRef.current) return
-        draftRef.current = {
-          points: [
-            ...draftRef.current.points,
-            ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
-          ]
-        }
-        redraw(historyRef.current.present, draftRef.current)
+        // Appended in place: rebuilding the array here made a long stroke
+        // quadratic in its own point count.
+        draftRef.current.points.push(
+          ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
+        )
+        scheduleRedraw()
       },
       onPointerUp: (event: ReactPointerEvent<HTMLCanvasElement>) => {
         if (event.pointerId !== pointerIdRef.current || !draftRef.current) return
-        const stroke = {
-          points: [
-            ...draftRef.current.points,
-            ...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent)
-          ]
-        }
+        const stroke = draftRef.current
+        stroke.points.push(...coalescedPointsOnCanvas(event.currentTarget, event.nativeEvent))
         draftRef.current = null
         pointerIdRef.current = null
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -621,7 +648,7 @@ export function useDrawingLayer({
         if (event.pointerId === pointerIdRef.current) cancelStroke()
       }
     }),
-    [apply, beginEditing, cancelStroke, installSession, mode, redraw]
+    [apply, beginEditing, cancelStroke, installSession, mode, redraw, scheduleRedraw]
   )
 
   const onKeyDown = useCallback(
@@ -673,6 +700,7 @@ export function useDrawingLayer({
       lifecycleRevisionRef.current += 1
       editingRef.current = false
       sessionRef.current = null
+      if (frameRef.current) cancelAnimationFrame(frameRef.current)
     },
     []
   )

--- a/client/features/drawings/useViewBuilderSketch.ts
+++ b/client/features/drawings/useViewBuilderSketch.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { stageDrawing } from '@/client/features/chat/attachment-staging'
-import { liveStore } from '@/client/features/chat/chat-store'
+import { stageDrawing, stageDrawingDraft } from '@/client/features/chat/attachment-staging'
+import { attachmentKey, liveStore } from '@/client/features/chat/chat-store'
 import type { WorkspaceTabId } from '@/lib/types'
 
 import { useDrawingLayer } from './useDrawingLayer'
@@ -29,6 +29,7 @@ export function useViewBuilderSketch({
 }: UseViewBuilderSketchOptions) {
   const attachmentIdRef = useRef(`sketch:${builderId}`)
   const uploadRevisionRef = useRef(0)
+  const uploadedBlobRef = useRef<Blob | null>(null)
   const pendingStageRef = useRef<Promise<void> | null>(null)
   const acceptExportsRef = useRef(true)
   const [continuing, setContinuing] = useState(false)
@@ -37,17 +38,52 @@ export function useViewBuilderSketch({
   onEditingStartRef.current = onEditingStart
   onContinueInChatRef.current = onContinueInChat
 
+  // While drawing, every commit only refreshes the chip's local preview. The
+  // single upload happens when the sketching session ends: prepareForSend
+  // (submit) or deactivate (tab switch, continue in chat).
   const change = useCallback(
     (blob: Blob | null) => {
       if (!acceptExportsRef.current) return
-      const revision = ++uploadRevisionRef.current
       if (!blob) {
+        uploadRevisionRef.current += 1
+        uploadedBlobRef.current = null
         pendingStageRef.current = null
         liveStore.getState().removeAttachment(workspaceId, sessionId, attachmentIdRef.current)
         return
       }
 
-      pendingStageRef.current = stageDrawing({
+      stageDrawingDraft({
+        workspaceId,
+        sessionId,
+        localId: attachmentIdRef.current,
+        purpose: 'sketch',
+        sourceTab,
+        blob
+      })
+    },
+    [sessionId, sourceTab, workspaceId]
+  )
+
+  // Exports are cached per history version, so an unchanged sketch comes back
+  // as the same Blob instance — the identity check is what makes repeated
+  // deactivations free instead of re-uploading the same image. A failed
+  // upload removes the attachment, so "same blob but not staged" retries.
+  const uploadIfNeeded = useCallback(
+    (blob: Blob | null): Promise<void> => {
+      if (!blob) return pendingStageRef.current ?? Promise.resolve()
+      if (blob === uploadedBlobRef.current) {
+        const staged = liveStore
+          .getState()
+          .attachments[attachmentKey(workspaceId, sessionId)]?.some(
+            attachment =>
+              attachment.localId === attachmentIdRef.current &&
+              (attachment.status === 'ready' || attachment.status === 'uploading')
+          )
+        if (staged) return pendingStageRef.current ?? Promise.resolve()
+      }
+      uploadedBlobRef.current = blob
+      const revision = ++uploadRevisionRef.current
+      const pending = stageDrawing({
         workspaceId,
         sessionId,
         localId: attachmentIdRef.current,
@@ -56,6 +92,8 @@ export function useViewBuilderSketch({
         blob,
         isCurrent: () => uploadRevisionRef.current === revision
       })
+      pendingStageRef.current = pending
+      return pending
     },
     [sessionId, sourceTab, workspaceId]
   )
@@ -68,14 +106,12 @@ export function useViewBuilderSketch({
   const { controls } = drawing
 
   const prepareForSend = useCallback(async () => {
-    await controls.flush()
-    await pendingStageRef.current
-  }, [controls])
+    await uploadIfNeeded(await controls.flush())
+  }, [controls, uploadIfNeeded])
 
   const deactivate = useCallback(async () => {
-    await controls.deactivate()
-    await pendingStageRef.current
-  }, [controls])
+    await uploadIfNeeded(await controls.deactivate())
+  }, [controls, uploadIfNeeded])
 
   const continueInChat = useCallback(async () => {
     if (continuing) return
@@ -91,6 +127,8 @@ export function useViewBuilderSketch({
   const resetDocument = useCallback(async () => {
     acceptExportsRef.current = false
     uploadRevisionRef.current += 1
+    uploadedBlobRef.current = null
+    pendingStageRef.current = null
     liveStore.getState().removeAttachment(workspaceId, sessionId, attachmentIdRef.current)
     try {
       await controls.cancel()

--- a/client/features/views/useViewBuilderDrafts.ts
+++ b/client/features/views/useViewBuilderDrafts.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { toast } from '@/client/components/ui/toast'
+import { useUiStore } from '@/client/store/ui'
 import type { ViewBuilder } from '@/lib/types'
 
 type UseViewBuilderDraftsOptions = {
@@ -8,8 +9,12 @@ type UseViewBuilderDraftsOptions = {
   onSave: (builderId: string, requirements: string) => Promise<unknown>
 }
 
+// Builder draft text lives in the UI store and is subscribed from the
+// composer, so a keystroke re-renders only the composer — never the workspace
+// screen with its tab bar, widgets, mounted views, and builder canvases. This
+// hook owns the writes: the store update, the debounced server save, and the
+// cleanup when a builder leaves its draft state.
 export function useViewBuilderDrafts({ builders, onSave }: UseViewBuilderDraftsOptions) {
-  const [drafts, setDrafts] = useState<Record<string, string>>({})
   const timersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>())
   const buildersRef = useRef(builders)
   const onSaveRef = useRef(onSave)
@@ -20,16 +25,11 @@ export function useViewBuilderDrafts({ builders, onSave }: UseViewBuilderDraftsO
     const timer = timersRef.current.get(builderId)
     if (timer) clearTimeout(timer)
     timersRef.current.delete(builderId)
-    setDrafts(current => {
-      if (!(builderId in current)) return current
-      const next = { ...current }
-      delete next[builderId]
-      return next
-    })
+    useUiStore.getState().setViewBuilderDraft(builderId, null)
   }, [])
 
   const change = useCallback((builderId: string, value: string) => {
-    setDrafts(current => ({ ...current, [builderId]: value }))
+    useUiStore.getState().setViewBuilderDraft(builderId, value)
     const existing = timersRef.current.get(builderId)
     if (existing) clearTimeout(existing)
     timersRef.current.set(
@@ -45,14 +45,15 @@ export function useViewBuilderDrafts({ builders, onSave }: UseViewBuilderDraftsO
     )
   }, [])
 
+  // Drop drafts for builders that left draft status through any path (submit
+  // from another surface, server-side transition). Builders absent from the
+  // list are cleared by the explicit discard/close paths, not here — the
+  // store outlives this screen and may hold other workspaces' drafts.
   useEffect(() => {
-    const draftIds = new Set(
-      builders.filter(builder => builder.status === 'draft').map(builder => builder.id)
-    )
-    for (const builderId of Object.keys(drafts)) {
-      if (!draftIds.has(builderId)) clear(builderId)
+    for (const builder of builders) {
+      if (builder.status !== 'draft') clear(builder.id)
     }
-  }, [builders, clear, drafts])
+  }, [builders, clear])
 
   useEffect(
     () => () => {
@@ -61,9 +62,5 @@ export function useViewBuilderDrafts({ builders, onSave }: UseViewBuilderDraftsO
     []
   )
 
-  return {
-    valueFor: (builder: ViewBuilder) => drafts[builder.id] ?? builder.input.requirements,
-    change,
-    clear
-  }
+  return { change, clear }
 }

--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -544,7 +544,8 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
   const builderChatDraft = activeDraftBuilder
     ? {
         sessionId: activeDraftBuilder.sessionId,
-        value: builderDrafts.valueFor(activeDraftBuilder),
+        builderId: activeDraftBuilder.id,
+        initialValue: activeDraftBuilder.input.requirements,
         onChange: (value: string) => builderDrafts.change(activeDraftBuilder.id, value),
         onRemoveDrawing: () => {
           void builderRefs.current.get(activeDraftBuilder.id)?.resetSketch()

--- a/client/store/ui.test.ts
+++ b/client/store/ui.test.ts
@@ -17,6 +17,7 @@ beforeEach(() => {
     hasSentMessageFromMoi: false,
     workspaceIdsPendingAnalysis: [],
     composerDrafts: {},
+    viewBuilderDrafts: {},
     dockedChatWidth: 360
   })
 })
@@ -81,6 +82,39 @@ describe('composer drafts', () => {
     expect(useUiStore.getState().composerDrafts).toEqual({ 'ws-1': 'Keep me' })
     expect(JSON.parse(storedValues.get('moi:ui') ?? '{}')).toMatchObject({
       state: { composerDrafts: { 'ws-1': 'Keep me' } }
+    })
+  })
+})
+
+describe('view builder drafts', () => {
+  test('keeps an empty draft distinct from no draft', () => {
+    useUiStore.getState().setViewBuilderDraft('builder-1', 'Chart of expenses')
+    useUiStore.getState().setViewBuilderDraft('builder-1', '')
+
+    // Deleted text must stay deleted — a missing entry falls back to the
+    // builder's server-saved requirements in the composer.
+    expect(useUiStore.getState().viewBuilderDrafts).toEqual({ 'builder-1': '' })
+
+    useUiStore.getState().setViewBuilderDraft('builder-1', null)
+
+    expect(useUiStore.getState().viewBuilderDrafts).toEqual({})
+  })
+
+  test('clearing a missing draft leaves state untouched', () => {
+    const before = useUiStore.getState()
+
+    useUiStore.getState().setViewBuilderDraft('builder-x', null)
+
+    expect(useUiStore.getState()).toBe(before)
+  })
+
+  test('restores drafts in a new store', () => {
+    useUiStore.getState().setViewBuilderDraft('builder-1', 'Weekly report view')
+
+    const restoredStore = createUiStore(localStorage)
+
+    expect(restoredStore.getState().viewBuilderDrafts).toEqual({
+      'builder-1': 'Weekly report view'
     })
   })
 })

--- a/client/store/ui.ts
+++ b/client/store/ui.ts
@@ -9,11 +9,13 @@ type UiStore = {
   hasSentMessageFromMoi: boolean
   workspaceIdsPendingAnalysis: string[]
   composerDrafts: Record<string, string>
+  viewBuilderDrafts: Record<string, string>
   dockedChatWidth: number
   setDiscoveredWorkspacesOpen: (open: boolean) => void
   markWorkspacePendingAnalysis: (workspaceId: string) => void
   markMessageSentFromMoi: (workspaceId: string) => void
   setComposerDraft: (workspaceId: string, value: string) => void
+  setViewBuilderDraft: (builderId: string, value: string | null) => void
   setDockedChatWidth: (width: number) => void
 }
 
@@ -25,6 +27,7 @@ export const createUiStore = (storage?: StateStorage) =>
         hasSentMessageFromMoi: false,
         workspaceIdsPendingAnalysis: [],
         composerDrafts: {},
+        viewBuilderDrafts: {},
         dockedChatWidth: 360,
         setDiscoveredWorkspacesOpen: open => set({ discoveredWorkspacesOpen: open }),
         markWorkspacePendingAnalysis: workspaceId =>
@@ -49,6 +52,22 @@ export const createUiStore = (storage?: StateStorage) =>
             if (value) composerDrafts[workspaceId] = value
             else delete composerDrafts[workspaceId]
             return { composerDrafts }
+          }),
+        // Unlike composer drafts, an empty string stays stored: the composer
+        // falls back to the builder's server-saved requirements when no draft
+        // exists, and deleting all text must not resurrect them. Pass null to
+        // drop the draft (submit, discard).
+        setViewBuilderDraft: (builderId, value) =>
+          set(state => {
+            const current = state.viewBuilderDrafts ?? {}
+            if (value === null) {
+              if (!(builderId in current)) return state
+              const viewBuilderDrafts = { ...current }
+              delete viewBuilderDrafts[builderId]
+              return { viewBuilderDrafts }
+            }
+            if (current[builderId] === value) return state
+            return { viewBuilderDrafts: { ...current, [builderId]: value } }
           }),
         setDockedChatWidth: width => set({ dockedChatWidth: width })
       }),


### PR DESCRIPTION
Stacks on #96, addressing findings 1, 2, 3, and 5 from [the review](https://claude.ai/code/artifact/d9c55842-2136-4f71-8e05-04d4ff24690d). Typing in the builder composer now re-renders only the composer (drafts moved to the UI store keyed by builder id), and the sketch uploads once when the drawing session ends instead of POSTing a full PNG per pen-up — the same two properties #95 established for annotations. The drawing surface also stays smooth as strokes accumulate, and a failed PNG export surfaces a toast instead of silently sending an earlier image.

Observable difference for a 30-stroke sketch, then send:

```
before: 30 × encode + POST /uploads (plus one per undo/redo/clear), each keystroke re-rendering tabs, widgets, views, canvases, ChatPanel
after:   1 × encode + POST at send/tab-switch; a keystroke re-renders ChatComposer only
```

Worth a close look:

- `useViewBuilderSketch.uploadIfNeeded` — skips re-upload via Blob identity, relying on `exportCommitted`'s per-history-version cache returning the same instance; a failed upload is detected by the attachment no longer being staged, which retries at the next session end.
- `setViewBuilderDraft` keeps `''` stored (unlike `composerDrafts`): deleting all text must not resurrect the server-saved requirements. `null` deletes.
- `useDrawingLayer` pointer moves mutate the draft stroke in place and batch redraws into rAF; the committed stroke reuses the draft object, safe because `draftRef` is nulled before `apply`.

Findings 4 (ChatPanel's builder mode branches) and 6 are deliberately not addressed here.

Verified: `tsc -p tsconfig.client.json` clean, oxlint clean, `bun test` — 1151 pass / 0 fail (3 new tests cover the draft-store semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DaNiYhRA2HYTgzQiR4caG

---
_Generated by [Claude Code](https://claude.ai/code/session_018DaNiYhRA2HYTgzQiR4caG)_