### PR TITLE
Validate service install options before checking server state

### DIFF
--- a/server/cli.ts
+++ b/server/cli.ts
@@ -5,7 +5,7 @@ import { formatHex } from 'culori'
 import { parse as devalueParse } from 'devalue'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'path'
+import { dirname, join, resolve } from 'path'
 import pc from './cli-pc'
 
 import { isAgentCaller } from './agent-caller'
@@ -61,6 +61,7 @@ import { updateWorkspaceSkills } from './skill-update'
 import {
   ServiceError,
   analyzeInstall,
+  captureServiceEnv,
   installService,
   queryServerInfo,
   restartService,
@@ -2393,6 +2394,25 @@ const serviceInstall = defineCommand({
         serviceFail(err)
       }
     }
+    const port = args.port ? Number(args.port) : undefined
+    if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) {
+      serviceFail(new ServiceError(`Invalid --port value "${args.port}" — use a port number.`))
+    }
+    // citty hands back an array when the flag repeats — accept both shapes.
+    const envArg = Array.isArray(args.env) ? args.env.join(',') : args.env
+    const extraEnv = (envArg ?? '')
+      .split(',')
+      .map(k => k.trim())
+      .filter(Boolean)
+    const serviceEnv = captureServiceEnv(process.env, dirname(process.execPath), extraEnv)
+    const missingEnv = extraEnv.filter(key => !(key in serviceEnv))
+    if (missingEnv.length > 0) {
+      serviceFail(
+        new ServiceError(
+          `--env ${missingEnv.join(', ')}: not set in this shell (or the value is not capturable).`
+        )
+      )
+    }
     // A foreground `moi start` holds the same ports the service needs. Refuse
     // rather than install a unit that instantly fails on bind.
     const runningInfo = await queryServerInfo()
@@ -2406,16 +2426,6 @@ const serviceInstall = defineCommand({
         )
       )
     }
-    const port = args.port ? Number(args.port) : undefined
-    if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) {
-      serviceFail(new ServiceError(`Invalid --port value "${args.port}" — use a port number.`))
-    }
-    // citty hands back an array when the flag repeats — accept both shapes.
-    const envArg = Array.isArray(args.env) ? args.env.join(',') : args.env
-    const extraEnv = (envArg ?? '')
-      .split(',')
-      .map(k => k.trim())
-      .filter(Boolean)
     try {
       const result = await installService({ port, extraEnv })
       console.log(


### PR DESCRIPTION
Invalid `moi service install` options now fail before moi probes the foreground server. This keeps validation deterministic and prevents an active development server from masking an invalid `--port` or missing `--env` value.

```text
$ moi service install --port nope
✗ Invalid --port value "nope" — use a port number.
```

The global-install shape check still runs first. Valid options continue through the existing foreground-server guard and service installation flow.

Review focus:

- The CLI preflight uses the same `captureServiceEnv` rules as installation, so uncapturable named values fail consistently.
- Runtime checks still happen before any service files are written.

Verified with:

- `bun test --only-failures` — 1,215 passed, 4 skipped
- `bun run lint`
- `bun run format:check`
- `git diff --check`
