### PR TITLE
Store applet thumbnails in .moi/.cache and guard slow captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # workspace template — ignore build artifacts and local state
 workspace/.moi/.build
+workspace/.moi/.cache
 workspace/.moi/.workspace.json
 workspace/.moi/node_modules
 workspace/.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Claude-only config (`.claude/settings.json` hooks, `.claude/launch.json`) stays 
 ## Data flow
 
 - Each workspace added/imported to moi stores its settings in a `.moi/.workspace.json` file in the workspace folder (hidden filename; `server/layout.ts` is its sole reader/writer).
-- Everything inside `.moi/` is safe to commit, so the same workspace can be shared with others.
+- Everything inside `.moi/` is safe to commit, so the same workspace can be shared with others — except the machine-local dot-dirs: `.build/` (bundler output), `.cache/` (derived artifacts such as applet thumbnails, see `server/thumbnails.ts`), and `.scratchpad/`. All are re-creatable and safe to delete or gitignore.
 - Prefer `.moi/.workspace.json` for state that describes the workspace itself rather than the person or device using it — e.g. chat/thread settings, widget layout, connectors. Litmus test: anyone who clones the workspace should get the same value.
 - Store per-user app state that should follow the local moi installation in the server-side `DATA_DIR`. Expose it through the API and use React Query for client caching and optimistic updates.
 - Store per-browser or per-device UI preferences in `client/store/ui.ts`.

--- a/client/api/workspace-keys.ts
+++ b/client/api/workspace-keys.ts
@@ -5,6 +5,7 @@ export const workspaceKeys = {
   preview: (id: string) => ['workspaces', 'preview', id] as const,
   layout: (id: string) => ['workspaces', 'layout', id] as const,
   widgets: (id: string) => ['workspaces', 'widgets', id] as const,
+  appletThumbnails: (id: string) => ['workspaces', 'applet-thumbnails', id] as const,
   views: (id: string) => ['workspaces', 'views', id] as const,
   viewBuilders: (id: string) => ['workspaces', 'view-builders', id] as const,
   sessions: (id: string) => ['workspaces', 'sessions', id] as const,

--- a/client/features/applets/api.ts
+++ b/client/features/applets/api.ts
@@ -1,8 +1,24 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { jsonRequest, requestVoid } from '@/client/api/http'
+import { jsonRequest, requestJson, requestVoid } from '@/client/api/http'
+import { WORKSPACE_RESOURCE_OPTIONS } from '@/client/api/query-options'
 import { workspaceKeys } from '@/client/api/workspace-keys'
-import type { AppletThumbnailBatch } from '@/lib/types'
+import type { AppletThumbnail, AppletThumbnailBatch } from '@/lib/types'
+
+// Freshness records only — image bytes stay server-side (`.moi/.cache`) and
+// reach the UI as plain <img> URLs.
+export function useAppletThumbnailRecords(workspaceId: string) {
+  return useQuery<AppletThumbnail[]>({
+    queryKey: workspaceKeys.appletThumbnails(workspaceId),
+    queryFn: async () =>
+      (
+        await requestJson<{ thumbnails: AppletThumbnail[] }>(
+          `/api/workspaces/${workspaceId}/applet-thumbnails`
+        )
+      ).thumbnails,
+    ...WORKSPACE_RESOURCE_OPTIONS
+  })
+}
 
 export function useSaveAppletThumbnails(workspaceId: string) {
   const queryClient = useQueryClient()
@@ -15,7 +31,7 @@ export function useSaveAppletThumbnails(workspaceId: string) {
         'Failed to save applet thumbnails'
       ),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: workspaceKeys.layout(workspaceId) })
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.appletThumbnails(workspaceId) })
       queryClient.invalidateQueries({ queryKey: workspaceKeys.preview(workspaceId) })
     }
   })

--- a/client/features/applets/applet-thumbnail.test.ts
+++ b/client/features/applets/applet-thumbnail.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, test } from 'bun:test'
 import type { AppletThumbnail } from '@/lib/types'
 
 import {
+  SLOW_CAPTURE_MS,
   THUMBNAIL_FRESH_MS,
   THUMBNAIL_MAX_EDGE,
   THUMBNAIL_PIXEL_RATIO,
   appletThumbnailRevision,
   collectAppletThumbnailUpdates,
   isAppletThumbnailStale,
+  shouldSkipSlowCapture,
   thumbnailScale
 } from './applet-thumbnail'
 
@@ -23,7 +25,6 @@ function record(overrides: Partial<AppletThumbnail> = {}): AppletThumbnail {
     revision: appletThumbnailRevision('bundle-1'),
     capturedAt: new Date(10_000).toISOString(),
     viewedAt: new Date(10_000).toISOString(),
-    image: 'old-image',
     ...overrides
   }
 }
@@ -55,32 +56,66 @@ describe('applet thumbnails', () => {
     expect(isAppletThumbnailStale(record(), revision, 10_000 + THUMBNAIL_FRESH_MS)).toBe(true)
   })
 
