### PR TITLE
Accept an explicit workspace id in moi init

### DIFF
--- a/lib/ids.ts
+++ b/lib/ids.ts
@@ -8,6 +8,19 @@ const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'
 // whole life. 10 chars (~52 bits) stays collision-free at any realistic count.
 export const newWorkspaceId = customAlphabet(ALPHABET, 10)
 
+// Ids may also be chosen by hand (`moi init --id <id>`), so they are validated
+// rather than assumed. Slightly wider than the generated alphabet — dashes and
+// underscores read well in a URL — but never leading with a dash, so an id
+// cannot be mistaken for a CLI flag.
+export function validateWorkspaceId(id: string): string | null {
+  if (!id) return 'Workspace id is required'
+  if (id.length > 64) return 'Workspace id is too long (max 64 characters)'
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(id)) {
+    return 'Use letters, numbers, dashes and underscores, starting with a letter or number'
+  }
+  return null
+}
+
 // Builder handles are copied onto the command line (`moi builder set …
 // --builder <id>`), and only need to be unique among a workspace's handful of
 // builders — so 6 chars (~31 bits) keeps the command short while staying

--- a/lib/ids.ts
+++ b/lib/ids.ts
@@ -8,6 +8,15 @@ const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'
 // whole life. 10 chars (~52 bits) stays collision-free at any realistic count.
 export const newWorkspaceId = customAlphabet(ALPHABET, 10)
 
+// Ids no workspace can hold, because a URL carrying one never reaches it:
+// `/api/workspaces/:id` is registered after the literal collection routes, so
+// `create`, `discover` and `order` match those instead, and `ws` is claimed by
+// the live-event WebSocket upgrade in `server/web.ts` before Hono sees the
+// request. A workspace registered under one of these would persist fine and
+// then be unreachable in the app. `server/api-reserved-ids.test.ts` re-derives
+// this list from the router so a new collection route cannot outgrow it.
+export const RESERVED_WORKSPACE_IDS = ['create', 'discover', 'order', 'ws']
+
 // Ids may also be chosen by hand (`moi init --id <id>`), so they are validated
 // rather than assumed. Slightly wider than the generated alphabet — dashes and
 // underscores read well in a URL — but never leading with a dash, so an id
@@ -17,6 +26,11 @@ export function validateWorkspaceId(id: string): string | null {
   if (id.length > 64) return 'Workspace id is too long (max 64 characters)'
   if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(id)) {
     return 'Use letters, numbers, dashes and underscores, starting with a letter or number'
+  }
+  // Case-insensitive: only the exact-case spelling collides with a route, but
+  // accepting `Create` while refusing `create` reads as a bug, not a rule.
+  if (RESERVED_WORKSPACE_IDS.includes(id.toLowerCase())) {
+    return `Workspace id ${id} is reserved (${RESERVED_WORKSPACE_IDS.join(', ')})`
   }
   return null
 }

--- a/server/api-reserved-ids.test.ts
+++ b/server/api-reserved-ids.test.ts
@@ -1,0 +1,52 @@
+// Guards `RESERVED_WORKSPACE_IDS` against route drift: a workspace id that
+// collides with a literal route under `/api/workspaces/` is persisted fine and
+// then unreachable, so the reserved list must keep covering every such route.
+import { expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { RESERVED_WORKSPACE_IDS } from '@/lib/ids'
+
+import { api } from './api'
+import { DEFAULT_REGISTRY_PATH, registerWorkspace, setRegistryPath } from './registry'
+
+// Literal (non-parameter) first segments registered under `/api/workspaces/` —
+// exactly the paths that would shadow `/:id`.
+function staticCollectionRoutes(): string[] {
+  const segments = new Set<string>()
+  for (const route of api.routes) {
+    const match = /^\/api\/workspaces\/([^/:*]+)(?:$|\/)/.exec(route.path)
+    if (match) segments.add(match[1]!)
+  }
+  return [...segments].sort()
+}
+
+test('every literal route under /api/workspaces is a reserved id', () => {
+  for (const segment of staticCollectionRoutes()) {
+    expect(RESERVED_WORKSPACE_IDS).toContain(segment)
+  }
+})
+
+test('the WebSocket path stays reserved', () => {
+  // `/api/workspaces/ws` is served from Bun's routes table in `web.ts`, not the
+  // Hono router above, so it can never be re-derived — it is pinned here.
+  expect(RESERVED_WORKSPACE_IDS).toContain('ws')
+})
+
+test('a reserved id is refused before it can shadow its route', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'moi-reserved-ids-'))
+  setRegistryPath(join(tempDir, 'workspaces.json'))
+  try {
+    for (const id of RESERVED_WORKSPACE_IDS) {
+      await expect(registerWorkspace(join(tempDir, id), { id })).rejects.toThrow('is reserved')
+    }
+    // Without the check, this request would return the static route's payload
+    // instead of the workspace — the failure mode the reservation prevents.
+    const response = await api.request('/api/workspaces/create')
+    expect(await response.json()).not.toHaveProperty('id', 'create')
+  } finally {
+    setRegistryPath(DEFAULT_REGISTRY_PATH)
+    await rm(tempDir, { recursive: true, force: true })
+  }
+})

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -49,7 +49,7 @@ import {
   matchHermesProfile
 } from './harness/hermes/discovery'
 import { type OpenClawAgent, discoverOpenClawAgents } from './harness/openclaw/discovery'
