### PR TITLE
Normalize shell commands across providers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.13.0",
         "sharp": "^0.35.1",
+        "shell-quote": "^1.10.0",
         "sugar-high": "^1.2.1",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
@@ -1554,6 +1555,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 

--- a/client/features/chat/tool-group/format.test.ts
+++ b/client/features/chat/tool-group/format.test.ts
@@ -72,6 +72,45 @@ describe('hermes tool titles', () => {
   })
 })
 
+describe('shell briefs across providers', () => {
+  function shellCall(provider: ToolCall['provider'], name: string, input: unknown): ToolCall {
+    return { toolCallId: 'tc-1', name, caller: 'model', provider, state: 'success', input }
+  }
+
+  test('strips the wrapper and shortens paths against the cwd', () => {
+    // Codex hands the script to the login shell; the row should read as what
+    // the model wrote, with workspace paths relative.
+    const codex = shellCall('codex', 'exec', {
+      command: `/bin/zsh -lc "sed -n '1,240p' /repo/.agents/skills/moi-workspace/SKILL.md && cat .moi/FIRMA.md"`
+    })
+    expect(formatInputBrief(codex, '/repo')).toBe(
+      "$ sed -n '1,240p' .agents/skills/moi-workspace/SKILL.md && cat .moi/FIRMA.md"
+    )
+  })
+
+  test('collapses a multi-line Claude Bash command to one line', () => {
+    const claude = shellCall('claude-code', 'Bash', {
+      command: 'git add -A &&\n  git commit -m "wip"'
+    })
+    expect(formatInputBrief(claude, null)).toBe('$ git add -A && git commit -m "wip"')
+  })
+
+  test('leaves an unwrapped command untouched', () => {
+    const claude = shellCall('claude-code', 'Bash', { command: 'bun test --coverage' })
+    expect(formatInputBrief(claude, null)).toBe('$ bun test --coverage')
+  })
+
+  test('drops the brief entirely when there is no command', () => {
+    const claude = shellCall('claude-code', 'Bash', {})
+    expect(formatInputBrief(claude, null)).toBe('')
+  })
+
+  test('reads a Hermes terminal title through the same normalization', () => {
+    const hermes = shellCall('hermes', `terminal: /bin/bash -lc "echo hi"`, {})
+    expect(formatInputBrief(hermes, null)).toBe('$ echo hi')
+  })
+})
+
 describe('formatDuration', () => {
   test('rounds sub-second durations up to a whole second', () => {
     expect(formatDuration(850)).toBe('1s')

--- a/client/features/chat/tool-group/format/claude.ts
+++ b/client/features/chat/tool-group/format/claude.ts
@@ -1,6 +1,7 @@
 // Claude Code vocabulary — also the default when a call carries no provider.
 import type { ToolCall } from '@/lib/types'
 
+import { shellBrief } from './shell'
 import { getInputValue, toolInput, type Shorten, type ToolFormatter } from './shared'
 
 // Claude tool names are mostly already presentable (Read, Bash, …); only a few
@@ -24,7 +25,7 @@ function shortToolName(name: string): string {
 function brief(call: ToolCall, shorten: Shorten): string {
   const tool = call.name
   const input = toolInput(call)
-  if (tool === 'Bash') return shorten(`$ ${getInputValue(input, 'command')}`)
+  if (tool === 'Bash') return shellBrief(getInputValue(input, 'command'), shorten)
   if (tool === 'Read' || tool === 'Write' || tool === 'Edit')
     return shorten(getInputValue(input, 'file_path'))
   if (tool === 'Glob') return shorten(getInputValue(input, 'pattern'))

--- a/client/features/chat/tool-group/format/codex.ts
+++ b/client/features/chat/tool-group/format/codex.ts
@@ -3,6 +3,7 @@
 // unchanged).
 import type { ToolCall } from '@/lib/types'
 
+import { shellBrief } from './shell'
 import { getInputValue, toolInput, type Shorten, type ToolFormatter } from './shared'
 
 // Exported for mcp.ts: these management pseudo-tools stay plain rows, never
@@ -81,7 +82,7 @@ function brief(call: ToolCall, shorten: Shorten): string {
         .filter(Boolean)
         .join(' ')
     if (action?.type === 'listFiles') return action.path ? shorten(action.path) : ''
-    return shorten(`$ ${getInputValue(input, 'command')}`)
+    return shellBrief(getInputValue(input, 'command'), shorten)
   }
   if (tool === 'apply_patch') {
     // The adapter sends structured per-file changes: [{ path, kind, diff }].

--- a/client/features/chat/tool-group/format/hermes.ts
+++ b/client/features/chat/tool-group/format/hermes.ts
@@ -6,6 +6,7 @@
 // the brief.
 import type { ToolCall } from '@/lib/types'
 
+import { prettifyShellCommand } from './shell'
 import type { Shorten, ToolFormatter } from './shared'
 
 // Split the action from its parenthesized qualifier and colon detail so the
@@ -62,7 +63,7 @@ function brief(call: ToolCall, shorten: Shorten): string {
   const { action, qualifier, detail } = splitTitle(call.name)
   const text = detail || qualifier
   if (!text) return ''
-  return action === 'terminal' ? `$ ${text}` : shorten(text)
+  return action === 'terminal' ? `$ ${prettifyShellCommand(text)}` : shorten(text)
 }
 
 export const hermesFormatter: ToolFormatter = { displayName, brief }

--- a/client/features/chat/tool-group/format/mcp.ts
+++ b/client/features/chat/tool-group/format/mcp.ts
@@ -3,6 +3,7 @@
 import type { ToolCall } from '@/lib/types'
 
 import { CODEX_TOOL_LABELS } from './codex'
+import { prettifyShellCommand } from './shell'
 
 export type McpRef = { server: string; tool: string; rest: string }
 
@@ -11,11 +12,14 @@ export type McpRef = { server: string; tool: string; rest: string }
 // stops at the first command separator so a chained command doesn't bleed into
 // `rest`. Returns null for non-`call` invocations.
 export function parseMcporterCall(call: ToolCall): McpRef | null {
-  const isShell = call.name === 'Bash' || call.name === 'exec'
+  const isShell = call.name === 'Bash' || call.name === 'exec' || call.name === 'bash'
   if (!isShell) return null
   const input = (call.input as Record<string, unknown>) ?? {}
-  const command = typeof input.command === 'string' ? input.command : ''
-  if (!command) return null
+  const raw = typeof input.command === 'string' ? input.command : ''
+  if (!raw) return null
+  // Match against the unwrapped command: providers that hand the script to
+  // `/bin/bash -lc "…"` would otherwise leave escaped quotes inside `rest`.
+  const command = prettifyShellCommand(raw)
   const m = command.match(
     /(?:^|\s|\$\()mcporter(?:\)?)\s+call\s+([A-Za-z0-9_-]+)\.([A-Za-z0-9_-]+)((?:\s+(?!&&|\|\||;|\|)\S+)*)/
   )

--- a/client/features/chat/tool-group/format/openclaw.ts
+++ b/client/features/chat/tool-group/format/openclaw.ts
@@ -5,6 +5,7 @@
 import type { ToolCall } from '@/lib/types'
 
 import { claudeFormatter } from './claude'
+import { prettifyShellCommand, shellBrief } from './shell'
 import { getInputValue, toolInput, type Shorten, type ToolFormatter } from './shared'
 
 const LABELS: Record<string, string> = {
@@ -74,14 +75,17 @@ function openclawBrief(call: ToolCall, shorten: Shorten): string {
     // `command` on 2026.7.1 + the newer `bash` tool; the 2026.7.2 exec sandbox
     // instead carries a `code` script (JS that shells out) — show whichever.
     const command = getInputValue(input, 'command') || getInputValue(input, 'code')
-    return command ? shorten(`$ ${command}`) : ''
+    return shellBrief(command, shorten)
   }
   if (tool === 'ls' || tool === 'find' || tool === 'grep')
     return shorten(getInputValue(input, 'path') || getInputValue(input, 'pattern'))
   if (tool === 'process') {
     const action = getInputValue(input, 'action')
     const name = getInputValue(input, 'name')
-    return [action, name].filter(Boolean).join(' ') || shorten(getInputValue(input, 'command'))
+    return (
+      [action, name].filter(Boolean).join(' ') ||
+      shorten(prettifyShellCommand(getInputValue(input, 'command')))
+    )
   }
   if (tool === 'web_search' || tool === 'x_search') return getInputValue(input, 'query')
   if (tool === 'web_fetch') return getInputValue(input, 'url')

--- a/client/features/chat/tool-group/format/shell.test.ts
+++ b/client/features/chat/tool-group/format/shell.test.ts
@@ -1,0 +1,111 @@
+// Shell-command normalization. The wrapped-command samples are the shapes
+// Codex and OpenClaw actually send (`/bin/bash -lc "…"`, any login shell).
+import { describe, expect, test } from 'bun:test'
+
+import { collapseCommand, prettifyShellCommand, unwrapShellCommand } from './shell'
+
+describe('unwrapping a shell wrapper', () => {
+  test('lifts the script out of `<shell> -c "…"`', () => {
+    expect(
+      unwrapShellCommand(
+        `/bin/bash -c "sed -n '1,240p' /home/sandbox/firma-os/.agents/skills/moi-workspace/SKILL.md && sed -n '1,240p' .moi/FIRMA.md"`
+      )
+    ).toBe(
+      `sed -n '1,240p' /home/sandbox/firma-os/.agents/skills/moi-workspace/SKILL.md && sed -n '1,240p' .moi/FIRMA.md`
+    )
+  })
+
+  test('handles any shell, any path, and combined flags', () => {
+    const cases = [
+      '/bin/zsh -lc "echo hi"',
+      '/usr/local/bin/fish -c "echo hi"',
+      "sh -c 'echo hi'",
+      'bash -lic "echo hi"',
+      '/bin/dash -c "echo hi"',
+      'env FOO=1 /bin/bash -lc "echo hi"',
+      'FOO=1 BAR=2 zsh -c "echo hi"',
+      'bash -o pipefail -c "echo hi"'
+    ]
+    for (const command of cases) expect(unwrapShellCommand(command)).toBe('echo hi')
+  })
+
+  test('unescapes one quoting level, single or double', () => {
+    // Double quotes: `\"` was the model's `"`, and `\d` must stay a regex.
+    expect(unwrapShellCommand('/bin/bash -c "grep \\"foo bar\\" -e \\d+ src"')).toBe(
+      'grep "foo bar" -e \\d+ src'
+    )
+    // Single quotes: literal throughout, including backslashes.
+    expect(unwrapShellCommand(`/bin/bash -lc 'grep "foo" -e \\d+ src'`)).toBe(
+      'grep "foo" -e \\d+ src'
+    )
+  })
+
+  test('leaves variables and substitutions in the script alone', () => {
+    // `shell-quote` would expand these; the brief must show what the model
+    // wrote, since nothing here runs.
+    expect(unwrapShellCommand('/bin/bash -lc "echo $HOME/${FOO:-x} $(pwd) `date`"')).toBe(
+      'echo $HOME/${FOO:-x} $(pwd) `date`'
+    )
+    expect(unwrapShellCommand('/bin/bash -lc "echo $((1 + 2))"')).toBe('echo $((1 + 2))')
+  })
+
+  test('renders a command the parser rejects as it came', () => {
+    // `${}` is a bash syntax error the model can still write; rendering must
+    // not throw over it.
+    expect(unwrapShellCommand('/bin/bash -lc "echo ${}"')).toBe('/bin/bash -lc "echo ${}"')
+  })
+
+  test('keeps globs and pipes inside the script', () => {
+    expect(unwrapShellCommand('/bin/bash -lc "ls *.ts | head -5"')).toBe('ls *.ts | head -5')
+  })
+
+  test('unwraps a nested wrapper', () => {
+    expect(unwrapShellCommand(`/bin/bash -lc "sh -c 'echo hi'"`)).toBe('echo hi')
+  })
+
+  test('leaves a plain command alone', () => {
+    const cases = [
+      'bun test --coverage',
+      'git rev-parse --is-inside-work-tree 2>/dev/null && git remote -v',
+      'echo "bash -c is just text here"',
+      // Quoting the model never closed — refuse to guess.
+      '/bin/bash -c "echo hi',
+      // Not a shell: the container is the interesting part of the row.
+      'docker run --rm alpine sh -c "echo hi"',
+      // Positional args after the script bind $0/$1; dropping them would
+      // misdescribe the run.
+      'bash -c "echo $0" name arg',
+      // A shell with no `-c` runs a script file, not a command string.
+      '/bin/bash ./deploy.sh'
+    ]
+    for (const command of cases) expect(unwrapShellCommand(command)).toBe(command)
+  })
+
+  test('keeps the wrapper when the script is empty', () => {
+    expect(unwrapShellCommand('/bin/bash -c ""')).toBe('/bin/bash -c ""')
+  })
+})
+
+describe('collapsing to one line', () => {
+  test('folds newlines and indentation into single spaces', () => {
+    expect(collapseCommand('git add -A\n  git commit -m "wip"')).toBe(
+      'git add -A git commit -m "wip"'
+    )
+  })
+
+  test('drops the backslash of a line continuation', () => {
+    expect(collapseCommand('rg foo \\\n  --glob "*.ts"')).toBe('rg foo --glob "*.ts"')
+  })
+
+  test('trims the ends', () => {
+    expect(collapseCommand('  bun test \n')).toBe('bun test')
+  })
+})
+
+describe('prettify', () => {
+  test('unwraps and collapses a multi-line wrapped script', () => {
+    expect(
+      prettifyShellCommand('/bin/bash -lc "cd server &&\n  bun test \\\n    --coverage"')
+    ).toBe('cd server && bun test --coverage')
+  })
+})

--- a/client/features/chat/tool-group/format/shell.ts
+++ b/client/features/chat/tool-group/format/shell.ts
@@ -1,0 +1,162 @@
+// Shell-command display normalization, shared by every provider's shell tool
+// (Claude `Bash`, Codex/OpenClaw `exec`/`bash`, Hermes `terminal:` titles).
+//
+// Agents rarely hand us the command a person would have typed. Codex and
+// OpenClaw hand the model's script to the login shell, so the tool input is
+// the wrapper invocation:
+//
+//   /bin/bash -c "sed -n '1,240p' SKILL.md && sed -n '1,240p' .moi/FIRMA.md"
+//
+// The wrapper is noise in a one-line brief: the shell path and `-lc` eat the
+// width, and the inner quoting arrives escaped, so the row shows `\"` where
+// the model wrote `"`. Rendering strips the wrapper and removes one quoting
+// level, leaving what actually ran:
+//
+//   sed -n '1,240p' SKILL.md && sed -n '1,240p' .moi/FIRMA.md
+//
+// Word splitting is `shell-quote`'s, not ours — quoting rules have too many
+// corners (`'` inside `"`, `\d` staying literal, `$(…)` and backticks passing
+// through) to re-derive here.
+//
+// Display only — nothing here feeds execution, so an unrecognized shape is
+// never an error: every step falls back to the raw command unchanged.
+import { parse } from 'shell-quote'
+
+import type { Shorten } from './shared'
+
+// `shell-quote` resolves `$VAR` through this callback, defaulting to the empty
+// string. We render commands rather than run them, so put the variable back
+// verbatim. Braces only survive where they carry meaning (`${FOO:-x}`); a bare
+// `${FOO}` reads the same without them. A command or arithmetic substitution
+// (`$(pwd)`, `$((1+2))`) arrives here as an empty key — a bare `$` restores it.
+function keepVariable(key: string): string {
+  if (!key) return '$'
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(key) ? `$${key}` : `\${${key}}`
+}
+
+// `shell-quote` throws on a few malformed inputs (`${}`), and a streaming tool
+// call can always show us a half-written command. Unparseable means "render it
+// as it came".
+function splitWords(command: string): ReturnType<typeof parse> | null {
+  try {
+    return parse(command, keepVariable)
+  } catch {
+    return null
+  }
+}
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path
+}
+
+// Shells whose `-c` argument is a command string we can lift out. Keep this to
+// real shells: unwrapping `docker run … sh -c …` would hide where the command
+// ran, which is the useful part of that row.
+const SHELLS = new Set([
+  'bash',
+  'sh',
+  'zsh',
+  'fish',
+  'dash',
+  'ash',
+  'ksh',
+  'mksh',
+  'csh',
+  'tcsh',
+  'nu',
+  'pwsh',
+  'powershell'
+])
+
+// Flags that consume the next word, so it isn't mistaken for the script
+// (`bash -o pipefail -c …`).
+const FLAGS_WITH_VALUE = new Set(['-o', '+o', '-O', '+O', '--rcfile', '--init-file'])
+
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/
+
+// `-c`, plus the combined short forms shells are usually invoked with (`-lc`,
+// `-ic`, `-euc`) and the long spellings (`--command`, pwsh's `-Command`).
+function isCommandFlag(word: string): boolean {
+  if (/^-[a-zA-Z]*c$/.test(word)) return true
+  const lower = word.toLowerCase()
+  return lower === '--command' || lower === '-command'
+}
+
+// One unwrap pass: `[VAR=v …] [env] <shell> [flags] -c <script>` → `<script>`.
+// Returns null when the command isn't that shape, which means "leave it alone".
+function unwrapOnce(command: string): string | null {
+  // Operators, globs and comments come back as objects rather than strings;
+  // a wrapper invocation is plain words all the way to the script, so a
+  // non-string where a word belongs ends the match.
+  const words = splitWords(command)
+  if (!words || words.length < 3) return null
+  const word = (index: number): string | null => {
+    const entry = words[index]
+    return typeof entry === 'string' ? entry : null
+  }
+
+  let i = 0
+  const skipAssignments = () => {
+    while (ENV_ASSIGNMENT.test(word(i) ?? '')) i++
+  }
+  skipAssignments()
+  if (basename(word(i) ?? '') === 'env') {
+    i++
+    skipAssignments()
+  }
+
+  if (!SHELLS.has(basename(word(i) ?? ''))) return null
+  i++
+
+  while (i < words.length) {
+    const flag = word(i)
+    if (flag === null) return null
+    if (isCommandFlag(flag)) {
+      // The script must be the final word. `bash -c script name arg` binds the
+      // extra words to `$0`/`$1`, and a brief that dropped them would claim the
+      // run was something it wasn't.
+      if (i + 2 !== words.length) return null
+      const script = word(i + 1)?.trim()
+      return script || null
+    }
+    if (!flag.startsWith('-') && !flag.startsWith('+')) return null
+    i += FLAGS_WITH_VALUE.has(flag) ? 2 : 1
+  }
+  return null
+}
+
+// Strip shell wrappers down to the command that actually ran. Bounded, because
+// wrappers nest in practice (a `bash -lc` that runs `sh -c …`) and a malformed
+// self-similar string must not loop.
+export function unwrapShellCommand(command: string): string {
+  let out = command
+  for (let pass = 0; pass < 3; pass++) {
+    const inner = unwrapOnce(out)
+    if (inner === null) return out
+    out = inner
+  }
+  return out
+}
+
+// Flatten a command to one line: the brief is a single truncating row, so a
+// multi-line script would otherwise render as its first line with the rest
+// silently collapsed by the browser, and its indentation as a wide gap.
+export function collapseCommand(command: string): string {
+  return command
+    .replace(/\\\r?\n[ \t]*/g, ' ') // line continuations: drop the backslash too
+    .replace(/[ \t]*\r?\n[ \t]*/g, ' ')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim()
+}
+
+// The rendered form of a shell command: wrapper stripped, one line.
+export function prettifyShellCommand(command: string): string {
+  return collapseCommand(unwrapShellCommand(command))
+}
+
+// The `$ …` brief every provider's shell tool shows. Empty command → empty
+// brief, so the row falls back to the bare label instead of a lone `$`.
+export function shellBrief(command: string, shorten: Shorten): string {
+  const pretty = prettifyShellCommand(command)
+  return pretty ? shorten(`$ ${pretty}`) : ''
+}

--- a/client/features/chat/tool-group/openclaw-tools.test.ts
+++ b/client/features/chat/tool-group/openclaw-tools.test.ts
@@ -45,13 +45,13 @@ describe('the codex runtime', () => {
     expect(formatInputBrief(c, null)).toBe('*** Update File: src/app.ts')
   })
 
-  test('shows the command for its shell tool', () => {
+  test('shows the command for its shell tool, without the login-shell wrapper', () => {
     const c = call('bash', {
       command: '/bin/bash -lc "sed -n \'1,120p\' notes.txt"',
       cwd: '/root/.openclaw/workspace'
     })
     expect(getToolDisplayName(c)).toBe('Bash')
-    expect(formatInputBrief(c, null)).toContain('sed -n')
+    expect(formatInputBrief(c, null)).toBe("$ sed -n '1,120p' notes.txt")
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.13.0",
     "sharp": "^0.35.1",
+    "shell-quote": "^1.10.0",
     "sugar-high": "^1.2.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",


### PR DESCRIPTION
Codex and OpenClaw hand the model's script to a login shell, so a tool row read `/bin/bash -c "sed -n '1,240p' SKILL.md && …"` — the wrapper ate the row's width and the inner quoting arrived escaped, showing `\"` where the model wrote `"`. Rendering now strips `<shell> [flags] -c <script>` and folds the script to one line, for every provider's shell tool.

```
before   $ /bin/bash -c "sed -n '1,240p' /repo/.agents/skills/moi-workspace/SKILL.md && cat .moi/FIRMA.md"
after    $ sed -n '1,240p' .agents/skills/moi-workspace/SKILL.md && cat .moi/FIRMA.md
```

`format/shell.ts` is the single implementation: Claude `Bash`, Codex `exec`, OpenClaw `exec`/`bash`/`process`, Hermes `terminal:` titles and the mcporter MCP-card detector all go through it. Word splitting is `shell-quote` (new dependency — MIT, zero deps, ~5KB) rather than hand-rolled quote handling.

Worth a close look:

- **What it refuses to unwrap** — `docker run … sh -c …` (where it ran is the point of that row), `bash -c script arg0 arg1` (the extra words bind `$0`/`$1`), unbalanced quotes, a shell running a script file. Unwrapping any of those would describe a run that didn't happen.
- **`keepVariable()`** — `shell-quote` *expands* `$VAR` by default, so the callback puts it back verbatim. The empty-key case is how `$(pwd)` and `$((1+2))` reach it; getting it wrong silently rewrites commands.
- **`parse()` throws** on some malformed input (`${}`), so it is wrapped — unparseable means render the raw string, same as any unrecognized shape.

Verified: `bun test` — 1295 pass, 0 fail (36 in the tool group, 15 of them new), plus oxlint, oxfmt, `typecheck:client`, and a full `build:client` to confirm the new dependency bundles.

https://claude.ai/code/session_01P6yP9EuVWRZZBraog2Eucf