### PR TITLE
Add cloud demo mode with install-moi dialog and config system

### DIFF
--- a/client/api/app-config.ts
+++ b/client/api/app-config.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { ClientAppConfig } from '@/lib/types'
+
+import { requestJson } from './http'
+
+export const appConfigKeys = {
+  all: ['app-config'] as const
+}
+
+// Startup config (GET /api/config): frozen for the server process lifetime,
+// so it never goes stale and is cached for the whole browser session.
+export function useAppConfig() {
+  return useQuery<ClientAppConfig>({
+    queryKey: appConfigKeys.all,
+    queryFn: () => requestJson('/api/config'),
+    staleTime: Infinity,
+    gcTime: Infinity
+  })
+}

--- a/client/api/app-config.ts
+++ b/client/api/app-config.ts
@@ -1,6 +1,4 @@
-import { useEffect } from 'react'
-
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useSyncExternalStore } from 'react'
 
 import type { ClientAppConfig } from '@/lib/types'
 
@@ -8,29 +6,46 @@ import { onWorkspaceEventsReconnect } from '@/client/runtime/useWorkspaceEvents'
 
 import { requestJson } from './http'
 
-export const appConfigKeys = {
-  all: ['app-config'] as const
+// Startup config (GET /api/config): frozen for the server process lifetime,
+// so it is fetched once before the app mounts (see init() in index.tsx) and
+// read synchronously everywhere after that — no query, no loading states.
+// The one thing that can change it is a server restart; the events socket
+// reconnecting is that signal, so the store re-fetches there.
+
+const DEFAULTS: ClientAppConfig = {
+  cloudDemo: false,
+  experiments: [],
+  demoInstallUrl: 'https://moi.computer'
 }
 
-// Startup config (GET /api/config): frozen for the server process lifetime,
-// so it never goes stale within one server run. The one thing that can change
-// it is a server restart — the events socket reconnecting is that signal, so
-// refetch there instead of on a timer.
-export function useAppConfig() {
-  const queryClient = useQueryClient()
+let current: ClientAppConfig = DEFAULTS
+const listeners = new Set<() => void>()
 
-  useEffect(
-    () =>
-      onWorkspaceEventsReconnect(() => {
-        queryClient.invalidateQueries({ queryKey: appConfigKeys.all })
-      }),
-    [queryClient]
-  )
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
 
-  return useQuery<ClientAppConfig>({
-    queryKey: appConfigKeys.all,
-    queryFn: () => requestJson('/api/config'),
-    staleTime: Infinity,
-    gcTime: Infinity
+// Failures keep the last known value (defaults on the very first fetch):
+// non-demo is the safe presentation, and the server still enforces its gates.
+async function fetchAppConfig(): Promise<void> {
+  try {
+    current = await requestJson<ClientAppConfig>('/api/config')
+    for (const listener of listeners) listener()
+  } catch {}
+}
+
+// Called once from init() before the app mounts; never rejects, so a config
+// hiccup cannot block the app from starting.
+export async function loadAppConfig(): Promise<void> {
+  await fetchAppConfig()
+  onWorkspaceEventsReconnect(() => {
+    void fetchAppConfig()
   })
+}
+
+export function useAppConfig(): ClientAppConfig {
+  return useSyncExternalStore(subscribe, () => current)
 }

--- a/client/api/app-config.ts
+++ b/client/api/app-config.ts
@@ -1,6 +1,10 @@
-import { useQuery } from '@tanstack/react-query'
+import { useEffect } from 'react'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import type { ClientAppConfig } from '@/lib/types'
+
+import { onWorkspaceEventsReconnect } from '@/client/runtime/useWorkspaceEvents'
 
 import { requestJson } from './http'
 
@@ -9,8 +13,20 @@ export const appConfigKeys = {
 }
 
 // Startup config (GET /api/config): frozen for the server process lifetime,
-// so it never goes stale and is cached for the whole browser session.
+// so it never goes stale within one server run. The one thing that can change
+// it is a server restart — the events socket reconnecting is that signal, so
+// refetch there instead of on a timer.
 export function useAppConfig() {
+  const queryClient = useQueryClient()
+
+  useEffect(
+    () =>
+      onWorkspaceEventsReconnect(() => {
+        queryClient.invalidateQueries({ queryKey: appConfigKeys.all })
+      }),
+    [queryClient]
+  )
+
   return useQuery<ClientAppConfig>({
     queryKey: appConfigKeys.all,
     queryFn: () => requestJson('/api/config'),

--- a/client/features/home/HomePage.tsx
+++ b/client/features/home/HomePage.tsx
@@ -69,7 +69,7 @@ export function HomePage() {
 
   function handleAdd(suggestion: DiscoveredWorkspace) {
     // Cloud demo: adding workspaces is off — offer the install dialog instead.
-    if (appConfig.data?.cloudDemo) {
+    if (appConfig.cloudDemo) {
       setInstallDialogOpen(true)
       return
     }

--- a/client/features/home/HomePage.tsx
+++ b/client/features/home/HomePage.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { IconChevronRight, IconEggCracked, IconLoader2, IconPlus } from '@tabler/icons-react'
 import { Link, useLocation } from 'wouter'
 
@@ -9,8 +11,10 @@ import {
 } from './api'
 import { CreateWorkspaceDialog } from './workspace-setup/CreateWorkspaceDialog'
 import { ImportWorkspaceDialog } from './workspace-setup/ImportWorkspaceDialog'
+import { InstallMoiDialog } from './workspace-setup/InstallMoiDialog'
 import { useWorkspaceImport } from './workspace-setup/useWorkspaceImport'
 import { HomeLogo } from './HomeLogo'
+import { useAppConfig } from '@/client/api/app-config'
 import { Button } from '@/client/components/ui/button'
 import {
   Collapsible,
@@ -38,6 +42,8 @@ export function HomePage() {
   const importFlow = useWorkspaceImport({
     onSuccess: entry => navigate(`/workspace/${entry.id}`)
   })
+  const appConfig = useAppConfig()
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
   const discoveredWorkspacesOpen = useUiStore(state => state.discoveredWorkspacesOpen)
   const setDiscoveredWorkspacesOpen = useUiStore(state => state.setDiscoveredWorkspacesOpen)
 
@@ -62,6 +68,11 @@ export function HomePage() {
   const count = workspaces.length
 
   function handleAdd(suggestion: DiscoveredWorkspace) {
+    // Cloud demo: adding workspaces is off — offer the install dialog instead.
+    if (appConfig.data?.cloudDemo) {
+      setInstallDialogOpen(true)
+      return
+    }
     importFlow.startImport(suggestion)
   }
 
@@ -149,6 +160,8 @@ export function HomePage() {
           onReset={importFlow.reset}
         />
       )}
+
+      <InstallMoiDialog open={installDialogOpen} onOpenChange={setInstallDialogOpen} />
     </div>
   )
 }

--- a/client/features/home/workspace-setup/CreateWorkspaceDialog.tsx
+++ b/client/features/home/workspace-setup/CreateWorkspaceDialog.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, type ReactElement, useState } from 'react'
 import { useLocation } from 'wouter'
 
 import { useCreateWorkspace, useWorkspaceSetupInfo } from '../api'
+import { useAppConfig } from '@/client/api/app-config'
 import { Button } from '@/client/components/ui/button'
 import {
   Dialog,
@@ -16,6 +17,7 @@ import { validateWorkspaceFolderName } from '@/lib/workspace-name'
 import { WORKSPACE_TYPE_ORDER } from '@/lib/workspace-types'
 import type { WorkspaceType } from '@/lib/types'
 
+import { InstallMoiDialog } from './InstallMoiDialog'
 import { WorkspaceAgentStep } from './WorkspaceAgentStep'
 import { WorkspaceDialogContent } from './WorkspaceDialogContent'
 
@@ -29,6 +31,7 @@ const DEFAULT_WORKSPACE_TYPE = WORKSPACE_TYPE_ORDER[0]
 
 export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
   const [, navigate] = useLocation()
+  const appConfig = useAppConfig()
   const info = useWorkspaceSetupInfo()
   const createMutation = useCreateWorkspace()
 
@@ -40,6 +43,12 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
   const trimmedName = name.trim()
   const nameError = trimmedName ? validateWorkspaceFolderName(trimmedName) : null
   const isCreating = createMutation.isPending
+
+  // Cloud demo: creating workspaces is off — the same trigger opens the
+  // install-moi dialog instead. After every hook so the hook order is stable.
+  if (appConfig.data?.cloudDemo) {
+    return <InstallMoiDialog trigger={trigger} />
+  }
 
   function finish(workspaceId: string) {
     setOpen(false)

--- a/client/features/home/workspace-setup/CreateWorkspaceDialog.tsx
+++ b/client/features/home/workspace-setup/CreateWorkspaceDialog.tsx
@@ -46,7 +46,7 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
 
   // Cloud demo: creating workspaces is off — the same trigger opens the
   // install-moi dialog instead. After every hook so the hook order is stable.
-  if (appConfig.data?.cloudDemo) {
+  if (appConfig.cloudDemo) {
     return <InstallMoiDialog trigger={trigger} />
   }
 

--- a/client/features/home/workspace-setup/InstallMoiDialog.tsx
+++ b/client/features/home/workspace-setup/InstallMoiDialog.tsx
@@ -5,11 +5,14 @@ import {
   IconCheck,
   IconCopy,
   IconFolders,
-  IconLock,
   IconTerminal2,
   IconX
 } from '@tabler/icons-react'
 
+import claudeIcon from '@/client/assets/claude.svg'
+import hermesIcon from '@/client/assets/hermes.png'
+import openaiIcon from '@/client/assets/openai.svg'
+import openclawIcon from '@/client/assets/openclaw.svg'
 import { Button } from '@/client/components/ui/button'
 import {
   Dialog,
@@ -24,22 +27,7 @@ import { useAppConfig } from '@/client/api/app-config'
 // The canonical setup prompt from moi.computer — pasted into any agent, it
 // fetches INSTALL.md and walks itself through the install.
 const AGENT_COMMAND =
-  'Set up the MOI workspace for this project. Fetch https://moi.computer/INSTALL.md, and follow the steps.'
-
-const FEATURES = [
-  {
-    icon: IconFolders,
-    text: 'Create workspaces for your own projects and folders'
-  },
-  {
-    icon: IconTerminal2,
-    text: 'Use your own agent and subscription — Claude Code, Codex, or OpenClaw'
-  },
-  {
-    icon: IconLock,
-    text: 'Everything runs and stays on your computer'
-  }
-] as const
+  'Set up the moi workspace for this project. Fetch https://moi.computer/INSTALL.md, and follow the steps.'
 
 type InstallMoiDialogProps = {
   // Trigger-owned (uncontrolled) or controlled via open/onOpenChange — the
@@ -182,59 +170,74 @@ function InstallMoiDialogContent() {
 
       <div className="flex flex-col gap-5 p-6 pt-3">
         <div className="flex flex-col gap-0.5">
-          <DialogTitle>Get moi on your computer</DialogTitle>
+          <DialogTitle>Use moi with your projects</DialogTitle>
           <DialogDescription>
-            This demo is limited to its built-in workspaces. The full moi runs locally with your own
-            agent.
+            This demo comes with sample workspaces. Connect moi to your agent to unlock all
+            features.
           </DialogDescription>
         </div>
 
         <ul className="flex flex-col gap-3">
-          {FEATURES.map(({ icon: Icon, text }) => (
-            <li key={text} className="flex items-center gap-3">
-              <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                <Icon size={16} stroke={1.75} />
+          <li className="flex items-center gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+              <IconFolders size={20} stroke={1.5} />
+            </span>
+            <span className="text-sm text-foreground">
+              Connect your own data and import existing projects
+            </span>
+          </li>
+          <li className="flex items-center gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+              <IconTerminal2 size={20} stroke={1.5} />
+            </span>
+            <span className="flex flex-wrap items-center gap-x-1 gap-y-0.5 text-sm text-foreground">
+              <span>Works with</span>
+              <span className="inline-flex items-center gap-1 font-medium">
+                <img src={claudeIcon} alt="" className="size-4 object-contain" />
+                Claude Code,
               </span>
-              <span className="text-sm text-foreground">{text}</span>
-            </li>
-          ))}
+              <span className="inline-flex items-center gap-1 font-medium">
+                <img src={openaiIcon} alt="" className="size-4 object-contain" />
+                Codex,
+              </span>
+              <span className="inline-flex items-center gap-1 font-medium">
+                <img src={hermesIcon} alt="" className="size-4 object-contain" />
+                Hermes,
+              </span>
+              <span className="inline-flex items-center gap-1 font-medium">
+                <img src={openclawIcon} alt="" className="size-4 object-contain" />
+                OpenClaw,
+              </span>
+              <span>and more.</span>
+            </span>
+          </li>
         </ul>
 
         <div className="flex flex-col gap-2">
-          <p className="text-sm text-muted-foreground">To install, paste this to your agent:</p>
-          <div className="relative rounded-lg bg-muted p-3 pr-11">
-            <code className="block font-mono text-xs leading-relaxed text-foreground">
+          <p className="text-sm text-muted-foreground">Paste this prompt into your agent:</p>
+          <div className="rounded-lg bg-muted p-3">
+            <code className="block font-mono text-sm leading-relaxed text-foreground">
               {AGENT_COMMAND}
             </code>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={copy}
-              aria-label={copied ? 'Copied' : 'Copy command'}
-              className="absolute top-1.5 right-1.5"
-            >
-              {copied ? <IconCheck stroke={1.75} /> : <IconCopy stroke={1.75} />}
-            </Button>
+            <div className="mt-5 flex flex-wrap items-center gap-2">
+              <Button type="button" onClick={copy}>
+                {copied ? (
+                  <IconCheck data-icon="inline-start" stroke={1.5} />
+                ) : (
+                  <IconCopy data-icon="inline-start" stroke={1.5} />
+                )}
+                {copied ? 'Copied' : 'Copy installation prompt'}
+              </Button>
+              <Button
+                variant="secondary"
+                nativeButton={false}
+                render={<a href={demoInstallUrl} target="_blank" rel="noreferrer" />}
+              >
+                Learn more
+                <IconArrowUpRight data-icon="inline-end" stroke={1.5} />
+              </Button>
+            </div>
           </div>
-        </div>
-
-        <div className="flex items-center justify-end gap-2">
-          <Button
-            variant="secondary"
-            render={<a href={demoInstallUrl} target="_blank" rel="noreferrer" />}
-          >
-            moi.computer
-            <IconArrowUpRight data-icon="inline-end" stroke={1.5} />
-          </Button>
-          <Button type="button" onClick={copy}>
-            {copied ? (
-              <IconCheck data-icon="inline-start" stroke={1.5} />
-            ) : (
-              <IconCopy data-icon="inline-start" stroke={1.5} />
-            )}
-            {copied ? 'Copied' : 'Copy command'}
-          </Button>
         </div>
       </div>
     </DialogContent>

--- a/client/features/home/workspace-setup/InstallMoiDialog.tsx
+++ b/client/features/home/workspace-setup/InstallMoiDialog.tsx
@@ -1,0 +1,165 @@
+import { type ReactElement, useEffect, useState } from 'react'
+
+import {
+  IconArrowUpRight,
+  IconCheck,
+  IconCopy,
+  IconFolders,
+  IconLock,
+  IconTerminal2,
+  IconX
+} from '@tabler/icons-react'
+
+import { HomeLogo } from '../HomeLogo'
+import { Button } from '@/client/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger
+} from '@/client/components/ui/dialog'
+import { useAppConfig } from '@/client/api/app-config'
+
+// The canonical setup prompt from moi.computer — pasted into any agent, it
+// fetches INSTALL.md and walks itself through the install.
+const AGENT_COMMAND =
+  'Set up the MOI workspace for this project. Fetch https://moi.computer/INSTALL.md, and follow the steps.'
+
+const FEATURES = [
+  {
+    icon: IconFolders,
+    text: 'Create workspaces for your own projects and folders'
+  },
+  {
+    icon: IconTerminal2,
+    text: 'Use your own agent and subscription — Claude Code, Codex, or OpenClaw'
+  },
+  {
+    icon: IconLock,
+    text: 'Everything runs and stays on your computer'
+  }
+] as const
+
+type InstallMoiDialogProps = {
+  // Trigger-owned (uncontrolled) or controlled via open/onOpenChange — the
+  // create-workspace buttons use the former, programmatic opens the latter.
+  trigger?: ReactElement
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+// Shown in the cloud demo wherever a workspace would be created: the demo is
+// limited to its built-in workspaces, and the way out is installing moi.
+export function InstallMoiDialog({ trigger, open, onOpenChange }: InstallMoiDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger && <DialogTrigger render={trigger} />}
+      <InstallMoiDialogContent />
+    </Dialog>
+  )
+}
+
+function useCopyCommand() {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+    const t = setTimeout(() => setCopied(false), 1500)
+    return () => clearTimeout(t)
+  }, [copied])
+
+  const copy = () => {
+    navigator.clipboard
+      ?.writeText(AGENT_COMMAND)
+      .then(() => setCopied(true))
+      .catch(() => {})
+  }
+
+  return { copied, copy }
+}
+
+function InstallMoiDialogContent() {
+  const config = useAppConfig()
+  const { copied, copy } = useCopyCommand()
+  const installUrl = config.data?.demoInstallUrl ?? 'https://moi.computer'
+
+  return (
+    <DialogContent className="w-[calc(100%-2rem)] max-w-md">
+      <div className="flex h-28 items-center justify-center bg-muted">
+        <HomeLogo className="text-muted-foreground" />
+      </div>
+      <DialogClose
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Close"
+            className="absolute top-4 right-4"
+          >
+            <IconX stroke={1.75} />
+          </Button>
+        }
+      />
+
+      <div className="flex flex-col gap-5 p-6">
+        <div className="flex flex-col gap-0.5">
+          <DialogTitle>Get moi on your computer</DialogTitle>
+          <DialogDescription>
+            This cloud demo is limited to its built-in workspaces. The full moi runs locally with
+            your own agent.
+          </DialogDescription>
+        </div>
+
+        <ul className="flex flex-col gap-3">
+          {FEATURES.map(({ icon: Icon, text }) => (
+            <li key={text} className="flex items-center gap-3">
+              <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                <Icon size={16} stroke={1.75} />
+              </span>
+              <span className="text-sm text-foreground">{text}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-muted-foreground">To install, paste this to your agent:</p>
+          <div className="relative rounded-lg bg-muted p-3 pr-11">
+            <code className="block font-mono text-xs leading-relaxed text-foreground">
+              {AGENT_COMMAND}
+            </code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={copy}
+              aria-label={copied ? 'Copied' : 'Copy command'}
+              className="absolute top-1.5 right-1.5"
+            >
+              {copied ? <IconCheck stroke={1.75} /> : <IconCopy stroke={1.75} />}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="secondary"
+            render={<a href={installUrl} target="_blank" rel="noreferrer" />}
+          >
+            moi.computer
+            <IconArrowUpRight data-icon="inline-end" stroke={1.5} />
+          </Button>
+          <Button type="button" onClick={copy}>
+            {copied ? (
+              <IconCheck data-icon="inline-start" stroke={1.5} />
+            ) : (
+              <IconCopy data-icon="inline-start" stroke={1.5} />
+            )}
+            {copied ? 'Copied' : 'Copy command'}
+          </Button>
+        </div>
+      </div>
+    </DialogContent>
+  )
+}

--- a/client/features/home/workspace-setup/InstallMoiDialog.tsx
+++ b/client/features/home/workspace-setup/InstallMoiDialog.tsx
@@ -10,7 +10,6 @@ import {
   IconX
 } from '@tabler/icons-react'
 
-import { HomeLogo } from '../HomeLogo'
 import { Button } from '@/client/components/ui/button'
 import {
   Dialog,
@@ -61,6 +60,85 @@ export function InstallMoiDialog({ trigger, open, onOpenChange }: InstallMoiDial
   )
 }
 
+// Hero artwork: a floppy disk cropped by the band, on a soft gradient. The
+// gradient's raw colors are a deliberate owner-approved exception to the
+// semantic-token rule — this block is an illustration (constant across
+// themes), not a UI surface.
+function FloppyHero() {
+  return (
+    <div className="relative h-44 overflow-hidden rounded-lg bg-[#e6dcc4] bg-[image:radial-gradient(75%_110%_at_0%_0%,#e0742f_0%,rgba(224,116,47,0)_48%),radial-gradient(110%_160%_at_100%_0%,#16352a_0%,rgba(22,53,42,0)_60%),radial-gradient(70%_90%_at_90%_100%,#8fb492_0%,rgba(143,180,146,0)_55%),radial-gradient(60%_80%_at_8%_100%,#dcc294_0%,rgba(220,194,148,0)_52%)]">
+      <FloppyDisk className="absolute top-9 left-1/2 w-52 -translate-x-1/2 -rotate-6 drop-shadow-xl" />
+      {/* film grain, keeps the flat gradients from banding */}
+      <svg
+        className="absolute inset-0 size-full opacity-30 mix-blend-soft-light"
+        aria-hidden="true"
+      >
+        <filter id="floppy-grain">
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.8"
+            numOctaves="2"
+            stitchTiles="stitch"
+          />
+        </filter>
+        <rect width="100%" height="100%" filter="url(#floppy-grain)" />
+      </svg>
+    </div>
+  )
+}
+
+type FloppyDiskProps = {
+  className?: string
+}
+
+// Front view of a 3.5" floppy: shutter with window, insert arrow, label
+// area, write-protect holes. Drawn inline so it stays crisp and asset-free.
+function FloppyDisk({ className }: FloppyDiskProps) {
+  return (
+    <svg viewBox="0 0 200 200" aria-hidden="true" className={className}>
+      <defs>
+        <linearGradient id="floppy-shutter" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#e3e3e1" />
+          <stop offset="0.5" stopColor="#c8c8c6" />
+          <stop offset="1" stopColor="#aeaeac" />
+        </linearGradient>
+      </defs>
+      {/* body with clipped top-right corner */}
+      <path
+        d="M14 2h146l26 26v160a10 10 0 0 1-10 10H14A10 10 0 0 1 4 188V12A10 10 0 0 1 14 2Z"
+        fill="#1a1b1d"
+      />
+      <path
+        d="M14 2h146l26 26v160a10 10 0 0 1-10 10H14A10 10 0 0 1 4 188V12A10 10 0 0 1 14 2Z"
+        fill="none"
+        stroke="#ffffff"
+        strokeOpacity="0.08"
+        strokeWidth="1.5"
+      />
+      {/* shutter */}
+      <path d="M64 2h96v66a6 6 0 0 1-6 6H70a6 6 0 0 1-6-6V2Z" fill="url(#floppy-shutter)" />
+      <rect x="116" y="12" width="28" height="52" rx="3" fill="#191a1c" />
+      {/* insert arrow */}
+      <path d="M26 30 34 16l8 14h-5v14h-6V30Z" fill="#0e0f10" />
+      {/* label area */}
+      <rect
+        x="22"
+        y="92"
+        width="156"
+        height="106"
+        rx="8"
+        fill="#202124"
+        stroke="#ffffff"
+        strokeOpacity="0.05"
+      />
+      {/* write-protect holes */}
+      <rect x="14" y="168" width="13" height="13" rx="2" fill="#0c0d0e" />
+      <rect x="172" y="168" width="13" height="13" rx="2" fill="#0c0d0e" />
+      <rect x="175" y="171" width="7" height="7" rx="1" fill="#e6e6e4" />
+    </svg>
+  )
+}
+
 function useCopyCommand() {
   const [copied, setCopied] = useState(false)
 
@@ -87,8 +165,8 @@ function InstallMoiDialogContent() {
 
   return (
     <DialogContent className="w-[calc(100%-2rem)] max-w-md">
-      <div className="flex h-28 items-center justify-center bg-muted">
-        <HomeLogo className="text-muted-foreground" />
+      <div className="p-2">
+        <FloppyHero />
       </div>
       <DialogClose
         render={
@@ -96,14 +174,14 @@ function InstallMoiDialogContent() {
             variant="ghost"
             size="icon-sm"
             aria-label="Close"
-            className="absolute top-4 right-4"
+            className="absolute top-4 right-4 text-white hover:bg-white/20 hover:text-white"
           >
             <IconX stroke={1.75} />
           </Button>
         }
       />
 
-      <div className="flex flex-col gap-5 p-6">
+      <div className="flex flex-col gap-5 p-6 pt-3">
         <div className="flex flex-col gap-0.5">
           <DialogTitle>Get moi on your computer</DialogTitle>
           <DialogDescription>

--- a/client/features/home/workspace-setup/InstallMoiDialog.tsx
+++ b/client/features/home/workspace-setup/InstallMoiDialog.tsx
@@ -159,9 +159,8 @@ function useCopyCommand() {
 }
 
 function InstallMoiDialogContent() {
-  const config = useAppConfig()
+  const { demoInstallUrl } = useAppConfig()
   const { copied, copy } = useCopyCommand()
-  const installUrl = config.data?.demoInstallUrl ?? 'https://moi.computer'
 
   return (
     <DialogContent className="w-[calc(100%-2rem)] max-w-md">
@@ -223,7 +222,7 @@ function InstallMoiDialogContent() {
         <div className="flex items-center justify-end gap-2">
           <Button
             variant="secondary"
-            render={<a href={installUrl} target="_blank" rel="noreferrer" />}
+            render={<a href={demoInstallUrl} target="_blank" rel="noreferrer" />}
           >
             moi.computer
             <IconArrowUpRight data-icon="inline-end" stroke={1.5} />

--- a/client/features/home/workspace-setup/InstallMoiDialog.tsx
+++ b/client/features/home/workspace-setup/InstallMoiDialog.tsx
@@ -184,8 +184,8 @@ function InstallMoiDialogContent() {
         <div className="flex flex-col gap-0.5">
           <DialogTitle>Get moi on your computer</DialogTitle>
           <DialogDescription>
-            This cloud demo is limited to its built-in workspaces. The full moi runs locally with
-            your own agent.
+            This demo is limited to its built-in workspaces. The full moi runs locally with your own
+            agent.
           </DialogDescription>
         </div>
 

--- a/client/index.tsx
+++ b/client/index.tsx
@@ -21,7 +21,12 @@ if (import.meta.hot) {
 }
 
 export async function init(el: HTMLElement) {
-  const { mount } = await import('./main')
+  // Startup config loads in parallel with the main chunk, so it is available
+  // synchronously to every component from the first render.
+  const [{ mount }] = await Promise.all([
+    import('./main'),
+    import('./api/app-config').then(m => m.loadAppConfig())
+  ])
   mount(el)
 }
 

--- a/client/runtime/useWorkspaceEvents.ts
+++ b/client/runtime/useWorkspaceEvents.ts
@@ -56,6 +56,11 @@ export type WorkspaceEvent =
 type WorkspaceEventHandler = (event: WorkspaceEvent) => void
 
 const listeners = new Set<WorkspaceEventHandler>()
+// Fired when the socket comes back after a drop — for the SPA that means the
+// server restarted (it holds the connection for its whole lifetime), so
+// restart-scoped state such as the startup config can refetch.
+const reconnectListeners = new Set<() => void>()
+let everConnected = false
 let ws: WebSocket | null = null
 let connecting = false
 
@@ -68,6 +73,8 @@ function ensureConnection() {
   socket.onopen = () => {
     ws = socket
     connecting = false
+    if (everConnected) for (const handler of reconnectListeners) handler()
+    everConnected = true
   }
 
   socket.onmessage = event => {
@@ -88,6 +95,16 @@ function ensureConnection() {
 
   socket.onerror = () => {
     socket.close()
+  }
+}
+
+// Subscribe to reconnects; returns the unsubscribe. Only fires while some
+// component holds the events socket open via useWorkspaceEvent (the app shell
+// always does).
+export function onWorkspaceEventsReconnect(handler: () => void): () => void {
+  reconnectListeners.add(handler)
+  return () => {
+    reconnectListeners.delete(handler)
   }
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -285,6 +285,20 @@ export type AppSettings = {
   autoUpdateSkills: boolean
 }
 
+// Client-safe subset of the startup config (`config.json` in the data dir +
+// `MOI_*` env overrides), served by GET /api/config. Frozen for the process
+// lifetime — changing it requires a server restart, so clients may cache it
+// forever. See server/app-config.ts.
+export type ClientAppConfig = {
+  // Cloud demo deployment: workspace creation is blocked; the UI offers the
+  // install-moi dialog instead.
+  cloudDemo: boolean
+  // Enabled experimental features, checked by slug.
+  experiments: string[]
+  // Link target for the install-moi dialog in the cloud demo.
+  demoInstallUrl: string
+}
+
 // Re-export the display format
 export type {
   Citation,

--- a/server/api-demo.test.ts
+++ b/server/api-demo.test.ts
@@ -38,7 +38,7 @@ test('cloud demo blocks creating a workspace', async () => {
   })
 
   expect(response.status).toBe(403)
-  expect(await response.text()).toBe('Workspace creation is not available in the moi cloud demo')
+  expect(await response.text()).toBe('Workspace creation is not available in the moi demo')
 })
 
 test('cloud demo blocks adding an existing folder', async () => {
@@ -49,7 +49,7 @@ test('cloud demo blocks adding an existing folder', async () => {
   })
 
   expect(response.status).toBe(403)
-  expect(await response.text()).toBe('Workspace creation is not available in the moi cloud demo')
+  expect(await response.text()).toBe('Workspace creation is not available in the moi demo')
 })
 
 test('GET /api/config reports the demo flag and install url', async () => {

--- a/server/api-demo.test.ts
+++ b/server/api-demo.test.ts
@@ -6,14 +6,20 @@ import { afterEach, beforeEach, expect, test } from 'bun:test'
 
 import { api } from './api'
 import { resetAppConfig } from './app-config'
+import { claudeCodeHarness } from './harness/claude-code'
+
+const originalClaudeAvailability = claudeCodeHarness.availability
 
 // All three env vars pinned so a real config.json on the machine running the
-// tests (env wins over file) can never change the assertions.
+// tests (env wins over file) can never change the assertions. Availability is
+// mocked because with the gate off the create route checks the harness before
+// validating the name — on a runner without the Claude CLI that 400s first.
 beforeEach(() => {
   process.env.MOI_CLOUD_DEMO = '1'
   process.env.MOI_EXPERIMENTS = ''
   process.env.MOI_DEMO_INSTALL_URL = 'https://moi.computer'
   resetAppConfig()
+  claudeCodeHarness.availability = async () => ({ available: true })
 })
 
 afterEach(() => {
@@ -21,6 +27,7 @@ afterEach(() => {
   delete process.env.MOI_EXPERIMENTS
   delete process.env.MOI_DEMO_INSTALL_URL
   resetAppConfig()
+  claudeCodeHarness.availability = originalClaudeAvailability
 })
 
 test('cloud demo blocks creating a workspace', async () => {

--- a/server/api-demo.test.ts
+++ b/server/api-demo.test.ts
@@ -1,0 +1,73 @@
+// Cloud demo protections on the API: both workspace-creation routes refuse
+// with 403, and GET /api/config exposes the flag to the client. The demo flag
+// comes from the startup config, toggled here via MOI_CLOUD_DEMO + the
+// resetAppConfig test seam.
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+
+import { api } from './api'
+import { resetAppConfig } from './app-config'
+
+// All three env vars pinned so a real config.json on the machine running the
+// tests (env wins over file) can never change the assertions.
+beforeEach(() => {
+  process.env.MOI_CLOUD_DEMO = '1'
+  process.env.MOI_EXPERIMENTS = ''
+  process.env.MOI_DEMO_INSTALL_URL = 'https://moi.computer'
+  resetAppConfig()
+})
+
+afterEach(() => {
+  delete process.env.MOI_CLOUD_DEMO
+  delete process.env.MOI_EXPERIMENTS
+  delete process.env.MOI_DEMO_INSTALL_URL
+  resetAppConfig()
+})
+
+test('cloud demo blocks creating a workspace', async () => {
+  const response = await api.request('/api/workspaces/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'my-workspace', type: 'claude-code' })
+  })
+
+  expect(response.status).toBe(403)
+  expect(await response.text()).toBe('Workspace creation is not available in the moi cloud demo')
+})
+
+test('cloud demo blocks adding an existing folder', async () => {
+  const response = await api.request('/api/workspaces', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path: '/tmp/some-folder', type: 'claude-code' })
+  })
+
+  expect(response.status).toBe(403)
+  expect(await response.text()).toBe('Workspace creation is not available in the moi cloud demo')
+})
+
+test('GET /api/config reports the demo flag and install url', async () => {
+  const response = await api.request('/api/config')
+  const body = await response.json()
+
+  expect(response.status).toBe(200)
+  expect(body).toEqual({
+    cloudDemo: true,
+    experiments: [],
+    demoInstallUrl: 'https://moi.computer'
+  })
+})
+
+test('without the demo flag, creation is not blocked by the gate', async () => {
+  delete process.env.MOI_CLOUD_DEMO
+  resetAppConfig()
+
+  const response = await api.request('/api/workspaces/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: '' })
+  })
+
+  // Falls through to ordinary validation instead of the demo 403.
+  expect(response.status).toBe(400)
+  expect(await response.text()).toBe('Folder name is required')
+})

--- a/server/api.ts
+++ b/server/api.ts
@@ -20,6 +20,7 @@ import type { MoiContext } from '@/lib/moi-context'
 import { viewBuilderDirectives } from '@/lib/view-builder-directives'
 
 import { agentStore } from './agent'
+import { clientAppConfig, getAppConfig } from './app-config'
 import { getAppSettings, pickAppSettingsPatch, saveAppSettings } from './app-settings'
 import { appletForModule, recordAppletError } from './applet-log'
 import { apiBaseFor, parseAppletTail, serveWorkspaceFile } from './applets'
@@ -942,7 +943,14 @@ workspaces.put('/order', async c => {
   }
 })
 
+// One message for both creation routes: in the cloud demo the instance is
+// provisioned with its workspaces; the UI never sends these requests (it opens
+// the install-moi dialog instead), so a 403 here means the API was called
+// directly.
+const DEMO_CREATE_BLOCKED = 'Workspace creation is not available in the moi cloud demo'
+
 workspaces.post('/', async c => {
+  if (getAppConfig().cloudDemo) return c.text(DEMO_CREATE_BLOCKED, 403)
   const body = await c.req.json()
   if (!body?.path) return c.text('Missing path', 400)
   const requestedType: unknown = body?.type ?? 'claude-code'
@@ -1008,6 +1016,7 @@ workspaces.get('/create', async c =>
 // Create a brand-new workspace: a fresh folder under CREATED_WORKSPACES_ROOT,
 // provisioned (skills + `.moi/` scaffold) and registered.
 workspaces.post('/create', async c => {
+  if (getAppConfig().cloudDemo) return c.text(DEMO_CREATE_BLOCKED, 403)
   const body = await c.req.json()
   const requestedType: unknown = body?.type ?? 'claude-code'
   if (!isHarnessType(requestedType)) {
@@ -1045,6 +1054,10 @@ workspaces.route('/:id', one)
 export const api = new Hono()
 
 api.route('/api/workspaces', workspaces)
+
+// Startup config (config.json in the data dir + MOI_* env), client-safe
+// subset. Immutable for the process lifetime — clients cache it forever.
+api.get('/api/config', c => c.json(clientAppConfig()))
 
 // App-wide settings (settings.json in the data dir). GET returns every key
 // with defaults applied; PATCH merges a partial body and returns the result.

--- a/server/api.ts
+++ b/server/api.ts
@@ -947,7 +947,7 @@ workspaces.put('/order', async c => {
 // provisioned with its workspaces; the UI never sends these requests (it opens
 // the install-moi dialog instead), so a 403 here means the API was called
 // directly.
-const DEMO_CREATE_BLOCKED = 'Workspace creation is not available in the moi cloud demo'
+const DEMO_CREATE_BLOCKED = 'Workspace creation is not available in the moi demo'
 
 workspaces.post('/', async c => {
   if (getAppConfig().cloudDemo) return c.text(DEMO_CREATE_BLOCKED, 403)

--- a/server/app-config.test.ts
+++ b/server/app-config.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'path'
+
+import { loadAppConfig } from './app-config'
+
+const NO_ENV: Record<string, string | undefined> = {}
+
+async function configFile(contents: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'moi-app-config-'))
+  const file = join(dir, 'config.json')
+  await writeFile(file, contents)
+  return file
+}
+
+test('defaults apply when no config file exists', () => {
+  const config = loadAppConfig('/nonexistent/config.json', NO_ENV)
+  expect(config).toEqual({
+    cloudDemo: false,
+    experiments: [],
+    demoInstallUrl: 'https://moi.computer'
+  })
+})
+
+test('config file values override defaults', async () => {
+  const file = await configFile(
+    JSON.stringify({
+      cloudDemo: true,
+      experiments: ['new-chat-ui'],
+      demoInstallUrl: 'https://moi.computer/download'
+    })
+  )
+  const config = loadAppConfig(file, NO_ENV)
+  expect(config.cloudDemo).toBe(true)
+  expect(config.experiments).toEqual(['new-chat-ui'])
+  expect(config.demoInstallUrl).toBe('https://moi.computer/download')
+})
+
+test('env vars override the config file', async () => {
+  const file = await configFile(JSON.stringify({ cloudDemo: true, experiments: ['from-file'] }))
+  const config = loadAppConfig(file, {
+    MOI_CLOUD_DEMO: '0',
+    MOI_EXPERIMENTS: ' a, b ,,c '
+  })
+  expect(config.cloudDemo).toBe(false)
+  expect(config.experiments).toEqual(['a', 'b', 'c'])
+})
+
+test('boolean env accepts 1/true/0/false and ignores anything else', () => {
+  const on = (value: string) => loadAppConfig('/nonexistent', { MOI_CLOUD_DEMO: value }).cloudDemo
+  expect(on('1')).toBe(true)
+  expect(on('TRUE')).toBe(true)
+  expect(on('0')).toBe(false)
+  expect(on('maybe')).toBe(false) // unparseable → default
+})
+
+test('empty MOI_EXPERIMENTS clears file-set experiments', async () => {
+  const file = await configFile(JSON.stringify({ experiments: ['from-file'] }))
+  const config = loadAppConfig(file, { MOI_EXPERIMENTS: '' })
+  expect(config.experiments).toEqual([])
+})
+
+test('invalid JSON falls back to defaults without throwing', async () => {
+  const file = await configFile('{ not json')
+  const config = loadAppConfig(file, NO_ENV)
+  expect(config.cloudDemo).toBe(false)
+})
+
+test('wrong-typed keys are dropped individually, valid keys survive', async () => {
+  const file = await configFile(
+    JSON.stringify({ cloudDemo: 'yes', experiments: ['kept'], demoInstallUrl: 42 })
+  )
+  const config = loadAppConfig(file, NO_ENV)
+  expect(config.cloudDemo).toBe(false)
+  expect(config.experiments).toEqual(['kept'])
+  expect(config.demoInstallUrl).toBe('https://moi.computer')
+})
+
+test('the resolved config is frozen', () => {
+  const config = loadAppConfig('/nonexistent', NO_ENV)
+  expect(Object.isFrozen(config)).toBe(true)
+})

--- a/server/app-config.test.ts
+++ b/server/app-config.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test'
+import { expect, spyOn, test } from 'bun:test'
 import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'path'
@@ -65,6 +65,23 @@ test('invalid JSON falls back to defaults without throwing', async () => {
   const file = await configFile('{ not json')
   const config = loadAppConfig(file, NO_ENV)
   expect(config.cloudDemo).toBe(false)
+})
+
+test('a read failure other than a missing file warns instead of staying silent', async () => {
+  const errors: string[] = []
+  const spy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    errors.push(args.map(String).join(' '))
+  })
+  try {
+    // A directory as the config path throws EISDIR — a stand-in for any
+    // non-ENOENT failure (permissions, mount errors).
+    const dir = await mkdtemp(join(tmpdir(), 'moi-app-config-'))
+    const config = loadAppConfig(dir, NO_ENV)
+    expect(config.cloudDemo).toBe(false)
+    expect(errors.join('\n')).toContain('could not read')
+  } finally {
+    spy.mockRestore()
+  }
 })
 
 test('wrong-typed keys are dropped individually, valid keys survive', async () => {

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -65,8 +65,16 @@ function fileValues(file: string): Partial<AppConfig> {
   let text: string
   try {
     text = readFileSync(file, 'utf8')
-  } catch {
-    return {} // no config file — the normal local case
+  } catch (err) {
+    // Only a missing file is silent (the normal local case). Anything else —
+    // permissions, mount errors — is loud: a deployment relying on config.json
+    // must not boot un-gated without a diagnostic. Deployments that need the
+    // demo gate guaranteed should pin MOI_CLOUD_DEMO=1 in the environment,
+    // which has no read-failure mode.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      warn(`could not read ${file}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    return {}
   }
   let parsed: unknown
   try {

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'path'
+
+import type { ClientAppConfig } from '@/lib/types'
+
+import { DATA_DIR } from './data-dir'
+
+// Startup (deployment) config, read once per process from `config.json` in
+// moi's data dir and overridable by `MOI_*` env vars (env wins). Distinct from
+// `settings.json` (user settings: conf-backed, API-mutable, changes at
+// runtime): config.json describes the deployment itself — nothing here changes
+// without a server restart, and no API writes it.
+//
+// Resolution: defaults < config.json < env. A missing file is the normal local
+// case; a malformed file or wrong-typed key warns on stderr and falls back
+// per-key, so a broken config never takes the CLI or server down with it.
+export type AppConfig = {
+  // Cloud demo deployment: workspace creation is blocked (UI shows the
+  // install-moi dialog instead) and `moi` system commands are disabled.
+  cloudDemo: boolean
+  // Gated experimental features, checked by slug.
+  experiments: string[]
+  // Link target for the install-moi dialog in the cloud demo.
+  demoInstallUrl: string
+}
+
+const DEFAULTS: AppConfig = {
+  cloudDemo: false,
+  experiments: [],
+  demoInstallUrl: 'https://moi.computer'
+}
+
+export const APP_CONFIG_FILE = join(DATA_DIR, 'config.json')
+
+function warn(message: string): void {
+  console.error(`[moi] config: ${message}`)
+}
+
+// '1'/'true' (case-insensitive) are true, '0'/'false' are false, anything
+// else — including empty — leaves the lower-precedence value in place.
+function parseBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined
+  const value = raw.trim().toLowerCase()
+  if (value === '1' || value === 'true') return true
+  if (value === '0' || value === 'false') return false
+  return undefined
+}
+
+// "a, b,c" → ['a','b','c']; empty entries dropped. An empty string clears the
+// list (explicitly setting MOI_EXPERIMENTS= disables file-set experiments).
+function parseList(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) return undefined
+  return raw
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function parseString(raw: string | undefined): string | undefined {
+  if (raw === undefined || raw.trim() === '') return undefined
+  return raw.trim()
+}
+
+function fileValues(file: string): Partial<AppConfig> {
+  let text: string
+  try {
+    text = readFileSync(file, 'utf8')
+  } catch {
+    return {} // no config file — the normal local case
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (err) {
+    warn(`ignoring ${file} — invalid JSON: ${err instanceof Error ? err.message : String(err)}`)
+    return {}
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    warn(`ignoring ${file} — expected a JSON object`)
+    return {}
+  }
+  const raw = parsed as Record<string, unknown>
+  const out: Partial<AppConfig> = {}
+  if (raw.cloudDemo !== undefined) {
+    if (typeof raw.cloudDemo === 'boolean') out.cloudDemo = raw.cloudDemo
+    else warn('ignoring "cloudDemo" — expected a boolean')
+  }
+  if (raw.experiments !== undefined) {
+    if (Array.isArray(raw.experiments) && raw.experiments.every(item => typeof item === 'string')) {
+      out.experiments = raw.experiments
+    } else warn('ignoring "experiments" — expected an array of strings')
+  }
+  if (raw.demoInstallUrl !== undefined) {
+    if (typeof raw.demoInstallUrl === 'string') out.demoInstallUrl = raw.demoInstallUrl
+    else warn('ignoring "demoInstallUrl" — expected a string')
+  }
+  return out
+}
+
+// Pure resolver, exported for tests. `getAppConfig` is the cached entrypoint.
+export function loadAppConfig(
+  file: string = APP_CONFIG_FILE,
+  env: Record<string, string | undefined> = process.env
+): AppConfig {
+  const fromFile = fileValues(file)
+  const fromEnv: Partial<AppConfig> = {
+    cloudDemo: parseBool(env.MOI_CLOUD_DEMO),
+    experiments: parseList(env.MOI_EXPERIMENTS),
+    demoInstallUrl: parseString(env.MOI_DEMO_INSTALL_URL)
+  }
+  const merged = { ...DEFAULTS, ...fromFile }
+  for (const key of Object.keys(fromEnv) as (keyof AppConfig)[]) {
+    if (fromEnv[key] === undefined) delete fromEnv[key]
+  }
+  return Object.freeze({ ...merged, ...fromEnv })
+}
+
+let _config: AppConfig | null = null
+
+export function getAppConfig(): AppConfig {
+  _config ??= loadAppConfig()
+  return _config
+}
+
+// Test seam: drop the cached config so the next getAppConfig() re-resolves
+// (tests point MOI_DATA_DIR elsewhere or set MOI_CLOUD_DEMO).
+export function resetAppConfig(): void {
+  _config = null
+}
+
+// The only shape that reaches the browser (GET /api/config). Server-only keys
+// added to AppConfig later stay out unless explicitly forwarded here.
+export function clientAppConfig(): ClientAppConfig {
+  const { cloudDemo, experiments, demoInstallUrl } = getAppConfig()
+  return { cloudDemo, experiments: [...experiments], demoInstallUrl }
+}

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -2851,15 +2851,16 @@ const main = defineCommand({
   subCommands: { ...workspaceCommands, ...systemCommands }
 })
 
-// Cloud demo: system commands manage moi itself (server, service, updates) —
-// in a demo container the instance is provisioned, not managed, so they print
-// a pointer to the real thing instead of running. `version` stays. The server
-// process itself (MOI_SERVER=1 — how launchd/systemd units and the demo
-// container entrypoint run `moi start`) is exempt, or the demo could not boot.
+// Cloud demo: system commands manage moi itself (service, updates, agent
+// runtimes) — in a demo container the instance is provisioned, not managed,
+// so they print a pointer to the real thing instead of running. Two stay:
+// `start`, because it is how the demo (container or a local test run) boots
+// at all — against an already-running server it just reports and exits — and
+// `version`, which is harmless and useful in bug reports.
 function exitIfDemoBlocked(): void {
   const invoked = process.argv[2]
-  if (!invoked || invoked === 'version' || !(invoked in systemCommands)) return
-  if (process.env.MOI_SERVER) return
+  if (!invoked || invoked === 'version' || invoked === 'start') return
+  if (!(invoked in systemCommands)) return
   const config = getAppConfig()
   if (!config.cloudDemo) return
   console.log(

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -2865,7 +2865,7 @@ function exitIfDemoBlocked(): void {
   console.log(
     '\n' +
       pc.yellow('◆') +
-      ` moi ${invoked} is not available in the cloud demo.\n` +
+      ` moi ${invoked} is not available in the demo.\n` +
       pc.dim('  Get moi on your computer: ') +
       pc.bold(config.demoInstallUrl) +
       '\n'

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -9,6 +9,7 @@ import { dirname, join, resolve } from 'path'
 import pc from './cli-pc'
 
 import { isAgentCaller } from './agent-caller'
+import { getAppConfig } from './app-config'
 
 import {
   COLOR_THEMES,
@@ -2849,6 +2850,30 @@ const main = defineCommand({
   }),
   subCommands: { ...workspaceCommands, ...systemCommands }
 })
+
+// Cloud demo: system commands manage moi itself (server, service, updates) —
+// in a demo container the instance is provisioned, not managed, so they print
+// a pointer to the real thing instead of running. `version` stays. The server
+// process itself (MOI_SERVER=1 — how launchd/systemd units and the demo
+// container entrypoint run `moi start`) is exempt, or the demo could not boot.
+function exitIfDemoBlocked(): void {
+  const invoked = process.argv[2]
+  if (!invoked || invoked === 'version' || !(invoked in systemCommands)) return
+  if (process.env.MOI_SERVER) return
+  const config = getAppConfig()
+  if (!config.cloudDemo) return
+  console.log(
+    '\n' +
+      pc.yellow('◆') +
+      ` moi ${invoked} is not available in the cloud demo.\n` +
+      pc.dim('  Get moi on your computer: ') +
+      pc.bold(config.demoInstallUrl) +
+      '\n'
+  )
+  process.exit(1)
+}
+
+exitIfDemoBlocked()
 
 type HelpCommand = { meta?: unknown }
 

--- a/server/test/cli-demo.test.ts
+++ b/server/test/cli-demo.test.ts
@@ -1,0 +1,86 @@
+// E2e for the cloud-demo CLI gate: system commands (except `version`) print a
+// pointer instead of running, workspace commands and the MOI_SERVER=1 server
+// process are exempt. Each test spawns the real CLI with an isolated
+// MOI_DATA_DIR so no real config.json can interfere.
+import { expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'path'
+
+const CLI = join(import.meta.dir, '..', 'cli.ts')
+
+type CliResult = { code: number; stdout: string; stderr: string }
+
+async function runCli(args: string[], env: Record<string, string> = {}): Promise<CliResult> {
+  const dataDir = await mkdtemp(join(tmpdir(), 'moi-cli-demo-'))
+  const proc = Bun.spawn(['bun', CLI, ...args], {
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      MOI_DATA_DIR: dataDir,
+      MOI_SERVER: undefined,
+      ...env
+    }
+  })
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text()
+  ])
+  return { code, stdout, stderr }
+}
+
+const DEMO = { MOI_CLOUD_DEMO: '1' }
+
+// Generous timeouts: each case cold-spawns a fresh `bun` compiling the whole
+// CLI import graph, which can take well over the 5s default on CI.
+const SPAWN_TIMEOUT = 30_000
+
+test(
+  'a system command is blocked in the cloud demo',
+  async () => {
+    const result = await runCli(['update'], DEMO)
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain('moi update is not available in the cloud demo')
+    expect(result.stdout).toContain('https://moi.computer')
+  },
+  SPAWN_TIMEOUT
+)
+
+test(
+  '`moi version` still works in the cloud demo',
+  async () => {
+    const result = await runCli(['version'], DEMO)
+    expect(result.code).toBe(0)
+    expect(result.stdout).toMatch(/\d+\.\d+\.\d+/)
+    expect(result.stdout).not.toContain('not available in the cloud demo')
+  },
+  SPAWN_TIMEOUT
+)
+
+test(
+  'the server process (MOI_SERVER=1) is exempt from the gate',
+  async () => {
+    // `update` against an unreachable registry: with the exemption the command
+    // really runs (and fails on the network), instead of printing the demo note.
+    const result = await runCli(['update'], {
+      ...DEMO,
+      MOI_SERVER: '1',
+      MOI_NPM_REGISTRY: 'http://127.0.0.1:1'
+    })
+    expect(result.stdout + result.stderr).not.toContain('not available in the cloud demo')
+  },
+  SPAWN_TIMEOUT
+)
+
+test(
+  'system commands run normally without the demo flag',
+  async () => {
+    const result = await runCli(['version'])
+    expect(result.code).toBe(0)
+    expect(result.stdout).not.toContain('not available in the cloud demo')
+  },
+  SPAWN_TIMEOUT
+)

--- a/server/test/cli-demo.test.ts
+++ b/server/test/cli-demo.test.ts
@@ -43,7 +43,7 @@ test(
   async () => {
     const result = await runCli(['update'], DEMO)
     expect(result.code).toBe(1)
-    expect(result.stdout).toContain('moi update is not available in the cloud demo')
+    expect(result.stdout).toContain('moi update is not available in the demo')
     expect(result.stdout).toContain('https://moi.computer')
   },
   SPAWN_TIMEOUT
@@ -55,7 +55,7 @@ test(
     const result = await runCli(['version'], DEMO)
     expect(result.code).toBe(0)
     expect(result.stdout).toMatch(/\d+\.\d+\.\d+/)
-    expect(result.stdout).not.toContain('not available in the cloud demo')
+    expect(result.stdout).not.toContain('not available in the demo')
   },
   SPAWN_TIMEOUT
 )
@@ -70,7 +70,7 @@ test(
       MOI_SERVER: '1',
       MOI_NPM_REGISTRY: 'http://127.0.0.1:1'
     })
-    expect(result.stdout + result.stderr).not.toContain('not available in the cloud demo')
+    expect(result.stdout + result.stderr).not.toContain('not available in the demo')
   },
   SPAWN_TIMEOUT
 )
@@ -80,7 +80,7 @@ test(
   async () => {
     const result = await runCli(['version'])
     expect(result.code).toBe(0)
-    expect(result.stdout).not.toContain('not available in the cloud demo')
+    expect(result.stdout).not.toContain('not available in the demo')
   },
   SPAWN_TIMEOUT
 )

--- a/server/test/cli-demo.test.ts
+++ b/server/test/cli-demo.test.ts
@@ -61,15 +61,12 @@ test(
 )
 
 test(
-  'the server process (MOI_SERVER=1) is exempt from the gate',
+  '`moi start` is exempt so the demo can boot',
   async () => {
-    // `update` against an unreachable registry: with the exemption the command
-    // really runs (and fails on the network), instead of printing the demo note.
-    const result = await runCli(['update'], {
-      ...DEMO,
-      MOI_SERVER: '1',
-      MOI_NPM_REGISTRY: 'http://127.0.0.1:1'
-    })
+    // --help renders usage without binding ports; reaching citty at all
+    // proves the gate let `start` through.
+    const result = await runCli(['start', '--help'], DEMO)
+    expect(result.code).toBe(0)
     expect(result.stdout + result.stderr).not.toContain('not available in the demo')
   },
   SPAWN_TIMEOUT


### PR DESCRIPTION
With `cloudDemo` on (`config.json` in the data dir, or `MOI_CLOUD_DEMO=1` — env wins), moi runs as a locked-down demo: every create/add-workspace action in the UI opens an install-moi dialog instead, both creation API routes refuse, and `moi` system commands point at moi.computer instead of running. The config layer underneath is new and dependency-free: defaults < `config.json` < `MOI_*` env, resolved once at boot and frozen. The client fetches the safe subset (`GET /api/config`) before the app mounts and reads it synchronously everywhere; the events socket reconnecting (= server restart) triggers a re-fetch, so open tabs follow a mode flip without a reload (`experiments` is plumbed but unread so far).

```
$ curl -X POST :13337/api/workspaces/create -d '{"name":"x"}'
403 Workspace creation is not available in the moi demo

$ MOI_CLOUD_DEMO=1 moi service
◆ moi service is not available in the demo.
  Get moi on your computer: https://moi.computer

$ curl :13337/api/config
{"cloudDemo":true,"experiments":[],"demoInstallUrl":"https://moi.computer"}
```

The dialog is an inset rounded gradient band with an inline-SVG floppy hero (cropped, film-grain overlay), three feature bullets, and the copyable agent setup command from moi.computer as the primary action.

Worth a close look:

- The CLI gate exempts `start` (it is how the demo boots — container entrypoint or `MOI_CLOUD_DEMO=1 bun run dev` locally; a second start against a running server just reports and exits) and `version`. The gate is guidance, not a security boundary; the API 403s are the enforcement.
- Config reaches components only through `useAppConfig()` (render-time, backed by a module store loaded in `init()` before mount) — a future module-scope read would race the boot fetch and see defaults.
- The hero's raw gradient colors and grain are a deliberate owner-approved exception to the semantic-token rule (theme-constant artwork), noted inline.

Verified: 17 tests across `server/app-config.test.ts`, `server/api-demo.test.ts`, `server/test/cli-demo.test.ts` (loader precedence and validation, both 403s, CLI gate including both exemptions); full `bun test` suite green; oxlint, oxfmt, and client tsc clean. Manually drove both modes in Chromium — demo shows the dialog from all entry points with working copy state, an open tab picked up a demo→normal flip through the reconnect re-fetch without a reload, and `MOI_CLOUD_DEMO=1 bun run dev` boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdjXaUCPU4wQoXPEeH9gxc