-import { liftToWorkspaceRoot, registerWorkspace } from './registry'
+import { assertWorkspaceIdAvailable, liftToWorkspaceRoot, registerWorkspace } from './registry'
 import { serverCwd } from './server-cwd'
 import {
   isBehind,
@@ -222,6 +222,11 @@ const init = defineCommand({
       type: 'boolean',
       default: false,
       description: 'Start the web server if not already running'
+    },
+    id: {
+      type: 'string',
+      description:
+        'Register under this id instead of a generated one — fails if the workspace is already registered'
     }
   },
   async run({ args }) {
@@ -254,6 +259,17 @@ const init = defineCommand({
           ' (from an older bug). Safe to remove:\n' +
           pc.dim('  rm -rf ' + stray)
       )
+    }
+
+    // A chosen id is only assignable at first registration, so refuse it here —
+    // before any skills are copied or `.moi/` is scaffolded.
+    if (args.id) {
+      try {
+        await assertWorkspaceIdAvailable(target, args.id)
+      } catch (err) {
+        console.error('\n' + pc.red('✗') + ' ' + (err as Error).message + '\n')
+        process.exit(1)
+      }
     }
 
     const projectRoot = join(import.meta.dir, '..')
@@ -292,18 +308,18 @@ const init = defineCommand({
     }
 
     // Always register the workspace in the persistent registry
-    const entry = await registerWorkspace(
-      target,
-      agent
+    const entry = await registerWorkspace(target, {
+      ...(args.id ? { id: args.id } : {}),
+      ...(agent
         ? {
-            type: 'openclaw',
+            type: 'openclaw' as const,
             name: agent.name,
             agentId: agent.agentId,
             isDefault: agent.isDefault,
             lastRunAt: agent.lastRunAt
           }
-        : { type: 'claude-code' }
-    )
+        : { type: 'claude-code' as const })
+    })
 
     console.log(pc.green('✓') + ' Initialized ' + pc.bold(target))
     console.log(

--- a/server/registry.test.ts
+++ b/server/registry.test.ts
@@ -105,6 +105,17 @@ describe('registerWorkspace with a chosen id', () => {
     expect(await listWorkspaces()).toEqual([])
   })
 
+  test('rejects an id that a collection route would shadow', async () => {
+    await expect(registerWorkspace('/Users/foo/project', { id: 'create' })).rejects.toThrow(
+      'Workspace id create is reserved'
+    )
+    // Case-insensitive, so the rule cannot be sidestepped by spelling.
+    await expect(registerWorkspace('/Users/foo/project', { id: 'WS' })).rejects.toThrow(
+      'is reserved'
+    )
+    expect(await listWorkspaces()).toEqual([])
+  })
+
   test('assertWorkspaceIdAvailable mirrors the registration checks', async () => {
     await expect(assertWorkspaceIdAvailable('/Users/foo/project', 'free')).resolves.toBeUndefined()
 

--- a/server/registry.test.ts
+++ b/server/registry.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'path'
 
 import {
+  assertWorkspaceIdAvailable,
   findWorkspaceForPath,
   getWorkspace,
   groupDiscoveredWorkspaces,
@@ -59,6 +60,62 @@ describe('registerWorkspace', () => {
     const a = await registerWorkspace('/Users/foo/project-a')
     const b = await registerWorkspace('/Users/foo/project-b')
     expect(a.id).not.toBe(b.id)
+  })
+})
+
+describe('registerWorkspace with a chosen id', () => {
+  test('registers under the given id', async () => {
+    const entry = await registerWorkspace('/Users/foo/project', { id: 'my-workspace' })
+    expect(entry.id).toBe('my-workspace')
+    expect((await getWorkspace('my-workspace'))!.path).toBe('/Users/foo/project')
+  })
+
+  test('rejects an id the workspace cannot take because it already has one', async () => {
+    const existing = await registerWorkspace('/Users/foo/project')
+
+    await expect(registerWorkspace('/Users/foo/project', { id: 'my-workspace' })).rejects.toThrow(
+      `/Users/foo/project is already registered with id ${existing.id}`
+    )
+    expect((await listWorkspaces()).map(e => e.id)).toEqual([existing.id])
+  })
+
+  test('re-registering with the same id is a no-op', async () => {
+    const first = await registerWorkspace('/Users/foo/project', { id: 'my-workspace' })
+    const again = await registerWorkspace('/Users/foo/project', { id: 'my-workspace' })
+    expect(again.id).toBe(first.id)
+    expect(await listWorkspaces()).toHaveLength(1)
+  })
+
+  test('rejects an id already taken by another workspace', async () => {
+    await registerWorkspace('/Users/foo/project-a', { id: 'shared' })
+
+    await expect(registerWorkspace('/Users/foo/project-b', { id: 'shared' })).rejects.toThrow(
+      'Workspace id shared is already taken'
+    )
+    expect(await listWorkspaces()).toHaveLength(1)
+  })
+
+  test('rejects a malformed id', async () => {
+    await expect(registerWorkspace('/Users/foo/project', { id: '-dashed' })).rejects.toThrow(
+      'Use letters, numbers, dashes and underscores'
+    )
+    await expect(registerWorkspace('/Users/foo/project', { id: 'has space' })).rejects.toThrow(
+      'Use letters, numbers, dashes and underscores'
+    )
+    expect(await listWorkspaces()).toEqual([])
+  })
+
+  test('assertWorkspaceIdAvailable mirrors the registration checks', async () => {
+    await expect(assertWorkspaceIdAvailable('/Users/foo/project', 'free')).resolves.toBeUndefined()
+
+    const existing = await registerWorkspace('/Users/foo/project')
+    await expect(assertWorkspaceIdAvailable('/Users/foo/project', 'free')).rejects.toThrow(
+      `already registered with id ${existing.id}`
+    )
+    // Relative paths resolve the same way registration does.
+    await expect(assertWorkspaceIdAvailable('.', existing.id)).rejects.toThrow(
+      `Workspace id ${existing.id} is already taken`
+    )
   })
 })
 

--- a/server/registry.ts
+++ b/server/registry.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join, resolve, sep } from 'path'
 
-import { newWorkspaceId } from '@/lib/ids'
+import { newWorkspaceId, validateWorkspaceId } from '@/lib/ids'
 import type { DiscoveredWorkspace, WorkspaceEntry, WorkspaceType } from '@/lib/types'
 import { orderWorkspaceTypes } from '@/lib/workspace-types'
 
@@ -48,11 +48,42 @@ async function writeRegistry(entries: WorkspaceEntry[]): Promise<void> {
 }
 
 export type RegisterOptions = {
+  // Register under this id instead of a generated one. Only accepted while the
+  // workspace is unregistered — see `workspaceIdError`.
+  id?: string
   type?: WorkspaceType
   name?: string
   agentId?: string
   isDefault?: boolean
   lastRunAt?: string
+}
+
+// Why a chosen id can be refused. An id is baked into `/workspace/<id>` URLs
+// and outlives the registration, so it is assigned once: a workspace that
+// already carries an id keeps it, and no two workspaces may share one.
+function workspaceIdError(
+  entries: WorkspaceEntry[],
+  normalPath: string,
+  id: string
+): string | null {
+  const invalid = validateWorkspaceId(id)
+  if (invalid) return invalid
+  const existing = entries.find(e => e.path === normalPath)
+  if (existing && existing.id !== id) {
+    return `${normalPath} is already registered with id ${existing.id}`
+  }
+  if (entries.some(e => e.id === id && e.path !== normalPath)) {
+    return `Workspace id ${id} is already taken`
+  }
+  return null
+}
+
+// Check a chosen id against the registry without registering anything, so a
+// caller can fail before doing expensive setup work. `registerWorkspace`
+// re-checks, so this is a courtesy, not the enforcement point.
+export async function assertWorkspaceIdAvailable(absPath: string, id: string): Promise<void> {
+  const error = workspaceIdError(await readRegistry(), resolve(absPath), id)
+  if (error) throw new Error(error)
 }
 
 export async function registerWorkspace(
@@ -61,10 +92,14 @@ export async function registerWorkspace(
 ): Promise<WorkspaceEntry> {
   const normalPath = resolve(absPath)
   const entries = await readRegistry()
+  if (opts.id) {
+    const error = workspaceIdError(entries, normalPath, opts.id)
+    if (error) throw new Error(error)
+  }
   const existing = entries.find(e => e.path === normalPath)
   if (existing) return existing
   const entry: WorkspaceEntry = {
-    id: newWorkspaceId(),
+    id: opts.id ?? newWorkspaceId(),
     path: normalPath,
     addedAt: new Date().toISOString(),
     ...(opts.type ? { type: opts.type } : {}),


### PR DESCRIPTION
`moi init --id <id>` registers the workspace under a chosen id instead of a
generated one, so a workspace's `/workspace/<id>` URL can be pinned by whoever
sets it up. An id is assignable only once: passing `--id` for a path that is
already registered under a different id fails, as does reusing an id another
workspace holds, or an id that is not a URL-safe token starting with a letter
or number. Re-running with the id the workspace already has stays a no-op, so
provisioning scripts remain idempotent.

The check runs before any provisioning, so a rejected init leaves the target
directory untouched. The flag is documented only in `moi init --help`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KGWzXXCaCCw4xhLE7qWrqV