+  test('skips slow re-captures of an unchanged bundle but retries a rebuilt one', () => {
+    const revision = appletThumbnailRevision('bundle-1')
+    const slow = record({ captureMs: SLOW_CAPTURE_MS })
+    expect(shouldSkipSlowCapture(slow, revision)).toBe(true)
+    expect(shouldSkipSlowCapture(record({ captureMs: SLOW_CAPTURE_MS - 1 }), revision)).toBe(false)
+    expect(shouldSkipSlowCapture(record({ captureMs: undefined }), revision)).toBe(false)
+    // A rebuilt bundle earns one measured attempt even on a slow target.
+    expect(shouldSkipSlowCapture(slow, appletThumbnailRevision('bundle-2'))).toBe(false)
+    expect(shouldSkipSlowCapture(undefined, revision)).toBe(false)
+  })
+
   test('touches fresh targets and captures stale targets sequentially', async () => {
-    const captures: string[] = []
+    let captures = 0
     const updates = await collectAppletThumbnailUpdates(
       'widget',
       [record()],
       [
         { id: 'one', revision: 'bundle-1', element: element() },
-        {
-          id: 'two',
-          revision: 'bundle-2',
-          element: element()
-        }
+        { id: 'two', revision: 'bundle-2', element: element() }
       ],
       () => false,
-      async (_element, stripHostChrome) => {
-        captures.push(stripHostChrome ? 'two' : 'one')
+      async () => {
+        captures += 1
         return 'new-image'
       },
       10_000
     )
 
-    expect(captures).toEqual(['two'])
+    expect(captures).toBe(1)
     expect(updates).toEqual([
       { id: 'one', revision: appletThumbnailRevision('bundle-1') },
-      { id: 'two', revision: appletThumbnailRevision('bundle-2'), image: 'new-image' }
+      {
+        id: 'two',
+        revision: appletThumbnailRevision('bundle-2'),
+        image: 'new-image',
+        captureMs: expect.any(Number)
+      }
     ])
+  })
+
+  test('sends a touch instead of re-capturing a slow target whose bundle is unchanged', async () => {
+    let captures = 0
+    const slow = record({
+      captureMs: SLOW_CAPTURE_MS,
+      capturedAt: new Date(0).toISOString()
+    })
+    const updates = await collectAppletThumbnailUpdates(
+      'widget',
+      [slow],
+      [{ id: 'one', revision: 'bundle-1', element: element() }],
+      () => false,
+      async () => {
+        captures += 1
+        return 'image'
+      },
+      THUMBNAIL_FRESH_MS + 1
+    )
+
+    expect(captures).toBe(0)
+    expect(updates).toEqual([{ id: 'one', revision: appletThumbnailRevision('bundle-1') }])
   })
 
   test('captures one active view target and stops a cancelled batch', async () => {
@@ -92,7 +127,12 @@ describe('applet thumbnails', () => {
       async () => 'view-image'
     )
     expect(viewUpdates).toEqual([
-      { id: 'dashboard', revision: appletThumbnailRevision('r1'), image: 'view-image' }
+      {
+        id: 'dashboard',
+        revision: appletThumbnailRevision('r1'),
+        image: 'view-image',
+        captureMs: expect.any(Number)
+      }
     ])
 
     let cancelled = false

--- a/client/features/applets/applet-thumbnail.ts
+++ b/client/features/applets/applet-thumbnail.ts
@@ -1,12 +1,16 @@
 import { useEffect, useRef } from 'react'
 
-import { useSaveAppletThumbnails } from '@/client/features/applets/api'
-import { useWorkspaceLayoutCtx } from '@/client/features/workspace/WorkspaceLayoutContext'
+import { useAppletThumbnailRecords, useSaveAppletThumbnails } from '@/client/features/applets/api'
+import { useWorkspaceId } from '@/client/features/workspace/WorkspaceContext'
 import type { AppletKind, AppletThumbnail, AppletThumbnailUpdate } from '@/lib/types'
 
 export const THUMBNAIL_MAX_EDGE = 1_000
 export const THUMBNAIL_PIXEL_RATIO = 3
 export const THUMBNAIL_FRESH_MS = 3 * 60 * 60 * 1_000
+// A capture that took this long janked the main thread (the DOM clone +
+// style-inline walk is synchronous). Routine age-based re-captures of such a
+// target are skipped; only a rebuilt bundle earns another attempt.
+export const SLOW_CAPTURE_MS = 1_000
 
 const THUMBNAIL_FORMAT_REVISION = '1000px-3x-webp-q80-v1'
 const SETTLE_MS = 5_000
@@ -49,6 +53,21 @@ export function isAppletThumbnailStale(
   if (!record || record.revision !== revision) return true
   const capturedAt = Date.parse(record.capturedAt)
   return !Number.isFinite(capturedAt) || now - capturedAt >= THUMBNAIL_FRESH_MS
+}
+
+// A slow target is only worth re-capturing when its bundle changed: the new
+// code deserves one measured attempt. A routine age-based refresh of the same
+// bundle is not worth a >1s main-thread stall for a slightly fresher image.
+export function shouldSkipSlowCapture(
+  record: AppletThumbnail | undefined,
+  revision: string
+): boolean {
+  return (
+    record !== undefined &&
+    record.revision === revision &&
+    record.captureMs !== undefined &&
+    record.captureMs >= SLOW_CAPTURE_MS
+  )
 }
 
 const timeoutNull = (ms: number) =>
@@ -108,12 +127,20 @@ export async function collectAppletThumbnailUpdates(
       updates.push({ id: target.id, revision })
       continue
     }
+    if (shouldSkipSlowCapture(record, revision)) {
+      updates.push({ id: target.id, revision })
+      continue
+    }
 
-    const image = target.element
-      ? await capture(target.element, kind === 'widget').catch(() => null)
-      : null
+    if (!target.element) {
+      updates.push({ id: target.id, revision, image: null })
+      continue
+    }
+    const started = performance.now()
+    const image = await capture(target.element, kind === 'widget').catch(() => null)
+    const captureMs = Math.round(performance.now() - started)
     if (isCancelled()) return null
-    updates.push({ id: target.id, revision, image })
+    updates.push({ id: target.id, revision, image, captureMs })
   }
 
   return updates
@@ -122,18 +149,22 @@ export async function collectAppletThumbnailUpdates(
 // Widgets provide every visible grid cell; a view provides only its active
 // frame. The lifecycle and persistence stay identical for both kinds.
 export function useAppletThumbnails({ kind, enabled, targets }: UseAppletThumbnailsArgs): void {
-  const { layout, workspaceId } = useWorkspaceLayoutCtx()
+  const workspaceId = useWorkspaceId()
+  const records = useAppletThumbnailRecords(workspaceId).data
   const save = useSaveAppletThumbnails(workspaceId)
   const targetsRef = useRef(targets)
   targetsRef.current = targets
-  const recordsRef = useRef(layout.appletThumbnails ?? [])
-  recordsRef.current = layout.appletThumbnails ?? []
+  const recordsRef = useRef(records ?? [])
+  recordsRef.current = records ?? []
   const saveRef = useRef(save.mutate)
   saveRef.current = save.mutate
   const targetKey = targets.map(target => `${target.id}@${target.revision ?? ''}`).join('\n')
+  // Hold the first pass until the stored records arrive — capturing against an
+  // unloaded store would re-screenshot everything on every page load.
+  const ready = records !== undefined
 
   useEffect(() => {
-    if (!enabled || targetKey === '') return
+    if (!enabled || !ready || targetKey === '') return
 
     let cancelled = false
     let generation = 0
@@ -173,5 +204,5 @@ export function useAppletThumbnails({ kind, enabled, targets }: UseAppletThumbna
       if (timer !== undefined) clearTimeout(timer)
       document.removeEventListener('visibilitychange', schedule)
     }
-  }, [enabled, kind, targetKey])
+  }, [enabled, kind, ready, targetKey])
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -548,24 +548,30 @@ export type WorkspaceLayout = {
   // Fast-mode default for new sessions. Undefined inherits the provider setting.
   selectedFastMode?: boolean
   theme?: import('./themes').WorkspaceTheme
-  // Client-captured applet previews. The normal layout GET strips image bytes;
-  // the dedicated endpoint is the only writer for these records.
-  appletThumbnails?: AppletThumbnail[]
 }
 
+// One applet's thumbnail freshness record. Image bytes live as files in the
+// workspace's `.moi/.cache/thumbnails/` (server/thumbnails.ts), never in
+// `.workspace.json` — the layout file stays small and commit-safe.
 export type AppletThumbnail = {
   kind: AppletKind
   id: string
   revision: string
   capturedAt: string
   viewedAt: string
-  image?: string
+  // How long the last successful capture took on this client, in ms. Lets the
+  // capture hook skip routine re-captures of applets that are slow to
+  // screenshot (see SLOW_CAPTURE_MS) instead of janking the main thread.
+  captureMs?: number
 }
 
 export type AppletThumbnailUpdate = {
   id: string
   revision: string
+  // A string replaces the stored image, null records a failed or skipped
+  // attempt (the previous image survives), undefined only touches recency.
   image?: string | null
+  captureMs?: number
 }
 
 export type AppletThumbnailBatch = {

--- a/server/api.ts
+++ b/server/api.ts
@@ -27,13 +27,8 @@ import { applyEnvChanged } from './env-apply'
 import { publishEvent } from './events'
 import { callFunction, parseFunctionPath } from './functions'
 import { processIcon } from './icon'
-import {
-  getWorkspacePreview,
-  loadLayout,
-  mergeLayoutForSave,
-  saveAppletThumbnails,
-  saveLayout
-} from './layout'
+import { getWorkspacePreview, loadLayout, mergeLayoutForSave, saveLayout } from './layout'
+import { getAppletThumbnailRecords, saveAppletThumbnails, serveAppletThumbnail } from './thumbnails'
 import { getClientFrameLog, getWireLog } from './harness/debug'
 import { allHarnesses, harnessFor, isHarnessType } from './harness/registry'
 import { broadcast } from './state'
@@ -151,13 +146,16 @@ one.use('*', withWorkspace)
 
 one.get('/preview', async c => {
   const ws = c.get('ws')
+  const wsId = c.req.param('id')
   const views = await getViewList(ws.path)
   return c.json(
-    await getWorkspacePreview(
-      ws.path,
-      includeFirstUserMessage => harnessFor(ws).workspacePreview(ws, includeFirstUserMessage),
-      views.map(view => view.id)
-    )
+    await getWorkspacePreview(ws.path, {
+      getProviderPreview: includeFirstUserMessage =>
+        harnessFor(ws).workspacePreview(ws, includeFirstUserMessage),
+      viewIds: views.map(view => view.id),
+      thumbnailUrl: (kind, id) =>
+        `/api/workspaces/${wsId}/applet-thumbnails/${kind}/${encodeURIComponent(id)}`
+    })
   )
 })
 
@@ -831,20 +829,32 @@ one.delete('/icon', async c => {
 // DELETE unregisters.
 one.get('/', async c => {
   const ws = c.get('ws')
-  // The client needs thumbnail freshness metadata, while image bytes only
-  // travel through the preview endpoint.
   const layout = await loadLayout(ws.path)
   return c.json({
     ...layout,
-    ...(layout.appletThumbnails && {
-      appletThumbnails: layout.appletThumbnails.map(({ image: _image, ...thumbnail }) => thumbnail)
-    }),
     // Resolved display name: the settings override, or the folder name.
     name: layout.name || basename(ws.path),
     cwd: ws.path,
     provider: ws.type,
     agentId: ws.agentId
   })
+})
+
+// Thumbnail freshness records, without image bytes — the capture hook compares
+// these against live bundle revisions. Images are served per-applet below.
+one.get('/applet-thumbnails', async c =>
+  c.json({ thumbnails: await getAppletThumbnailRecords(c.get('ws').path) })
+)
+
+one.get('/applet-thumbnails/:kind/:name', c => {
+  const kind = c.req.param('kind')
+  if (kind !== 'widget' && kind !== 'view') return c.text('Not found', 404)
+  return serveAppletThumbnail(
+    c.get('ws').path,
+    kind,
+    c.req.param('name'),
+    c.req.header('if-none-match')
+  )
 })
 
 // Settled widget and view visits share one batch endpoint and storage path.
@@ -864,7 +874,8 @@ one.put('/applet-thumbnails', async c => {
         typeof thumbnail.revision === 'string' &&
         (thumbnail.image === undefined ||
           thumbnail.image === null ||
-          typeof thumbnail.image === 'string')
+          typeof thumbnail.image === 'string') &&
+        (thumbnail.captureMs === undefined || typeof thumbnail.captureMs === 'number')
     )
   if (!valid) return c.text('Bad request', 400)
   await saveAppletThumbnails(c.get('ws').path, input.kind, input.thumbnails)

--- a/server/api.ts
+++ b/server/api.ts
@@ -28,7 +28,12 @@ import { publishEvent } from './events'
 import { callFunction, parseFunctionPath } from './functions'
 import { processIcon } from './icon'
 import { getWorkspacePreview, loadLayout, mergeLayoutForSave, saveLayout } from './layout'
-import { getAppletThumbnailRecords, saveAppletThumbnails, serveAppletThumbnail } from './thumbnails'
+import {
+  getAppletThumbnailRecords,
+  isValidAppletId,
+  saveAppletThumbnails,
+  serveAppletThumbnail
+} from './thumbnails'
 import { getClientFrameLog, getWireLog } from './harness/debug'
 import { allHarnesses, harnessFor, isHarnessType } from './harness/registry'
 import { broadcast } from './state'
@@ -871,6 +876,7 @@ one.put('/applet-thumbnails', async c => {
         typeof thumbnail === 'object' &&
         !Array.isArray(thumbnail) &&
         typeof thumbnail.id === 'string' &&
+        isValidAppletId(thumbnail.id) &&
         typeof thumbnail.revision === 'string' &&
         (thumbnail.image === undefined ||
           thumbnail.image === null ||

--- a/server/applets.ts
+++ b/server/applets.ts
@@ -23,6 +23,7 @@ import {
   buildApplet,
   scanRelativeImports
 } from './bundler/build-applet'
+import { pruneAppletThumbnails } from './thumbnails'
 
 export type AppletPaths = {
   moiRoot: string
@@ -594,6 +595,8 @@ export async function buildApplets<C>(
     await mkdir(buildDir, { recursive: true })
   }
   await pruneStaleBuilds(buildDir, new Set(names))
+  // A deleted applet's thumbnail dies with its bundle.
+  await pruneAppletThumbnails(workspacePath, kind, names)
 
   const jobs = await Promise.all(
     names.map(async name => {

--- a/server/layout.ts
+++ b/server/layout.ts
@@ -1,14 +1,10 @@
 import { join } from 'path'
 
-import type {
-  AppletKind,
-  AppletThumbnail,
-  AppletThumbnailBatch,
-  WorkspaceLayout,
-  WorkspacePreview
-} from '@/lib/types'
+import type { AppletKind, WorkspaceLayout, WorkspacePreview } from '@/lib/types'
 import { createDefaultWorkspaceLayout, createDefaultWorkspaceTabs } from '@/lib/workspace-layout'
 import { isWorkspaceTabId } from '@/lib/workspace-tabs'
+
+import { getCapturedThumbnails } from './thumbnails'
 
 function normalizeTabs(value: unknown): WorkspaceLayout['tabs'] {
   if (!value || typeof value !== 'object') return createDefaultWorkspaceTabs()
@@ -28,11 +24,12 @@ function normalizeLayout(parsed: Record<string, unknown>): WorkspaceLayout {
     layout.layoutMode = defaults.layoutMode
   }
   layout.tabs = normalizeTabs(layout.tabs)
-  if (!Array.isArray(layout.appletThumbnails)) delete layout.appletThumbnails
-  // Thumbnail caches from the two feature-specific implementations are
-  // intentionally dropped. Applets are captured again into the shared model.
+  // Legacy thumbnail caches are intentionally dropped, not migrated — images
+  // now live as files under `.moi/.cache/thumbnails` (server/thumbnails.ts)
+  // and applets are simply captured again there.
   delete layout.widgetThumbnails
   delete layout.viewThumbnails
+  delete layout.appletThumbnails
   delete layout.sectionMode
   delete layout.chatMode
   return layout as unknown as WorkspaceLayout
@@ -65,67 +62,25 @@ export async function saveLayout(layout: WorkspaceLayout, workspacePath: string)
 // A blind overwrite therefore erases a `moi config`-set name (and could revert an
 // icon). So drop whatever identity the body carries and re-apply the server-owned
 // fields from `existing` — conditionally, so an absent field never serializes
-// as `name: undefined`. Applet thumbnails have their own endpoint and the layout
-// GET omits their image bytes, so normal layout writes preserve the stored set.
+// as `name: undefined`.
 export function mergeLayoutForSave(
   existing: WorkspaceLayout,
   body: WorkspaceLayout
 ): WorkspaceLayout {
-  const { name: _name, icon: _icon, appletThumbnails: _appletThumbnails, ...editor } = body
+  const { name: _name, icon: _icon, ...editor } = body
+  // Stale clients may still round-trip the pre-`.cache` thumbnail records;
+  // never let a layout PUT resurrect them in `.workspace.json`.
+  delete (editor as Record<string, unknown>).appletThumbnails
   return {
     ...editor,
     ...(existing.name !== undefined && { name: existing.name }),
-    ...(existing.icon !== undefined && { icon: existing.icon }),
-    ...(existing.appletThumbnails !== undefined && {
-      appletThumbnails: existing.appletThumbnails
-    })
+    ...(existing.icon !== undefined && { icon: existing.icon })
   }
-}
-
-const PREVIEW_LIMIT = 3
-
-// Merge a settled applet batch into the one shared thumbnail store. A string
-// replaces the image, null records a failed attempt while keeping any previous
-// image, and an omitted image only updates visit recency.
-export async function saveAppletThumbnails(
-  workspacePath: string,
-  kind: AppletKind,
-  updates: AppletThumbnailBatch['thumbnails']
-): Promise<void> {
-  const existing = await loadLayout(workspacePath)
-  const now = new Date().toISOString()
-  const records = [...(existing.appletThumbnails ?? [])]
-
-  for (const update of updates) {
-    const index = records.findIndex(record => record.kind === kind && record.id === update.id)
-    const previous = records[index]
-
-    if (update.image === undefined) {
-      if (previous) records[index] = { ...previous, viewedAt: now }
-      continue
-    }
-
-    const record: AppletThumbnail = {
-      kind,
-      id: update.id,
-      revision: update.revision,
-      capturedAt: now,
-      viewedAt: now,
-      ...(typeof update.image === 'string'
-        ? { image: update.image }
-        : previous?.image !== undefined
-          ? { image: previous.image }
-          : {})
-    }
-    if (previous) records[index] = record
-    else records.push(record)
-  }
-
-  await saveLayout({ ...existing, appletThumbnails: records }, workspacePath)
 }
 
 // Thumbnails for the home screen's workspace card. Widgets take the front
 // slots in grid order, then recent views fill what remains.
+const PREVIEW_LIMIT = 3
 const PREVIEW_MESSAGE_LIMIT = 240
 
 function normalizePreviewMessage(message: string | undefined): string | undefined {
@@ -135,30 +90,36 @@ function normalizePreviewMessage(message: string | undefined): string | undefine
   return `${normalized.slice(0, PREVIEW_MESSAGE_LIMIT - 1).trimEnd()}…`
 }
 
-export async function getWorkspacePreview(
-  workspacePath: string,
+export type WorkspacePreviewOptions = {
   getProviderPreview?: (includeFirstUserMessage: boolean) => Promise<{
     firstUserMessage?: string
     updatedAt?: number
-  }>,
-  viewIds: readonly string[] = []
+  }>
+  viewIds?: readonly string[]
+  // Maps a captured applet to the image URL the home card should render —
+  // the API layer owns the route shape (GET .../applet-thumbnails/:kind/:id).
+  thumbnailUrl: (kind: AppletKind, id: string) => string
+}
+
+export async function getWorkspacePreview(
+  workspacePath: string,
+  { getProviderPreview, viewIds = [], thumbnailUrl }: WorkspacePreviewOptions
 ): Promise<WorkspacePreview> {
   try {
     const layout = await loadLayout(workspacePath)
-    const records = layout.appletThumbnails ?? []
+    const captured = await getCapturedThumbnails(workspacePath)
     const validViewIds = new Set(viewIds)
-    const recordByKey = new Map(records.map(record => [`${record.kind}:${record.id}`, record]))
+    const capturedWidgets = new Set(
+      captured.filter(record => record.kind === 'widget').map(record => record.id)
+    )
     const widgetImages = [...layout.widgetGrid]
       .sort((a, b) => a.y - b.y || a.x - b.x)
-      .map(item => recordByKey.get(`widget:${item.i}`)?.image)
-      .filter((image): image is string => typeof image === 'string')
-    const viewImages = records
-      .filter(
-        record =>
-          record.kind === 'view' && validViewIds.has(record.id) && typeof record.image === 'string'
-      )
+      .filter(item => capturedWidgets.has(item.i))
+      .map(item => thumbnailUrl('widget', item.i))
+    const viewImages = captured
+      .filter(record => record.kind === 'view' && validViewIds.has(record.id))
       .sort((a, b) => Date.parse(b.viewedAt) - Date.parse(a.viewedAt))
-      .map(record => record.image as string)
+      .map(record => thumbnailUrl('view', record.id))
     const thumbnails = [...widgetImages, ...viewImages].slice(0, PREVIEW_LIMIT)
     // The message bubble is the card's fallback for "nothing to show": gate on
     // captured thumbnails, not grid emptiness — a workspace with widgets that

--- a/server/moi-scaffold.ts
+++ b/server/moi-scaffold.ts
@@ -53,11 +53,31 @@ async function runBunInstall(moiDir: string): Promise<number> {
 // derived caches (applet thumbnails), and installed dependencies are all
 // re-creatable and would otherwise churn or bloat the repo. The applet sources,
 // package.json, and lockfile stay committable — they ARE the workspace.
+const REQUIRED_IGNORES = ['.build/', '.cache/', 'node_modules/'] as const
+
 export const MOI_GITIGNORE = `# moi internals — machine-local, re-creatable state
-.build/
-.cache/
-node_modules/
+${REQUIRED_IGNORES.join('\n')}
 `
+
+// Create `.moi/.gitignore` when missing, or append required entries a
+// pre-gitignore or hand-edited file lacks. Never rewrites existing content —
+// user additions survive. Safe to call often; no-ops once the file is right.
+export async function ensureMoiGitignore(workspacePath: string): Promise<void> {
+  const moiDir = join(workspacePath, '.moi')
+  if (!(await isDirectory(moiDir))) return
+  const path = join(moiDir, '.gitignore')
+  const file = Bun.file(path)
+  if (!(await file.exists())) {
+    await Bun.write(path, MOI_GITIGNORE)
+    return
+  }
+  const text = await file.text()
+  // Match entries with or without the trailing slash or a leading slash.
+  const present = new Set(text.split('\n').map(line => line.trim().replace(/^\/|\/$/g, '')))
+  const missing = REQUIRED_IGNORES.filter(entry => !present.has(entry.replace(/\/$/, '')))
+  if (missing.length === 0) return
+  await Bun.write(path, `${text.replace(/\n*$/, '\n')}${missing.join('\n')}\n`)
+}
 
 // Ambient types for applets (widgets & views). Editor DX only — the moi
 // bundler resolves the `moi` module and asset imports at build time without any
@@ -144,13 +164,18 @@ export async function scaffoldMoiDir(
   }
   const moiDir = join(workspacePath, '.moi')
   const packagePath = join(moiDir, 'package.json')
-  if (await Bun.file(packagePath).exists()) return 'exists'
+  if (await Bun.file(packagePath).exists()) {
+    // Repair path: workspaces scaffolded before `.moi/.gitignore` existed pick
+    // it up on the next `moi init` instead of leaking cache files into git.
+    await ensureMoiGitignore(workspacePath)
+    return 'exists'
+  }
   // A bare `.moi/` dir without package.json counts as not-bootstrapped —
   // fill in the missing pieces.
 
   await mkdir(join(moiDir, 'widgets'), { recursive: true })
   await Bun.write(packagePath, JSON.stringify(MOI_PACKAGE_JSON, null, 2) + '\n')
-  await Bun.write(join(moiDir, '.gitignore'), MOI_GITIGNORE)
+  await ensureMoiGitignore(workspacePath)
   await writeAppletEnvDts(workspacePath)
 
   const exited = installDependencies(moiDir)

--- a/server/moi-scaffold.ts
+++ b/server/moi-scaffold.ts
@@ -49,6 +49,16 @@ async function runBunInstall(moiDir: string): Promise<number> {
   return install.exited
 }
 
+// Keep machine-local state out of workspaces that are git repos: build output,
+// derived caches (applet thumbnails), and installed dependencies are all
+// re-creatable and would otherwise churn or bloat the repo. The applet sources,
+// package.json, and lockfile stay committable — they ARE the workspace.
+export const MOI_GITIGNORE = `# moi internals — machine-local, re-creatable state
+.build/
+.cache/
+node_modules/
+`
+
 // Ambient types for applets (widgets & views). Editor DX only — the moi
 // bundler resolves the `moi` module and asset imports at build time without any
 // declarations. Lives at `.moi/` root, NOT inside widgets/views, so it isn't
@@ -140,6 +150,7 @@ export async function scaffoldMoiDir(
 
   await mkdir(join(moiDir, 'widgets'), { recursive: true })
   await Bun.write(packagePath, JSON.stringify(MOI_PACKAGE_JSON, null, 2) + '\n')
+  await Bun.write(join(moiDir, '.gitignore'), MOI_GITIGNORE)
   await writeAppletEnvDts(workspacePath)
 
   const exited = installDependencies(moiDir)

--- a/server/test/layout.test.ts
+++ b/server/test/layout.test.ts
@@ -3,15 +3,10 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-import type { AppletKind, AppletThumbnail, WorkspaceLayout } from '@/lib/types'
+import type { AppletKind, WorkspaceLayout } from '@/lib/types'
 
-import {
-  getLayoutPath,
-  getWorkspacePreview,
-  loadLayout,
-  mergeLayoutForSave,
-  saveAppletThumbnails
-} from '../layout'
+import { getLayoutPath, getWorkspacePreview, loadLayout, mergeLayoutForSave } from '../layout'
+import { getThumbnailsDir } from '../thumbnails'
 
 // The grid editor and `moi config` write the same `.workspace.json`. A layout
 // PUT is authoritative for the editor fields but must NOT touch identity
@@ -23,22 +18,6 @@ const base: WorkspaceLayout = {
   widgetGrid: [],
   layoutMode: 'fullscreen',
   tabs: { open: ['agent', 'widgets'], active: 'agent' }
-}
-
-function thumbnail(
-  kind: AppletKind,
-  id: string,
-  image: string,
-  viewedAt = '2026-01-01T00:00:00.000Z'
-): AppletThumbnail {
-  return {
-    kind,
-    id,
-    revision: 'revision',
-    capturedAt: '2026-01-01T00:00:00.000Z',
-    viewedAt,
-    image
-  }
 }
 
 async function withWorkspaceFile<T>(
@@ -55,6 +34,33 @@ async function withWorkspaceFile<T>(
     await rm(dir, { recursive: true, force: true })
   }
 }
+
+// Seed the `.moi/.cache/thumbnails` store the preview reads from. Writing the
+// index directly keeps `viewedAt` controllable (saves stamp the server clock).
+async function seedThumbnails(
+  dir: string,
+  records: { kind: AppletKind; id: string; viewedAt?: string }[]
+) {
+  const cacheDir = getThumbnailsDir(dir)
+  await mkdir(cacheDir, { recursive: true })
+  const index = []
+  for (const record of records) {
+    const file = `${record.kind}-${record.id}.webp`
+    await Bun.write(join(cacheDir, file), 'bytes')
+    index.push({
+      kind: record.kind,
+      id: record.id,
+      revision: 'revision',
+      capturedAt: '2026-01-01T00:00:00.000Z',
+      viewedAt: record.viewedAt ?? '2026-01-01T00:00:00.000Z',
+      file
+    })
+  }
+  await Bun.write(join(cacheDir, 'index.json'), JSON.stringify(index))
+}
+
+// Deterministic URL shape for assertions; the real one is the API route.
+const thumbnailUrl = (kind: AppletKind, id: string) => `${kind}:${id}`
 
 describe('loadLayout', () => {
   test('opens a new workspace in split view with the default tabs', async () => {
@@ -148,13 +154,14 @@ describe('loadLayout', () => {
       {
         ...base,
         widgetThumbnails: { key: 'old', images: { widget: 'image' } },
-        viewThumbnails: [{ viewId: 'view', image: 'image' }]
+        viewThumbnails: [{ viewId: 'view', image: 'image' }],
+        appletThumbnails: [{ kind: 'widget', id: 'w', revision: 'r', image: 'inline-image' }]
       },
       async dir => {
         const loaded = await loadLayout(dir)
         expect('widgetThumbnails' in loaded).toBe(false)
         expect('viewThumbnails' in loaded).toBe(false)
-        expect(loaded.appletThumbnails).toBeUndefined()
+        expect('appletThumbnails' in loaded).toBe(false)
       }
     )
   })
@@ -216,75 +223,12 @@ describe('mergeLayoutForSave', () => {
     expect(merged.name).toBe('Keep')
   })
 
-  test('preserves applet thumbnails outside the normal layout write', () => {
-    const existing: WorkspaceLayout = {
-      ...base,
-      appletThumbnails: [thumbnail('widget', 'w', 'widget-image')]
-    }
+  test('never lets a stale client write thumbnail records back into the layout', () => {
     const body = {
       ...base,
-      appletThumbnails: [thumbnail('view', 'stale', 'stale-image')]
-    }
-    const merged = mergeLayoutForSave(existing, body)
-    expect(merged.appletThumbnails).toEqual(existing.appletThumbnails)
-  })
-})
-
-describe('applet thumbnail persistence', () => {
-  test('stores every widget and view record through one merge path', async () => {
-    await withWorkspaceFile(base, async dir => {
-      await saveAppletThumbnails(dir, 'widget', [
-        { id: 'one', revision: 'w1', image: 'one-image' },
-        { id: 'two', revision: 'w2', image: 'two-image' },
-        { id: 'three', revision: 'w3', image: 'three-image' },
-        { id: 'four', revision: 'w4', image: 'four-image' }
-      ])
-      await saveAppletThumbnails(dir, 'view', [
-        { id: 'dashboard', revision: 'v1', image: 'view-image' }
-      ])
-
-      const records = (await loadLayout(dir)).appletThumbnails ?? []
-      expect(records).toHaveLength(5)
-      expect(records.map(record => `${record.kind}:${record.id}`)).toEqual([
-        'widget:one',
-        'widget:two',
-        'widget:three',
-        'widget:four',
-        'view:dashboard'
-      ])
-    })
-  })
-
-  test('replaces captures, preserves images on failure, and only touches fresh visits', async () => {
-    await withWorkspaceFile(
-      {
-        ...base,
-        appletThumbnails: [thumbnail('view', 'dashboard', 'old-image')]
-      },
-      async dir => {
-        await saveAppletThumbnails(dir, 'view', [
-          { id: 'dashboard', revision: 'new-revision', image: 'new-image' }
-        ])
-        const captured = (await loadLayout(dir)).appletThumbnails?.[0]
-        expect(captured?.revision).toBe('new-revision')
-        expect(captured?.image).toBe('new-image')
-        expect(captured?.capturedAt).not.toBe('2026-01-01T00:00:00.000Z')
-
-        const capturedAt = captured?.capturedAt
-        await saveAppletThumbnails(dir, 'view', [{ id: 'dashboard', revision: 'ignored-on-touch' }])
-        const touched = (await loadLayout(dir)).appletThumbnails?.[0]
-        expect(touched?.revision).toBe('new-revision')
-        expect(touched?.capturedAt).toBe(capturedAt)
-        expect(touched?.image).toBe('new-image')
-
-        await saveAppletThumbnails(dir, 'view', [
-          { id: 'dashboard', revision: 'failed-revision', image: null }
-        ])
-        const failed = (await loadLayout(dir)).appletThumbnails?.[0]
-        expect(failed?.revision).toBe('failed-revision')
-        expect(failed?.image).toBe('new-image')
-      }
-    )
+      appletThumbnails: [{ kind: 'widget', id: 'w', image: 'inline-image' }]
+    } as unknown as WorkspaceLayout
+    expect('appletThumbnails' in mergeLayoutForSave(base, body)).toBe(false)
   })
 })
 
@@ -301,7 +245,7 @@ describe('getWorkspacePreview', () => {
         theme
       },
       async dir => {
-        expect(await getWorkspacePreview(dir)).toEqual({
+        expect(await getWorkspacePreview(dir, { thumbnailUrl })).toEqual({
           thumbnails: [],
           theme
         })
@@ -318,18 +262,18 @@ describe('getWorkspacePreview', () => {
           { i: 'fourth', x: 0, y: 3 },
           { i: 'right', x: 2, y: 0 },
           { i: 'left', x: 0, y: 0 }
-        ],
-        appletThumbnails: [
-          thumbnail('widget', 'stale', 'stale-image'),
-          thumbnail('widget', 'right', 'right-image'),
-          thumbnail('widget', 'bottom', 'bottom-image'),
-          thumbnail('widget', 'fourth', 'fourth-image'),
-          thumbnail('widget', 'left', 'left-image')
         ]
       },
       async dir => {
-        expect(await getWorkspacePreview(dir)).toEqual({
-          thumbnails: ['left-image', 'right-image', 'bottom-image']
+        await seedThumbnails(dir, [
+          { kind: 'widget', id: 'stale' },
+          { kind: 'widget', id: 'right' },
+          { kind: 'widget', id: 'bottom' },
+          { kind: 'widget', id: 'fourth' },
+          { kind: 'widget', id: 'left' }
+        ])
+        expect(await getWorkspacePreview(dir, { thumbnailUrl })).toEqual({
+          thumbnails: ['widget:left', 'widget:right', 'widget:bottom']
         })
       }
     )
@@ -339,17 +283,19 @@ describe('getWorkspacePreview', () => {
     await withWorkspaceFile(
       {
         ...base,
-        widgetGrid: [{ i: 'widget', x: 0, y: 0 }],
-        appletThumbnails: [
-          thumbnail('widget', 'widget', 'widget-image'),
-          thumbnail('view', 'deleted', 'deleted-view', '2026-01-04T00:00:00.000Z'),
-          thumbnail('view', 'recent', 'recent-view', '2026-01-03T00:00:00.000Z'),
-          thumbnail('view', 'older', 'older-view', '2026-01-02T00:00:00.000Z')
-        ]
+        widgetGrid: [{ i: 'widget', x: 0, y: 0 }]
       },
       async dir => {
-        expect(await getWorkspacePreview(dir, undefined, ['older', 'recent'])).toEqual({
-          thumbnails: ['widget-image', 'recent-view', 'older-view']
+        await seedThumbnails(dir, [
+          { kind: 'widget', id: 'widget' },
+          { kind: 'view', id: 'deleted', viewedAt: '2026-01-04T00:00:00.000Z' },
+          { kind: 'view', id: 'recent', viewedAt: '2026-01-03T00:00:00.000Z' },
+          { kind: 'view', id: 'older', viewedAt: '2026-01-02T00:00:00.000Z' }
+        ])
+        expect(
+          await getWorkspacePreview(dir, { viewIds: ['older', 'recent'], thumbnailUrl })
+        ).toEqual({
+          thumbnails: ['widget:widget', 'view:recent', 'view:older']
         })
       }
     )
@@ -359,15 +305,15 @@ describe('getWorkspacePreview', () => {
     await withWorkspaceFile(
       {
         ...base,
-        widgetGrid: [{ i: 'widget', x: 0, y: 0 }],
-        appletThumbnails: [
-          thumbnail('widget', 'widget', 'widget-image'),
-          thumbnail('view', 'deleted', 'deleted')
-        ]
+        widgetGrid: [{ i: 'widget', x: 0, y: 0 }]
       },
       async dir => {
-        expect(await getWorkspacePreview(dir, undefined, [])).toEqual({
-          thumbnails: ['widget-image']
+        await seedThumbnails(dir, [
+          { kind: 'widget', id: 'widget' },
+          { kind: 'view', id: 'deleted' }
+        ])
+        expect(await getWorkspacePreview(dir, { viewIds: [], thumbnailUrl })).toEqual({
+          thumbnails: ['widget:widget']
         })
       }
     )
@@ -376,10 +322,13 @@ describe('getWorkspacePreview', () => {
   test('loads and normalizes the first user message when the grid is empty', async () => {
     await withWorkspaceFile(base, async dir => {
       const message = `  ${'A'.repeat(260)}\nsecond line  `
-      const preview = await getWorkspacePreview(dir, async includeFirstUserMessage => ({
-        firstUserMessage: includeFirstUserMessage ? message : undefined,
-        updatedAt: 900
-      }))
+      const preview = await getWorkspacePreview(dir, {
+        getProviderPreview: async includeFirstUserMessage => ({
+          firstUserMessage: includeFirstUserMessage ? message : undefined,
+          updatedAt: 900
+        }),
+        thumbnailUrl
+      })
 
       expect(preview.thumbnails).toEqual([])
       expect(preview.updatedAt).toBe(900)
@@ -396,12 +345,15 @@ describe('getWorkspacePreview', () => {
         widgetGrid: [{ i: 'waiting-for-thumbnail', x: 0, y: 0 }]
       },
       async dir => {
-        const preview = await getWorkspacePreview(dir, async includeFirstUserMessage => {
-          expect(includeFirstUserMessage).toBe(true)
-          return {
-            firstUserMessage: 'Shown until a capture lands',
-            updatedAt: 900
-          }
+        const preview = await getWorkspacePreview(dir, {
+          getProviderPreview: async includeFirstUserMessage => {
+            expect(includeFirstUserMessage).toBe(true)
+            return {
+              firstUserMessage: 'Shown until a capture lands',
+              updatedAt: 900
+            }
+          },
+          thumbnailUrl
         })
 
         expect(preview).toEqual({
@@ -417,31 +369,42 @@ describe('getWorkspacePreview', () => {
     await withWorkspaceFile(
       {
         ...base,
-        widgetGrid: [{ i: 'captured', x: 0, y: 0 }],
-        appletThumbnails: [thumbnail('widget', 'captured', 'captured-image')]
+        widgetGrid: [{ i: 'captured', x: 0, y: 0 }]
       },
       async dir => {
-        const preview = await getWorkspacePreview(dir, async includeFirstUserMessage => {
-          expect(includeFirstUserMessage).toBe(false)
-          return {
-            firstUserMessage: 'Should stay hidden',
-            updatedAt: 900
-          }
+        await seedThumbnails(dir, [{ kind: 'widget', id: 'captured' }])
+        const preview = await getWorkspacePreview(dir, {
+          getProviderPreview: async includeFirstUserMessage => {
+            expect(includeFirstUserMessage).toBe(false)
+            return {
+              firstUserMessage: 'Should stay hidden',
+              updatedAt: 900
+            }
+          },
+          thumbnailUrl
         })
 
-        expect(preview).toEqual({ thumbnails: ['captured-image'], updatedAt: 900 })
+        expect(preview).toEqual({ thumbnails: ['widget:captured'], updatedAt: 900 })
       }
     )
   })
 
   test('keeps an empty folder when the fallback is empty or unreadable', async () => {
     await withWorkspaceFile(base, async dir => {
-      expect(await getWorkspacePreview(dir, async () => ({ firstUserMessage: ' \n ' }))).toEqual({
+      expect(
+        await getWorkspacePreview(dir, {
+          getProviderPreview: async () => ({ firstUserMessage: ' \n ' }),
+          thumbnailUrl
+        })
+      ).toEqual({
         thumbnails: []
       })
       expect(
-        await getWorkspacePreview(dir, async () => {
-          throw new Error('unreadable session')
+        await getWorkspacePreview(dir, {
+          getProviderPreview: async () => {
+            throw new Error('unreadable session')
+          },
+          thumbnailUrl
         })
       ).toEqual({ thumbnails: [] })
     })

--- a/server/test/moi-scaffold.test.ts
+++ b/server/test/moi-scaffold.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'path'
 
-import { scaffoldMoiDir } from '../moi-scaffold'
+import { ensureMoiGitignore, scaffoldMoiDir } from '../moi-scaffold'
 import { silenceConsole } from './quiet'
 
 // The scaffold backstop: `scaffoldMoiDir` must refuse to create a `.moi/` inside
@@ -76,5 +76,31 @@ describe('scaffoldMoiDir install', () => {
 
     expect(result).toBe('exists')
     expect(installs).toBe(0)
+    // The repair path: pre-gitignore workspaces pick the file up on re-init.
+    expect(existsSync(join(moiDir, '.gitignore'))).toBe(true)
+  })
+})
+
+describe('ensureMoiGitignore', () => {
+  test('appends missing entries without touching user content', async () => {
+    const moiDir = join(WS, '.moi')
+    mkdirSync(moiDir, { recursive: true })
+    writeFileSync(join(moiDir, '.gitignore'), '# mine\nsecrets.txt\n.build/\n')
+
+    await ensureMoiGitignore(WS)
+
+    const text = await Bun.file(join(moiDir, '.gitignore')).text()
+    expect(text).toContain('# mine\nsecrets.txt\n.build/\n')
+    expect(text).toContain('.cache/')
+    expect(text).toContain('node_modules/')
+
+    // A complete file is left byte-identical.
+    await ensureMoiGitignore(WS)
+    expect(await Bun.file(join(moiDir, '.gitignore')).text()).toBe(text)
+  })
+
+  test('does nothing when the workspace has no .moi directory', async () => {
+    await ensureMoiGitignore(WS)
+    expect(existsSync(join(WS, '.moi'))).toBe(false)
   })
 })

--- a/server/test/moi-scaffold.test.ts
+++ b/server/test/moi-scaffold.test.ts
@@ -45,6 +45,11 @@ describe('scaffoldMoiDir install', () => {
     expect(existsSync(join(moiDir, 'package.json'))).toBe(true)
     expect(existsSync(join(moiDir, 'widgets'))).toBe(true)
     expect(await Bun.file(join(moiDir, 'applet-env.d.ts')).text()).toContain('icon?: string')
+    // Machine-local state must never end up committed in a workspace repo.
+    const gitignore = await Bun.file(join(moiDir, '.gitignore')).text()
+    for (const entry of ['.build/', '.cache/', 'node_modules/']) {
+      expect(gitignore).toContain(entry)
+    }
   })
 
   test('returns "installing" when the install outlives the wait', async () => {

--- a/server/test/thumbnails.test.ts
+++ b/server/test/thumbnails.test.ts
@@ -87,6 +87,17 @@ describe('saveAppletThumbnails', () => {
     ])
     expect(await getAppletThumbnailRecords(dir)).toEqual([])
   })
+
+  test('drops ids that would escape the cache directory', async () => {
+    await saveAppletThumbnails(dir, 'widget', [
+      { id: '../../escape', revision: 'r', image: image('escape') },
+      { id: 'safe', revision: 'r', image: image('safe') }
+    ])
+    const records = await getAppletThumbnailRecords(dir)
+    expect(records.map(record => record.id)).toEqual(['safe'])
+    // `widget-../../escape.webp` would have landed one level above the cache.
+    expect(await Bun.file(join(getThumbnailsDir(dir), '..', 'escape.webp')).exists()).toBe(false)
+  })
 })
 
 describe('pruneAppletThumbnails', () => {

--- a/server/test/thumbnails.test.ts
+++ b/server/test/thumbnails.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import {
+  getAppletThumbnailRecords,
+  getThumbnailsDir,
+  pruneAppletThumbnails,
+  saveAppletThumbnails,
+  serveAppletThumbnail
+} from '../thumbnails'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'moi-thumbs-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+const image = (text: string) => `data:image/webp;base64,${Buffer.from(text).toString('base64')}`
+
+async function storedImage(kind: string, id: string): Promise<string | null> {
+  const file = Bun.file(join(getThumbnailsDir(dir), `${kind}-${id}.webp`))
+  return (await file.exists()) ? file.text() : null
+}
+
+describe('saveAppletThumbnails', () => {
+  test('stores widget and view records in one index with image files beside it', async () => {
+    await saveAppletThumbnails(dir, 'widget', [
+      { id: 'one', revision: 'w1', image: image('one') },
+      { id: 'two', revision: 'w2', image: image('two') }
+    ])
+    await saveAppletThumbnails(dir, 'view', [
+      { id: 'dashboard', revision: 'v1', image: image('view'), captureMs: 420 }
+    ])
+
+    const records = await getAppletThumbnailRecords(dir)
+    expect(records.map(record => `${record.kind}:${record.id}`)).toEqual([
+      'widget:one',
+      'widget:two',
+      'view:dashboard'
+    ])
+    expect(records[2].captureMs).toBe(420)
+    // Records never carry image bytes — those live only as files.
+    expect(records.every(record => !('image' in record) && !('file' in record))).toBe(true)
+    expect(await storedImage('widget', 'one')).toBe('one')
+    expect(await storedImage('view', 'dashboard')).toBe('view')
+  })
+
+  test('replaces captures, preserves images on failure, and only touches fresh visits', async () => {
+    await saveAppletThumbnails(dir, 'view', [
+      { id: 'dashboard', revision: 'old-revision', image: image('old') }
+    ])
+
+    await saveAppletThumbnails(dir, 'view', [
+      { id: 'dashboard', revision: 'new-revision', image: image('new'), captureMs: 50 }
+    ])
+    const [captured] = await getAppletThumbnailRecords(dir)
+    expect(captured.revision).toBe('new-revision')
+    expect(await storedImage('view', 'dashboard')).toBe('new')
+
+    // A touch (no image) only bumps recency — revision and capture time stay.
+    await saveAppletThumbnails(dir, 'view', [{ id: 'dashboard', revision: 'ignored-on-touch' }])
+    const [touched] = await getAppletThumbnailRecords(dir)
+    expect(touched.revision).toBe('new-revision')
+    expect(touched.capturedAt).toBe(captured.capturedAt)
+    expect(touched.viewedAt >= captured.viewedAt).toBe(true)
+
+    // A failed attempt (null) records the new revision and duration but keeps
+    // the previous image file, so a broken applet doesn't loop the capture.
+    await saveAppletThumbnails(dir, 'view', [
+      { id: 'dashboard', revision: 'failed-revision', image: null, captureMs: 9_000 }
+    ])
+    const [failed] = await getAppletThumbnailRecords(dir)
+    expect(failed.revision).toBe('failed-revision')
+    expect(failed.captureMs).toBe(9_000)
+    expect(await storedImage('view', 'dashboard')).toBe('new')
+  })
+
+  test('rejects images that are not inline webp/png/jpeg data URLs', async () => {
+    await saveAppletThumbnails(dir, 'widget', [
+      { id: 'evil', revision: 'r', image: 'not-a-data-url' }
+    ])
+    expect(await getAppletThumbnailRecords(dir)).toEqual([])
+  })
+})
+
+describe('pruneAppletThumbnails', () => {
+  test('drops records and files of deleted applets, same kind only', async () => {
+    await saveAppletThumbnails(dir, 'widget', [
+      { id: 'kept', revision: 'r', image: image('kept') },
+      { id: 'gone', revision: 'r', image: image('gone') }
+    ])
+    await saveAppletThumbnails(dir, 'view', [{ id: 'gone', revision: 'r', image: image('view') }])
+
+    await pruneAppletThumbnails(dir, 'widget', ['kept'])
+
+    const records = await getAppletThumbnailRecords(dir)
+    expect(records.map(record => `${record.kind}:${record.id}`)).toEqual([
+      'widget:kept',
+      'view:gone'
+    ])
+    expect(await storedImage('widget', 'gone')).toBeNull()
+    expect(await storedImage('view', 'gone')).toBe('view')
+  })
+})
+
+describe('serveAppletThumbnail', () => {
+  test('serves the image with an ETag and answers a match with 304', async () => {
+    await saveAppletThumbnails(dir, 'widget', [
+      { id: 'clock', revision: 'r', image: image('clock') }
+    ])
+
+    const response = await serveAppletThumbnail(dir, 'widget', 'clock')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('image/webp')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-cache')
+    expect(await response.text()).toBe('clock')
+
+    const etag = response.headers.get('ETag')
+    expect(etag).toBeTruthy()
+    const revalidated = await serveAppletThumbnail(dir, 'widget', 'clock', etag)
+    expect(revalidated.status).toBe(304)
+  })
+
+  test('404s unknown applets and 400s invalid ids', async () => {
+    expect((await serveAppletThumbnail(dir, 'widget', 'nope')).status).toBe(404)
+    expect((await serveAppletThumbnail(dir, 'widget', '../escape')).status).toBe(400)
+  })
+})

--- a/server/thumbnails.ts
+++ b/server/thumbnails.ts
@@ -1,0 +1,182 @@
+// Applet thumbnail store: `.moi/.cache/thumbnails/` holds one image file per
+// captured applet plus an `index.json` of freshness records. Kept out of
+// `.workspace.json` on purpose — images are heavy, machine-local derived state,
+// and the layout file is meant to be small and shareable. Everything here is
+// re-creatable by opening the workspace in a browser, so `.moi/.cache` is safe
+// to delete (and to gitignore) wholesale.
+import { mkdir, rename, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { AppletKind, AppletThumbnail, AppletThumbnailBatch } from '@/lib/types'
+
+// Index records carry the image file name (`widget-clock.webp`) so existence
+// and content type never need an fs probe. Server-internal — the API strips it.
+type StoredAppletThumbnail = AppletThumbnail & { file?: string }
+
+const INDEX_FILE = 'index.json'
+
+const DATA_URL_RE = /^data:(image\/(?:webp|png|jpeg));base64,([A-Za-z0-9+/=]+)$/
+
+const EXT_BY_MIME: Record<string, string> = {
+  'image/webp': 'webp',
+  'image/png': 'png',
+  'image/jpeg': 'jpg'
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  webp: 'image/webp',
+  png: 'image/png',
+  jpg: 'image/jpeg'
+}
+
+export function getThumbnailsDir(workspacePath: string): string {
+  return join(workspacePath, '.moi', '.cache', 'thumbnails')
+}
+
+async function loadIndex(dir: string): Promise<StoredAppletThumbnail[]> {
+  try {
+    const parsed: unknown = JSON.parse(await Bun.file(join(dir, INDEX_FILE)).text())
+    if (Array.isArray(parsed)) return parsed as StoredAppletThumbnail[]
+  } catch {}
+  return []
+}
+
+// Write through a temp sibling + atomic rename so a crash mid-write never
+// leaves a truncated index or image (same recipe as scratchpad assets).
+async function writeAtomic(dir: string, name: string, data: string | Uint8Array): Promise<void> {
+  const tmp = join(dir, `.tmp-${crypto.randomUUID()}`)
+  await Bun.write(tmp, data)
+  await rename(tmp, join(dir, name))
+}
+
+async function saveIndex(dir: string, records: StoredAppletThumbnail[]): Promise<void> {
+  await writeAtomic(dir, INDEX_FILE, JSON.stringify(records, null, 2))
+}
+
+export async function getAppletThumbnailRecords(workspacePath: string): Promise<AppletThumbnail[]> {
+  const records = await loadIndex(getThumbnailsDir(workspacePath))
+  return records.map(({ file: _file, ...record }) => record)
+}
+
+// The widget and view capture passes can land concurrently; serialize the
+// read-modify-write per workspace so neither batch clobbers the other's index.
+const saveQueues = new Map<string, Promise<void>>()
+
+function enqueue(workspacePath: string, task: () => Promise<void>): Promise<void> {
+  const next = (saveQueues.get(workspacePath) ?? Promise.resolve()).then(task, task)
+  saveQueues.set(workspacePath, next)
+  return next
+}
+
+// Merge a settled capture batch into the store. A data-URL image replaces the
+// applet's file, null records a failed or skipped attempt while keeping any
+// previous file, and an omitted image only updates visit recency.
+export function saveAppletThumbnails(
+  workspacePath: string,
+  kind: AppletKind,
+  updates: AppletThumbnailBatch['thumbnails']
+): Promise<void> {
+  return enqueue(workspacePath, async () => {
+    const dir = getThumbnailsDir(workspacePath)
+    await mkdir(dir, { recursive: true })
+    const now = new Date().toISOString()
+    const records = await loadIndex(dir)
+
+    for (const update of updates) {
+      const index = records.findIndex(record => record.kind === kind && record.id === update.id)
+      const previous = index >= 0 ? records[index] : undefined
+
+      if (update.image === undefined) {
+        if (previous) records[index] = { ...previous, viewedAt: now }
+        continue
+      }
+
+      let file = previous?.file
+      if (typeof update.image === 'string') {
+        const parsed = DATA_URL_RE.exec(update.image)
+        if (!parsed) continue
+        const next = `${kind}-${update.id}.${EXT_BY_MIME[parsed[1]]}`
+        await writeAtomic(dir, next, Buffer.from(parsed[2], 'base64'))
+        if (previous?.file && previous.file !== next) {
+          await rm(join(dir, previous.file), { force: true }).catch(() => {})
+        }
+        file = next
+      }
+
+      const record: StoredAppletThumbnail = {
+        kind,
+        id: update.id,
+        revision: update.revision,
+        capturedAt: now,
+        viewedAt: now,
+        ...(update.captureMs !== undefined && { captureMs: update.captureMs }),
+        ...(file !== undefined && { file })
+      }
+      if (previous) records[index] = record
+      else records.push(record)
+    }
+
+    await saveIndex(dir, records)
+  })
+}
+
+// Drop records (and their image files) for applets of `kind` that no longer
+// exist. Called from the build pipeline beside the stale-bundle prune, so a
+// deleted applet's thumbnail dies with its bundle.
+export function pruneAppletThumbnails(
+  workspacePath: string,
+  kind: AppletKind,
+  keepIds: readonly string[]
+): Promise<void> {
+  return enqueue(workspacePath, async () => {
+    const dir = getThumbnailsDir(workspacePath)
+    const records = await loadIndex(dir)
+    const keep = new Set(keepIds)
+    const stale = records.filter(record => record.kind === kind && !keep.has(record.id))
+    if (stale.length === 0) return
+    for (const record of stale) {
+      if (record.file) await rm(join(dir, record.file), { force: true }).catch(() => {})
+    }
+    await saveIndex(
+      dir,
+      records.filter(record => !stale.includes(record))
+    )
+  })
+}
+
+// Records that actually have an image on disk, for the home-card preview.
+export async function getCapturedThumbnails(
+  workspacePath: string
+): Promise<{ kind: AppletKind; id: string; viewedAt: string }[]> {
+  const records = await loadIndex(getThumbnailsDir(workspacePath))
+  return records
+    .filter(record => record.file !== undefined)
+    .map(({ kind, id, viewedAt }) => ({ kind, id, viewedAt }))
+}
+
+// One thumbnail image. Same caching story as applet bundles: strong ETag from
+// size+mtime with `private, no-cache`, so an unchanged file costs a bodyless
+// 304 and a re-capture busts every consumer on the next revalidation.
+export async function serveAppletThumbnail(
+  workspacePath: string,
+  kind: AppletKind,
+  id: string,
+  ifNoneMatch?: string | null
+): Promise<Response> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) return new Response('Invalid id', { status: 400 })
+  const dir = getThumbnailsDir(workspacePath)
+  const records = await loadIndex(dir)
+  const record = records.find(item => item.kind === kind && item.id === id)
+  if (!record?.file) return new Response('Not found', { status: 404 })
+  const file = Bun.file(join(dir, record.file))
+  if (!(await file.exists())) return new Response('Not found', { status: 404 })
+
+  const etag = `"${file.size}-${Math.trunc(file.lastModified)}"`
+  const headers = {
+    ETag: etag,
+    'Cache-Control': 'private, no-cache',
+    'Content-Type': MIME_BY_EXT[record.file.split('.').pop() ?? ''] ?? 'application/octet-stream'
+  }
+  if (ifNoneMatch === etag) return new Response(null, { status: 304, headers })
+  return new Response(file, { headers })
+}

--- a/server/thumbnails.ts
+++ b/server/thumbnails.ts
@@ -9,11 +9,22 @@ import { join } from 'node:path'
 
 import type { AppletKind, AppletThumbnail, AppletThumbnailBatch } from '@/lib/types'
 
+import { ensureMoiGitignore } from './moi-scaffold'
+
 // Index records carry the image file name (`widget-clock.webp`) so existence
 // and content type never need an fs probe. Server-internal — the API strips it.
 type StoredAppletThumbnail = AppletThumbnail & { file?: string }
 
 const INDEX_FILE = 'index.json'
+
+// Applet ids become file names under the cache dir, so anything outside this
+// set (`../`, separators) is a path-traversal attempt. Enforced on every
+// entry point that derives a path — the PUT batch, prune, and serve.
+const APPLET_ID_RE = /^[a-zA-Z0-9_-]+$/
+
+export function isValidAppletId(id: string): boolean {
+  return APPLET_ID_RE.test(id)
+}
 
 const DATA_URL_RE = /^data:(image\/(?:webp|png|jpeg));base64,([A-Za-z0-9+/=]+)$/
 
@@ -79,10 +90,14 @@ export function saveAppletThumbnails(
   return enqueue(workspacePath, async () => {
     const dir = getThumbnailsDir(workspacePath)
     await mkdir(dir, { recursive: true })
+    // The cache must be ignored the moment it can hold data — this is also the
+    // backfill path for workspaces scaffolded before `.moi/.gitignore` existed.
+    await ensureMoiGitignore(workspacePath)
     const now = new Date().toISOString()
     const records = await loadIndex(dir)
 
     for (const update of updates) {
+      if (!isValidAppletId(update.id)) continue
       const index = records.findIndex(record => record.kind === kind && record.id === update.id)
       const previous = index >= 0 ? records[index] : undefined
 
@@ -163,7 +178,7 @@ export async function serveAppletThumbnail(
   id: string,
   ifNoneMatch?: string | null
 ): Promise<Response> {
-  if (!/^[a-zA-Z0-9_-]+$/.test(id)) return new Response('Invalid id', { status: 400 })
+  if (!isValidAppletId(id)) return new Response('Invalid id', { status: 400 })
   const dir = getThumbnailsDir(workspacePath)
   const records = await loadIndex(dir)
   const record = records.find(item => item.kind === kind && item.id === id)

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -90,6 +90,12 @@ my-agent-folder/
     .scratchpad/              <- Scratchpad image files. Internal — pull pixels via `moi scratch read-image`, never open it.
 ```
 
+Every dot-prefixed file or folder inside `.moi/` (`.build/`, `.cache/`, `.workspace.json`,
+`.scratchpad*`, `.gitignore`, …) is a moi internal: auto-generated, machine-local, and liable to
+change format without notice. Avoid them as much as possible — do not read, edit, delete, or commit
+them, and never point tooling at them. Go through the `moi` CLI instead; your surface is the
+non-dot files: `widgets/`, `views/`, `package.json`, and code you place under `.moi/` yourself.
+
 # Build environment
 
 - Bun is the required dependency of moi, so it must be installed

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -91,10 +91,13 @@ my-agent-folder/
 ```
 
 Every dot-prefixed file or folder inside `.moi/` (`.build/`, `.cache/`, `.workspace.json`,
-`.scratchpad*`, `.gitignore`, …) is a moi internal: auto-generated, machine-local, and liable to
-change format without notice. Avoid them as much as possible — do not read, edit, delete, or commit
-them, and never point tooling at them. Go through the `moi` CLI instead; your surface is the
-non-dot files: `widgets/`, `views/`, `package.json`, and code you place under `.moi/` yourself.
+`.scratchpad*`, `.gitignore`, …) is a moi internal: auto-generated and liable to change format
+without notice. Avoid them as much as possible — do not read, edit, or delete them, and never point
+tooling at them; go through the `moi` CLI instead. Version control needs no special handling: the
+scaffolded `.moi/.gitignore` already excludes the machine-local entries (`.build/`, `.cache/`,
+`node_modules/`), while `.workspace.json` and `.scratchpad.json` are workspace state that ships
+with the repo — commit them as-is, just never hand-edit them. Your surface is the non-dot files:
+`widgets/`, `views/`, `package.json`, and code you place under `.moi/` yourself.
 
 # Build environment
 


### PR DESCRIPTION
Stacked on #100. Thumbnail images move out of `.workspace.json` into `.moi/.cache/thumbnails/` as WebP files with an `index.json` of freshness records — the layout file stays small and commit-safe, and home cards load images over HTTP with ETag revalidation instead of base64 JSON. Captures are now timed: a target whose last capture took ≥1s is only re-attempted when its bundle changes, so a heavy view can't jank the main thread on routine 3-hour refreshes.

After a visit to the seeded test workspace:

```text
.moi/.cache/thumbnails/
  index.json          <- {kind, id, revision, capturedAt, viewedAt, captureMs}
  widget-clock.webp   <- GET .../applet-thumbnails/widget/clock  (ETag → 304)
  view-dash.webp
.moi/.workspace.json  <- 238 bytes, no thumbnail keys
```

`moi init` now also scaffolds `.moi/.gitignore` (`.build/`, `.cache/`, `node_modules/`), and the workspace skill tells agents every dot-entry inside `.moi/` is a moi internal to leave alone.

Worth a close look:

- `server/thumbnails.ts` — the new store: per-workspace save queue serializes concurrent widget/view batches; a failed capture (`image: null`) keeps the old file but records the new revision, deliberately trading staleness for not retry-looping a broken applet.
- `server/applets.ts` — thumbnail prune now runs inside every `buildApplets` pass, beside the stale-bundle sweep.
- Known gap carried over from #100: a rebundle that lands while the browser is on another screen can capture the stale in-page module under the new revision (revision comes from the server, pixels from the loaded module). Fix would be plumbing the loaded bundle version into capture targets.

Verified: `bun test` — 1247 pass, 0 fail; typecheck, lint, format clean. Full e2e in Chromium via agent-browser: init scaffolds the gitignore, widget + view captures land as files, ETag revalidation answers 304, home card renders from URLs, deleting a view prunes its record, rebundling while the workspace is open recaptures the fresh module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pMgAaQKhiFZQzYA2wxkEv

---
_Generated by [Claude Code](https://claude.ai/code/session_015pMgAaQKhiFZQzYA2wxkEv)_