### PR TITLE
Cache update checks and add restart coordination

### DIFF
--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -133,9 +133,10 @@ Recovery, if `verify` fails or the run is rejected:
    `latest` did **not**.
 2. `npm view moi-computer@<version> dist.attestations` — trusted publishing attaches provenance
    automatically; its absence means the publish did not go through OIDC.
-3. **Smoke the published package.** This needs the moi ports to itself: `CONTROL_PORT` is a
-   hardcoded `13059` (`server/constants.ts`) that `server/control.ts` binds unconditionally, so
-   `--port` does not let a second instance coexist. Before installing:
+3. **Smoke the published package.** This needs the moi ports to itself: `CONTROL_PORT` defaults to
+   `13059` (`server/constants.ts`) and `server/control.ts` binds it unconditionally, so `--port`
+   does not let a second instance coexist. (`MOI_CONTROL_PORT` overrides it, but that is a test
+   seam — smoke the real defaults.) Before installing:
    - `lsof -ti:13059 -ti:13337` — if anything is running, it is almost certainly the user's own
      `bun run dev` in their terminal. Stop it, and **tell the user you stopped it**. Do not
      silently respawn it in §8; a detached agent-owned supervisor is not the same thing and its

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ alone. `--check` changes nothing and is made for scripts and agents.
 the update happened.
 
 Updates installed from the UI restart moi and reload the browser automatically.
+The app checks npm at most once an hour, and only while it is open — a
+closed app makes no network calls of its own.
 
 # Connect an agent
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ alone. `--check` changes nothing and is made for scripts and agents.
 the update happened.
 
 Updates installed from the UI restart moi and reload the browser automatically.
-The app checks npm at most once an hour, and only while it is open — a
-closed app makes no network calls of its own.
+The app checks npm at most once an hour while it is open, retrying in five
+minutes if the registry could not be reached; a closed app makes no network
+calls of its own.
 
 # Connect an agent
 

--- a/client/features/update/api.ts
+++ b/client/features/update/api.ts
@@ -5,15 +5,25 @@ import type { UpdateResult, UpdateStatus } from '@/lib/types'
 
 export const updateKey = ['update'] as const
 
-const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+// The server decides how often the npm registry is actually consulted and
+// serves a cached answer in between, so polling here is a local memory read.
+// Keep it frequent enough that a tab left open all day stays current — and note
+// React Query pauses intervals while the tab is hidden, so a background window
+// costs nothing and catches up on focus instead.
+const UPDATE_POLL_INTERVAL_MS = 5 * 60 * 1000
 const RESTART_POLL_INTERVAL_MS = 1000
 
 export function useUpdateStatus(restarting: boolean) {
   return useQuery<UpdateStatus>({
     queryKey: updateKey,
     queryFn: () => requestJson('/api/update'),
-    staleTime: UPDATE_CHECK_INTERVAL_MS,
-    refetchInterval: restarting ? RESTART_POLL_INTERVAL_MS : UPDATE_CHECK_INTERVAL_MS,
+    staleTime: UPDATE_POLL_INTERVAL_MS,
+    refetchInterval: restarting ? RESTART_POLL_INTERVAL_MS : UPDATE_POLL_INTERVAL_MS,
+    // A tab that sat in the background for days is stale by definition; give it
+    // a fresh answer the moment someone looks at it.
+    refetchOnWindowFocus: true,
+    // While the server is restarting every request fails until it is back. The
+    // poll interval is the retry.
     retry: false
   })
 }

--- a/server/api-update.test.ts
+++ b/server/api-update.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 
 import type { UpdateStatus } from '@/lib/types'
 
 import { api } from './api'
+import { __resetUpdateStateForTests, installUpdate, scheduleRestartForUpdate } from './update'
 
 describe('update API', () => {
+  afterEach(() => __resetUpdateStateForTests())
+
   test('reports a source checkout as unavailable without touching the registry', async () => {
     const response = await api.request('/api/update')
     const status = (await response.json()) as UpdateStatus
@@ -19,5 +22,50 @@ describe('update API', () => {
 
     expect(response.status).toBe(409)
     expect(await response.text()).toBe('This moi install cannot be updated from the app.')
+  })
+
+  test('refuses a second update while one is in flight', async () => {
+    // Park a real install mid-run: the second click must be told so, not
+    // silently handed the first install's result.
+    installUpdate({
+      runningVersion: '0.5.2',
+      analysis: {
+        kind: 'global',
+        root: '/home/u/.bun/install/global/node_modules/moi-computer',
+        bin: '/home/u/.bun/bin/moi'
+      },
+      fetchLatest: async () => '0.6.0',
+      detectManager: async () => 'bun',
+      runManager: () => new Promise<number>(() => {}),
+      readInstalledVersion: async () => '0.6.0'
+    })
+    await Bun.sleep(0)
+
+    const response = await api.request('/api/update', { method: 'POST' })
+
+    expect(response.status).toBe(409)
+    expect(await response.text()).toBe('An update is already in progress.')
+  })
+
+  test('tells a click after a finished install that moi is restarting', async () => {
+    await installUpdate({
+      runningVersion: '0.5.2',
+      analysis: {
+        kind: 'global',
+        root: '/home/u/.bun/install/global/node_modules/moi-computer',
+        bin: '/home/u/.bun/bin/moi'
+      },
+      fetchLatest: async () => '0.6.0',
+      detectManager: async () => 'bun',
+      runManager: async () => 0,
+      readInstalledVersion: async () => '0.6.0'
+    })
+    // A delay no test run reaches: firing it would SIGTERM the test process.
+    scheduleRestartForUpdate(2 ** 30)
+
+    const response = await api.request('/api/update', { method: 'POST' })
+
+    expect(response.status).toBe(409)
+    expect(await response.text()).toBe('An update is installed — moi is restarting.')
   })
 })

--- a/server/api.ts
+++ b/server/api.ts
@@ -86,10 +86,12 @@ import type { WorkspaceImportMetadata } from './workspace-import'
 import { getWorkspaceEnvView, isValidEnvKey, updateWorkspaceEnv } from './workspace-env'
 import type { EnvUpdate } from './workspace-env'
 import {
-  UPDATE_RESTART_EXIT_CODE,
-  getUpdateStatus,
+  getCachedUpdateStatus,
   hasRunningAgentSessions,
-  installUpdate
+  installUpdate,
+  restartPendingForUpdate,
+  scheduleRestartForUpdate,
+  updateInProgress
 } from './update'
 
 // The resolved workspace is stashed on the context by `withWorkspace`, so every
@@ -1066,12 +1068,25 @@ api.route('/api/workspaces', workspaces)
 // subset. Immutable for the process lifetime — clients cache it forever.
 api.get('/api/config', c => c.json(clientAppConfig()))
 
+// Served from a lazily-refreshed cache: this handler is a memory read, and the
+// registry is consulted on the schedule `getCachedUpdateStatus` owns rather
+// than once per request. `no-store` keeps the browser from adding a second,
+// unrelated cache on top of it.
 api.get('/api/update', async c => {
   c.header('Cache-Control', 'no-store')
-  return c.json(await getUpdateStatus())
+  return c.json(await getCachedUpdateStatus())
 })
 
 api.post('/api/update', async c => {
+  if (updateInProgress()) {
+    return c.text(
+      restartPendingForUpdate()
+        ? 'An update is installed — moi is restarting.'
+        : 'An update is already in progress.',
+      409
+    )
+  }
+
   const agentRunning = hasRunningAgentSessions(
     allHarnesses().flatMap(harness => harness.activeSessions())
   )
@@ -1083,11 +1098,7 @@ api.post('/api/update', async c => {
     const result = await installUpdate()
     if (!result) return c.text('This moi install cannot be updated from the app.', 409)
     const response = c.json(result)
-    const restart = setTimeout(() => {
-      process.exitCode = UPDATE_RESTART_EXIT_CODE
-      process.kill(process.pid, 'SIGTERM')
-    }, 500)
-    restart.unref()
+    scheduleRestartForUpdate()
     return response
   } catch (error) {
     return c.text(error instanceof Error ? error.message : 'Could not update moi.', 500)

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -1,6 +1,8 @@
 export const PORT = Number(process.env.PORT) || 13337
-// M=13, E=5, I=9 -> 13059
-export const CONTROL_PORT = 13059
+// M=13, E=5, I=9 -> 13059. Overridable like PORT so a test can bring up a
+// throwaway server beside a real one; server and CLI read this same module, so
+// a process given the override binds and dials the same port either way.
+export const CONTROL_PORT = Number(process.env.MOI_CONTROL_PORT) || 13059
 // The address the control server binds AND the one every client dials — never
 // the name `localhost`. Resolution of that name is not guaranteed: container
 // images ship an /etc/hosts without a `localhost` entry (Bun's resolver, unlike

--- a/server/test/update-api-e2e.test.ts
+++ b/server/test/update-api-e2e.test.ts
@@ -1,0 +1,325 @@
+// End-to-end for the update *API*: a real server process, booted from a fake
+// bun-style global install, answering real HTTP against a local mock registry
+// that counts every request it receives. That count is the whole point — it is
+// what proves the server checks on its own schedule instead of once per
+// client request, and that no client behaviour (reloads, extra tabs, an
+// offline spell, a laptop waking up) can turn into registry traffic.
+//
+// The last test lets the server update itself for real — `bun install -g` into
+// an isolated BUN_INSTALL — and asserts it exits 75, the code the foreground
+// CLI and service managers both read as "updated, bring me back".
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { cp, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { UPDATE_RESTART_EXIT_CODE } from '../update'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..')
+const NEW_VERSION = '99.0.0'
+const RUNNING_VERSION = '0.5.2'
+
+// Compressed from the shipped hour/five-minutes so the timing is testable.
+const TTL_MS = 2_000
+const BACKOFF_MS = 600
+
+let home: string
+let fakeRoot: string
+let registry: ReturnType<typeof Bun.serve>
+let tarball: Uint8Array
+
+// How many times the server actually asked the registry for the latest
+// version, and a switch to take the registry down under it.
+let latestChecks = 0
+let registryDown = false
+
+async function buildTarball(): Promise<Uint8Array> {
+  const dir = await mkdtemp(join(tmpdir(), 'moi-update-api-pkg-'))
+  const pkg = join(dir, 'package')
+  await mkdir(join(pkg, 'bin'), { recursive: true })
+  await writeFile(
+    join(pkg, 'package.json'),
+    JSON.stringify({ name: 'moi-computer', version: NEW_VERSION, bin: { moi: 'bin/moi.mjs' } })
+  )
+  await writeFile(
+    join(pkg, 'bin', 'moi.mjs'),
+    `#!/usr/bin/env bun\nconsole.log('${NEW_VERSION}')\n`
+  )
+  const tar = Bun.spawn(['tar', 'czf', '-', '-C', dir, 'package'], {
+    stdout: 'pipe',
+    stderr: 'ignore'
+  })
+  const bytes = new Uint8Array(await new Response(tar.stdout).arrayBuffer())
+  await tar.exited
+  await rm(dir, { recursive: true, force: true })
+  return bytes
+}
+
+async function freePort(): Promise<number> {
+  const probe = Bun.serve({ port: 0, hostname: '127.0.0.1', fetch: () => new Response('') })
+  const port = probe.port
+  probe.stop(true)
+  return port
+}
+
+beforeAll(async () => {
+  home = await mkdtemp(join(tmpdir(), 'moi-update-api-e2e-'))
+  fakeRoot = join(home, '.bun', 'install', 'global', 'node_modules', 'moi-computer')
+
+  // A published global install: real server code, a stub dist/index.html so
+  // analyzeInstall calls it 'global' (and so the server serves prebuilt assets
+  // instead of starting the dev bundler), node_modules symlinked back.
+  await mkdir(fakeRoot, { recursive: true })
+  // The same tree `files` in package.json publishes — the server imports
+  // `../client/index.html` at startup, so a server-side e2e needs `client/`
+  // that a CLI-only one can skip.
+  for (const entry of [
+    'server',
+    'client',
+    'lib',
+    'workspace',
+    'package.json',
+    'bunfig.toml',
+    'tsconfig.json',
+    'bin'
+  ]) {
+    await cp(join(REPO_ROOT, entry), join(fakeRoot, entry), { recursive: true })
+  }
+  await mkdir(join(fakeRoot, 'dist'), { recursive: true })
+  await writeFile(join(fakeRoot, 'dist', 'index.html'), '<html></html>')
+  await symlink(join(REPO_ROOT, 'node_modules'), join(fakeRoot, 'node_modules'))
+
+  // The repo may sit on a prerelease, which the update path refuses to touch.
+  const pkgPath = join(fakeRoot, 'package.json')
+  const pkg = JSON.parse(await Bun.file(pkgPath).text()) as { version: string }
+  pkg.version = RUNNING_VERSION
+  await writeFile(pkgPath, JSON.stringify(pkg, null, 2))
+
+  // `moi` on PATH, laid out exactly as `bun i -g` does it.
+  await mkdir(join(home, '.bun', 'bin'), { recursive: true })
+  await symlink(
+    join('..', 'install', 'global', 'node_modules', 'moi-computer', 'bin', 'moi.mjs'),
+    join(home, '.bun', 'bin', 'moi')
+  )
+
+  tarball = await buildTarball()
+  const shasum = createHash('sha1').update(tarball).digest('hex')
+  const integrity = 'sha512-' + createHash('sha512').update(tarball).digest('base64')
+
+  registry = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    fetch(req) {
+      const path = new URL(req.url).pathname
+      const dist = {
+        tarball: `http://127.0.0.1:${registry.port}/moi-computer/-/moi-computer-${NEW_VERSION}.tgz`,
+        shasum,
+        integrity
+      }
+      const manifest = {
+        name: 'moi-computer',
+        version: NEW_VERSION,
+        bin: { moi: 'bin/moi.mjs' },
+        dist
+      }
+      if (path === '/moi-computer/latest') {
+        latestChecks += 1
+        if (registryDown) return new Response('down', { status: 503 })
+        return Response.json(manifest)
+      }
+      if (path === '/moi-computer') {
+        return Response.json({
+          name: 'moi-computer',
+          'dist-tags': { latest: NEW_VERSION },
+          versions: { [NEW_VERSION]: manifest }
+        })
+      }
+      if (path.endsWith('.tgz')) {
+        return new Response(tarball, { headers: { 'Content-Type': 'application/octet-stream' } })
+      }
+      return new Response('not found', { status: 404 })
+    }
+  })
+}, 120_000)
+
+afterAll(async () => {
+  registry?.stop(true)
+  await rm(home, { recursive: true, force: true })
+})
+
+type Server = {
+  url: string
+  proc: ReturnType<typeof Bun.spawn>
+  stop: () => Promise<void>
+}
+
+// Boot a real server process from the fake install and wait until it answers.
+async function startServer(envExtra: Record<string, string> = {}): Promise<Server> {
+  const port = await freePort()
+  const controlPort = await freePort()
+  const proc = Bun.spawn(['bun', join(fakeRoot, 'server', 'cli.ts'), 'start'], {
+    cwd: fakeRoot,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      HOME: home,
+      MOI_SERVER: '1',
+      MOI_DATA_DIR: join(home, 'moi-data'),
+      BUN_INSTALL: join(home, '.bun'),
+      PATH: `${join(home, '.bun', 'bin')}:${process.env.PATH}`,
+      PORT: String(port),
+      MOI_CONTROL_PORT: String(controlPort),
+      MOI_NPM_REGISTRY: `http://127.0.0.1:${registry.port}`,
+      NPM_CONFIG_REGISTRY: `http://127.0.0.1:${registry.port}`,
+      MOI_UPDATE_BOOT_GRACE_MS: '0',
+      MOI_UPDATE_CACHE_TTL_MS: String(TTL_MS),
+      MOI_UPDATE_FAILURE_BACKOFF_MS: String(BACKOFF_MS),
+      NO_COLOR: '1',
+      ...envExtra
+    }
+  })
+
+  const url = `http://127.0.0.1:${port}`
+  // `/api/config` is a plain read — waiting on `/api/update` would fire the
+  // very checks these tests are counting.
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    if (proc.exitCode !== null) throw new Error(`server exited early (${proc.exitCode})`)
+    try {
+      const res = await fetch(`${url}/api/config`)
+      if (res.ok) {
+        await res.arrayBuffer()
+        return { url, proc, stop: () => stopServer(proc) }
+      }
+    } catch {}
+    await Bun.sleep(100)
+  }
+  throw new Error('server never came up')
+}
+
+async function stopServer(proc: ReturnType<typeof Bun.spawn>): Promise<void> {
+  if (proc.exitCode !== null) return
+  proc.kill('SIGKILL')
+  await proc.exited
+}
+
+type Status = { runningVersion: string; availableVersion: string | null }
+
+async function getStatus(url: string): Promise<Status> {
+  const res = await fetch(`${url}/api/update`)
+  expect(res.status).toBe(200)
+  return (await res.json()) as Status
+}
+
+describe('update API (e2e)', () => {
+  test('the boot grace window keeps the registry untouched', async () => {
+    latestChecks = 0
+    // A grace longer than this test can run: nothing may reach the registry,
+    // however many times a client asks.
+    const server = await startServer({ MOI_UPDATE_BOOT_GRACE_MS: String(10 * 60_000) })
+    try {
+      for (let i = 0; i < 5; i++) {
+        expect(await getStatus(server.url)).toEqual({
+          runningVersion: RUNNING_VERSION,
+          availableVersion: null
+        })
+      }
+      expect(latestChecks).toBe(0)
+    } finally {
+      await server.stop()
+    }
+  }, 120_000)
+
+  test('one registry check serves every client until the TTL expires', async () => {
+    latestChecks = 0
+    const server = await startServer()
+    try {
+      // Five tabs opening at once — one check between them.
+      const first = await Promise.all([
+        getStatus(server.url),
+        getStatus(server.url),
+        getStatus(server.url),
+        getStatus(server.url),
+        getStatus(server.url)
+      ])
+      for (const status of first) {
+        expect(status).toEqual({
+          runningVersion: RUNNING_VERSION,
+          availableVersion: NEW_VERSION
+        })
+      }
+      expect(latestChecks).toBe(1)
+
+      // Polling hard inside the TTL costs nothing.
+      for (let i = 0; i < 10; i++) await getStatus(server.url)
+      expect(latestChecks).toBe(1)
+
+      // Past it, exactly one refresh.
+      await Bun.sleep(TTL_MS + 200)
+      await Promise.all([getStatus(server.url), getStatus(server.url)])
+      expect(latestChecks).toBe(2)
+    } finally {
+      await server.stop()
+    }
+  }, 120_000)
+
+  test('an unreachable registry backs off instead of retrying every poll', async () => {
+    latestChecks = 0
+    registryDown = true
+    const server = await startServer()
+    try {
+      expect(await getStatus(server.url)).toEqual({
+        runningVersion: RUNNING_VERSION,
+        availableVersion: null
+      })
+      expect(latestChecks).toBe(1)
+
+      // A client polling through the outage must not become the retry loop.
+      for (let i = 0; i < 10; i++) await getStatus(server.url)
+      expect(latestChecks).toBe(1)
+
+      // The retry comes on the short backoff — well before the TTL — and the
+      // recovered registry is picked up.
+      registryDown = false
+      await Bun.sleep(BACKOFF_MS + 200)
+      expect(await getStatus(server.url)).toEqual({
+        runningVersion: RUNNING_VERSION,
+        availableVersion: NEW_VERSION
+      })
+      expect(latestChecks).toBe(2)
+    } finally {
+      registryDown = false
+      await server.stop()
+    }
+  }, 120_000)
+
+  // Last: this one really replaces the install tree with the stub package.
+  test('POST installs the update and exits for the supervisor to restart', async () => {
+    latestChecks = 0
+    const server = await startServer()
+    try {
+      expect((await getStatus(server.url)).availableVersion).toBe(NEW_VERSION)
+
+      const res = await fetch(`${server.url}/api/update`, { method: 'POST' })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ installedVersion: NEW_VERSION })
+
+      // The exit code is the whole restart handshake: `superviseServerUpdates`
+      // and the service managers all respawn on it.
+      expect(await server.proc.exited).toBe(UPDATE_RESTART_EXIT_CODE)
+
+      // And the bin on PATH really is the new package now.
+      const check = Bun.spawn([join(home, '.bun', 'bin', 'moi'), 'version'], {
+        stdout: 'pipe',
+        env: { ...process.env, PATH: `${join(home, '.bun', 'bin')}:${process.env.PATH}` }
+      })
+      expect((await new Response(check.stdout).text()).trim()).toBe(NEW_VERSION)
+      await check.exited
+    } finally {
+      await server.stop()
+    }
+  }, 180_000)
+})

--- a/server/test/update.test.ts
+++ b/server/test/update.test.ts
@@ -5,13 +5,18 @@ import {
   __resetUpdateStateForTests,
   detectPackageManager,
   fetchLatestVersion,
+  getCachedUpdateStatus,
   getUpdateStatus,
   hasRunningAgentSessions,
   installUpdate,
   isNewer,
   manualUpdateLines,
+  owningManager,
+  ownInstall,
+  scheduleRestartForUpdate,
   superviseServerUpdates,
-  updateArgv
+  updateArgv,
+  updateInProgress
 } from '../update'
 import { isPrerelease } from '../version'
 
@@ -277,6 +282,240 @@ describe('update status', () => {
     expect(runs).toBe(1)
     finish?.(0)
     await Promise.all([first, second])
+  })
+})
+
+// ---- cached status ----------------------------------------------------------
+
+// A clock and an uptime the test drives by hand: the cache is all about when
+// things happen, and nothing here should depend on the wall clock.
+function clock(startUptimeMs = 10 * 60 * 1000) {
+  let time = 1_700_000_000_000
+  let uptime = startUptimeMs
+  return {
+    now: () => time,
+    uptimeMs: () => uptime,
+    advance(ms: number) {
+      time += ms
+      uptime += ms
+    },
+    rewind(ms: number) {
+      time -= ms
+    }
+  }
+}
+
+describe('cached update status', () => {
+  const globalInstall = {
+    kind: 'global' as const,
+    root: '/home/u/.bun/install/global/node_modules/moi-computer',
+    bin: '/home/u/.bun/bin/moi'
+  }
+  const timings = {
+    bootGraceMs: 60_000,
+    cacheTtlMs: 60 * 60 * 1000,
+    failureBackoffMs: 5 * 60 * 1000
+  }
+
+  afterEach(() => __resetUpdateStateForTests())
+
+  // Every check that reaches the registry increments `checks`, so the
+  // assertions below are all "how many times did we actually go out?".
+  function checker(latest: () => string) {
+    let checks = 0
+    return {
+      checks: () => checks,
+      options: (time: ReturnType<typeof clock>) => ({
+        runningVersion: '0.5.2',
+        analysis: globalInstall,
+        detectManager: async () => 'bun' as const,
+        fetchLatest: async () => {
+          checks += 1
+          return latest()
+        },
+        now: time.now,
+        uptimeMs: time.uptimeMs,
+        timings
+      })
+    }
+  }
+
+  test('checks nothing during the boot grace window', async () => {
+    const time = clock(0)
+    const probe = checker(() => '0.6.0')
+
+    expect(await getCachedUpdateStatus(probe.options(time))).toEqual({
+      runningVersion: '0.5.2',
+      availableVersion: null
+    })
+    expect(probe.checks()).toBe(0)
+
+    // Reloading the page ten times inside the window must not compound it.
+    for (let i = 0; i < 10; i++) await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(0)
+
+    time.advance(timings.bootGraceMs)
+    expect(await getCachedUpdateStatus(probe.options(time))).toEqual({
+      runningVersion: '0.5.2',
+      availableVersion: '0.6.0'
+    })
+    expect(probe.checks()).toBe(1)
+  })
+
+  test('serves the cached answer for the whole TTL, then refreshes once', async () => {
+    const time = clock()
+    const probe = checker(() => '0.6.0')
+
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(1)
+
+    // A client polling every 5 minutes for an hour is still one registry hit.
+    for (let i = 0; i < 11; i++) {
+      time.advance(5 * 60 * 1000)
+      await getCachedUpdateStatus(probe.options(time))
+    }
+    expect(probe.checks()).toBe(1)
+
+    time.advance(5 * 60 * 1000)
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(2)
+  })
+
+  test('retries a failed check on the short backoff, not the long TTL', async () => {
+    const time = clock()
+    let offline = true
+    const probe = checker(() => {
+      if (offline) throw new Error('offline')
+      return '0.6.0'
+    })
+
+    expect(await getCachedUpdateStatus(probe.options(time))).toEqual({
+      runningVersion: '0.5.2',
+      availableVersion: null
+    })
+    expect(probe.checks()).toBe(1)
+
+    // Polls inside the backoff window are absorbed — an offline machine must
+    // not turn a 5-minute poll into a 5-minute retry storm.
+    time.advance(60_000)
+    await getCachedUpdateStatus(probe.options(time))
+    time.advance(60_000)
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(1)
+
+    // Past the backoff the network is retried, long before the hour TTL.
+    offline = false
+    time.advance(timings.failureBackoffMs)
+    expect(await getCachedUpdateStatus(probe.options(time))).toEqual({
+      runningVersion: '0.5.2',
+      availableVersion: '0.6.0'
+    })
+    expect(probe.checks()).toBe(2)
+  })
+
+  test('waking from sleep costs one check, not one per missed interval', async () => {
+    const time = clock()
+    const probe = checker(() => '0.6.0')
+
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(1)
+
+    // Eight hours asleep — eight TTLs missed, and no timer fired for any of
+    // them. The first poll after waking does exactly one check.
+    time.advance(8 * 60 * 60 * 1000)
+    await getCachedUpdateStatus(probe.options(time))
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(2)
+  })
+
+  test('a clock that jumped backwards does not pin the cache', async () => {
+    const time = clock()
+    const probe = checker(() => '0.6.0')
+
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(1)
+
+    // NTP correcting a laptop's clock after sleep leaves `attemptedAt` in the
+    // future; treating that as fresh forever would strand the cache.
+    time.rewind(24 * 60 * 60 * 1000)
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(2)
+  })
+
+  test('concurrent callers share one registry request', async () => {
+    const time = clock()
+    const probe = checker(() => '0.6.0')
+
+    const all = await Promise.all(
+      Array.from({ length: 5 }, () => getCachedUpdateStatus(probe.options(time)))
+    )
+
+    expect(probe.checks()).toBe(1)
+    for (const status of all) expect(status.availableVersion).toBe('0.6.0')
+  })
+
+  test('a completed install drops the cached availability', async () => {
+    const time = clock()
+    const probe = checker(() => '0.6.0')
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(1)
+
+    await installUpdate({
+      runningVersion: '0.5.2',
+      analysis: globalInstall,
+      fetchLatest: async () => '0.6.0',
+      detectManager: async () => 'bun',
+      runManager: async () => 0,
+      readInstalledVersion: async () => '0.6.0'
+    })
+
+    // The cached "0.6.0 available" is stale the moment it is installed.
+    await getCachedUpdateStatus(probe.options(time))
+    expect(probe.checks()).toBe(2)
+  })
+
+  test('probes the install location once per process', () => {
+    expect(ownInstall()).toBe(ownInstall())
+    expect(owningManager()).toBe(owningManager())
+  })
+})
+
+// ---- install mutex and restart ----------------------------------------------
+
+describe('install mutex', () => {
+  afterEach(() => __resetUpdateStateForTests())
+
+  test('reports an install in flight until it settles', async () => {
+    let finish: ((code: number) => void) | null = null
+    expect(updateInProgress()).toBe(false)
+
+    const install = installUpdate({
+      runningVersion: '0.5.2',
+      analysis: {
+        kind: 'global',
+        root: '/home/u/.bun/install/global/node_modules/moi-computer',
+        bin: '/home/u/.bun/bin/moi'
+      },
+      fetchLatest: async () => '0.6.0',
+      detectManager: async () => 'bun',
+      runManager: () => new Promise<number>(resolve => (finish = resolve)),
+      readInstalledVersion: async () => '0.6.0'
+    })
+
+    await Bun.sleep(0)
+    expect(updateInProgress()).toBe(true)
+    finish?.(0)
+    await install
+    expect(updateInProgress()).toBe(true) // latched until the restart lands
+  })
+
+  test('schedules one restart however many callers ask', () => {
+    // A delay no test run will reach: the timer is unref'd, and firing it would
+    // SIGTERM the test process.
+    const far = 2 ** 30
+    expect(scheduleRestartForUpdate(far)).toBe(true)
+    expect(scheduleRestartForUpdate(far)).toBe(false)
+    expect(scheduleRestartForUpdate(far)).toBe(false)
   })
 })
 

--- a/server/update.ts
+++ b/server/update.ts
@@ -172,6 +172,23 @@ type UpdateOptions = {
   readInstalledVersion?: (bin: string) => Promise<string | null>
 }
 
+// Both of these describe where this process was installed from, which cannot
+// change while it runs — and `detectPackageManager` may spawn `npm root -g`, a
+// whole Node process. Probe each once and reuse the answer for every later
+// check; the promise (not the value) is memoized so concurrent callers share
+// the one probe. `null` is a real answer here — an install nobody owns stays
+// unowned — so it is cached like any other.
+let installAnalysis: InstallAnalysis | null = null
+let managerProbe: Promise<PackageManager | null> | null = null
+
+export function ownInstall(): InstallAnalysis {
+  return (installAnalysis ??= analyzeInstall())
+}
+
+export function owningManager(): Promise<PackageManager | null> {
+  return (managerProbe ??= detectPackageManager())
+}
+
 type AvailableUpdate = {
   version: string
   packageManager: PackageManager
@@ -184,24 +201,140 @@ export function hasRunningAgentSessions(sessions: { activity: SessionActivity }[
 
 async function findAvailableUpdate(options: UpdateOptions): Promise<AvailableUpdate | null> {
   const runningVersion = options.runningVersion ?? VERSION
-  const analysis = options.analysis ?? analyzeInstall()
+  const analysis = options.analysis ?? ownInstall()
   if (analysis.kind !== 'global' || isPrerelease(runningVersion)) return null
   const version = await (options.fetchLatest ?? fetchLatestVersion)()
   if (!isNewer(version, runningVersion)) return null
-  const packageManager = await (options.detectManager ?? detectPackageManager)()
+  const packageManager = await (options.detectManager ?? owningManager)()
   return packageManager ? { version, packageManager, bin: analysis.bin } : null
 }
 
-// Background checks stay quiet. The UI only needs the running version and an
-// actionable newer version, if one can be installed safely.
-export async function getUpdateStatus(options: UpdateOptions = {}): Promise<UpdateStatus> {
+// Background checks stay quiet: every failure reads to the UI as "nothing to
+// install". The cache still needs to tell the two apart — an unreachable
+// registry should be retried in minutes, a successful "you are current" in
+// hours — so the outcome carries `ok` alongside the status the UI sees.
+type CheckOutcome = { ok: boolean; status: UpdateStatus }
+
+async function checkForUpdate(options: UpdateOptions): Promise<CheckOutcome> {
   const runningVersion = options.runningVersion ?? VERSION
   try {
     const update = await findAvailableUpdate(options)
-    return { runningVersion, availableVersion: update?.version ?? null }
+    return { ok: true, status: { runningVersion, availableVersion: update?.version ?? null } }
   } catch {
-    return { runningVersion, availableVersion: null }
+    return { ok: false, status: { runningVersion, availableVersion: null } }
   }
+}
+
+// One uncached check. The cached path below is what the API serves.
+export async function getUpdateStatus(options: UpdateOptions = {}): Promise<UpdateStatus> {
+  return (await checkForUpdate(options)).status
+}
+
+// ---- cached status ----------------------------------------------------------
+
+// There is deliberately no background timer. The check runs when a client asks
+// and the cached answer has aged out, which means: a closed app makes no
+// network calls at all, the cost stays flat no matter how many tabs or reloads
+// there are, and a machine waking from sleep does exactly one check on the next
+// poll instead of firing into a network stack that is not up yet.
+export type UpdateTimings = {
+  // Nothing is checked this early into the process — one grace window per
+  // server boot, not per tab, so a burst of reloads cannot compound it.
+  bootGraceMs: number
+  // How long a successful answer is served before it is refreshed.
+  cacheTtlMs: number
+  // How long a *failed* check is remembered. Without this the client's poll
+  // interval becomes the retry interval and an offline machine hammers the
+  // registry all day.
+  failureBackoffMs: number
+}
+
+export const UPDATE_BOOT_GRACE_MS = 60_000
+export const UPDATE_CACHE_TTL_MS = 60 * 60 * 1000
+export const UPDATE_FAILURE_BACKOFF_MS = 5 * 60 * 1000
+
+// Test seams (`MOI_UPDATE_*_MS`): the e2e drives real HTTP against a spawned
+// server, so it needs these compressed to milliseconds.
+function envMs(name: string, fallback: number): number {
+  const raw = Number(process.env[name])
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback
+}
+
+function defaultTimings(): UpdateTimings {
+  return {
+    bootGraceMs: envMs('MOI_UPDATE_BOOT_GRACE_MS', UPDATE_BOOT_GRACE_MS),
+    cacheTtlMs: envMs('MOI_UPDATE_CACHE_TTL_MS', UPDATE_CACHE_TTL_MS),
+    failureBackoffMs: envMs('MOI_UPDATE_FAILURE_BACKOFF_MS', UPDATE_FAILURE_BACKOFF_MS)
+  }
+}
+
+type StatusCache = {
+  status: UpdateStatus
+  attemptedAt: number
+  ok: boolean
+}
+
+type CachedStatusOptions = UpdateOptions & {
+  now?: () => number
+  uptimeMs?: () => number
+  timings?: Partial<UpdateTimings>
+}
+
+let statusCache: StatusCache | null = null
+let statusInFlight: Promise<UpdateStatus> | null = null
+
+// Wall-clock deltas only ever widen an interval here. A clock that jumped
+// backwards (an NTP correction after sleep is the usual cause) would otherwise
+// read as "checked in the future" and pin the cache forever, so treat it as
+// infinitely old: the cost of being wrong is one extra check.
+function elapsed(since: number, now: number): number {
+  return now >= since ? now - since : Number.POSITIVE_INFINITY
+}
+
+function needsRefresh(
+  cache: StatusCache | null,
+  now: number,
+  uptime: number,
+  timings: UpdateTimings
+): boolean {
+  if (uptime < timings.bootGraceMs) return false
+  if (!cache) return true
+  const age = elapsed(cache.attemptedAt, now)
+  return age >= (cache.ok ? timings.cacheTtlMs : timings.failureBackoffMs)
+}
+
+// What `GET /api/update` serves: the cached answer, refreshed lazily. Callers
+// that arrive together share one refresh, so N tabs crossing the TTL boundary
+// at the same moment produce one registry request, not N.
+export async function getCachedUpdateStatus(
+  options: CachedStatusOptions = {}
+): Promise<UpdateStatus> {
+  const now = (options.now ?? Date.now)()
+  const uptime = (options.uptimeMs ?? defaultUptimeMs)()
+  const timings = { ...defaultTimings(), ...options.timings }
+
+  if (!needsRefresh(statusCache, now, uptime, timings)) {
+    return (
+      statusCache?.status ?? {
+        runningVersion: options.runningVersion ?? VERSION,
+        availableVersion: null
+      }
+    )
+  }
+
+  statusInFlight ??= checkForUpdate(options)
+    .then(outcome => {
+      statusCache = { status: outcome.status, attemptedAt: now, ok: outcome.ok }
+      return outcome.status
+    })
+    .finally(() => {
+      statusInFlight = null
+    })
+  return statusInFlight
+}
+
+function defaultUptimeMs(): number {
+  return process.uptime() * 1000
 }
 
 async function performUpdate(options: UpdateOptions): Promise<UpdateResult | null> {
@@ -228,12 +361,26 @@ async function performUpdate(options: UpdateOptions): Promise<UpdateResult | nul
 // Multiple open browser tabs share one install. They also share this promise,
 // so two clicks never launch two global package-manager processes. A successful
 // result stays cached for the few milliseconds until the server restarts.
+//
+// This guards this process only. A `moi update` run in a terminal while the UI
+// installs is still two package managers writing one global tree; that needs a
+// lock file both entry points take, which is not here yet.
 let installInFlight: Promise<UpdateResult | null> | null = null
+
+// Lets the API answer a second click with "already in progress" instead of
+// silently reporting someone else's install as its own. Stays true once an
+// install succeeds — the restart it scheduled has not landed yet, and
+// `restartPendingForUpdate` tells those two states apart.
+export function updateInProgress(): boolean {
+  return installInFlight !== null
+}
 
 export function installUpdate(options: UpdateOptions = {}): Promise<UpdateResult | null> {
   installInFlight ??= performUpdate(options).then(
     result => {
       if (!result) installInFlight = null
+      // The install just invalidated whatever the cache says is available.
+      else statusCache = null
       return result
     },
     error => {
@@ -244,6 +391,39 @@ export function installUpdate(options: UpdateOptions = {}): Promise<UpdateResult
   return installInFlight
 }
 
+// ---- restart ----------------------------------------------------------------
+
+// Long enough for the HTTP response that triggered it to be flushed to the
+// browser that clicked — it is that response the client waits on before it
+// starts polling for the restarted server.
+export const UPDATE_RESTART_DELAY_MS = 500
+
+let restartScheduled = false
+
+export function restartPendingForUpdate(): boolean {
+  return restartScheduled
+}
+
+// Hand the process back to whoever supervises it: the foreground CLI
+// (`superviseServerUpdates`) and service managers alike bring it back on a
+// non-zero exit, and 75 is the code they agree means "updated, come back".
+// Latched, so concurrent callers schedule one SIGTERM rather than one each.
+export function scheduleRestartForUpdate(delayMs = UPDATE_RESTART_DELAY_MS): boolean {
+  if (restartScheduled) return false
+  restartScheduled = true
+  const timer = setTimeout(() => {
+    process.exitCode = UPDATE_RESTART_EXIT_CODE
+    process.kill(process.pid, 'SIGTERM')
+  }, delayMs)
+  timer.unref()
+  return true
+}
+
 export function __resetUpdateStateForTests(): void {
   installInFlight = null
+  statusCache = null
+  statusInFlight = null
+  installAnalysis = null
+  managerProbe = null
+  restartScheduled = false
 }


### PR DESCRIPTION
Stacked on #102.

`GET /api/update` hit the npm registry on every request, so the real check rate was "once per tab per page load" — and on npm-owned installs each one also spawned `npm root -g`. The six-hour `staleTime` couldn't fix that: nothing persists the query cache, so a reload reset it, while a tab left in a background window went stale instead (React Query pauses intervals while hidden). The registry is now consulted on the server's own schedule and the handler serves a cached answer, which makes the client free to poll often.

What the new e2e counts at the mock registry — five tabs open at once, then ten polls:

```
GET /api/update ×5 (concurrent)  → registry hits: 1   availableVersion 99.0.0
GET /api/update ×10 (within TTL) → registry hits: 1
… TTL expires, GET ×2            → registry hits: 2
registry 503, GET ×10            → registry hits: 1   (5-min backoff, not 10 retries)
```

Params: 60s boot grace, 1h TTL, 5-min failure backoff; client polls every 5 min and refetches on window focus. **No background timer** — a closed app makes no network calls at all, and a machine waking from sleep does one check on the next poll rather than firing into a network stack that isn't up yet.

Worth a close look:

- **`checkForUpdate` now returns `ok`** alongside the status. A failed check and "you're current" both surface as `availableVersion: null`, so without that flag the cache can't tell a 5-minute retry from a 1-hour one.
- **`updateInProgress()` stays latched after a successful install** — the scheduled restart hasn't landed. `restartPendingForUpdate()` separates the two so the 409 says "restarting" rather than "in progress". On an unsupervised server that never restarts, this stays latched.
- **`CONTROL_PORT` now reads `MOI_CONTROL_PORT`** (like `PORT`). Production default unchanged; without it the e2e can't boot a server beside a real one.

Not addressed: a `moi update` in a terminal during a UI install is still two package managers on one tree — that needs a lock file both entry points take.

Verified with `bun test` (1339 pass, 0 fail, 4 pre-existing skips), plus `oxlint`, `oxfmt --check`, and `tsc -p tsconfig.client.json` clean. The e2e in `server/test/update-api-e2e.test.ts` boots a real server process from a fake bun-style global install and finishes with a real `bun install -g` through the API, asserting exit code 75 and that the bin on PATH reports the new version.
