### PR TITLE
Defer shadcn and ts-morph imports out of CLI startup

### DIFF
--- a/server/cli-ui-components.ts
+++ b/server/cli-ui-components.ts
@@ -240,20 +240,19 @@ const list = defineCommand({
   }
 })
 
-const uiComponentsSubCommands = { add, docs, list }
+// Exported so cli.ts can keep a static command shell (name + description, all
+// the root help needs) and pull this module in only when a subcommand actually
+// runs — see the lazy `uiComponents` there.
+export const uiComponentsSubCommands = { add, docs, list }
 
-export const uiComponents = defineCommand({
-  meta: {
-    name: 'ui-components',
-    description: 'Standard UI components for applets (curated shadcn set)'
-  },
-  subCommands: uiComponentsSubCommands,
-  async run({ rawArgs }) {
-    // citty invokes the parent run even after dispatching a subcommand — only
-    // render the catalog when no subcommand ran (same pattern as `moi env`).
-    const first = rawArgs.find(a => !a.startsWith('-'))
-    if (first && Object.hasOwn(uiComponentsSubCommands, first)) return
-    const entry = await resolveCwdWorkspace()
-    renderCatalog(uiDirFor(entry.path))
-  }
-})
+// The bare `moi ui-components` behavior, factored out of the command object so
+// cli.ts can invoke it from a static shell without importing this module until
+// the command actually runs.
+export async function runUiComponentsCatalog(rawArgs: string[]): Promise<void> {
+  // citty invokes the parent run even after dispatching a subcommand — only
+  // render the catalog when no subcommand ran (same pattern as `moi env`).
+  const first = rawArgs.find(a => !a.startsWith('-'))
+  if (first && Object.hasOwn(uiComponentsSubCommands, first)) return
+  const entry = await resolveCwdWorkspace()
+  renderCatalog(uiDirFor(entry.path))
+}

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -41,7 +41,6 @@ import {
   renderEnvView,
   resolveCwdWorkspace
 } from './cli-env'
-import { uiComponents } from './cli-ui-components'
 import { columns, keyValue } from './cli-ui'
 import { CONTROL_HOST, CONTROL_PORT, CONTROL_URL, PORT } from './constants'
 import { type ControlProbe, controlFailureMessage, probeControlServer } from './control-client'
@@ -2929,6 +2928,25 @@ const version = defineCommand({
   meta: { name: 'version', description: 'Print the moi version' },
   run() {
     console.log(versionWithCommit())
+  }
+})
+
+// A static shell over ./cli-ui-components, which reaches `shadcn` and
+// `ts-morph` — ~31 MB of JS that costs ~300 ms to parse and evaluate. The meta
+// is inlined here (duplicating the real command's) because it is all the root
+// help needs: both citty's usage renderer and printMainHelp read only
+// `meta.description`, so a lazily-resolved subcommand would be imported by
+// every `moi --help`. Keeping the shell static defers the module to the point
+// where a subcommand actually runs.
+const uiComponents = defineCommand({
+  meta: {
+    name: 'ui-components',
+    description: 'Standard UI components for applets (curated shadcn set)'
+  },
+  subCommands: () => import('./cli-ui-components').then(m => m.uiComponentsSubCommands),
+  async run({ rawArgs }) {
+    const { runUiComponentsCatalog } = await import('./cli-ui-components')
+    await runUiComponentsCatalog(rawArgs)
   }
 })
 

--- a/server/ui-components.ts
+++ b/server/ui-components.ts
@@ -9,10 +9,13 @@
 // written to `.moi/ui/` and imported relatively (`../ui/button`). The command
 // writes source files and nothing else: it never installs dependencies and
 // never rebuilds — it prints next steps for the agent instead.
-import { getRegistryItems } from 'shadcn/registry'
-import { transformIcons, transformMenu } from 'shadcn/utils'
-import { Project, ScriptKind, SyntaxKind } from 'ts-morph'
-import type { SourceFile } from 'ts-morph'
+// `shadcn/registry`, `shadcn/utils` and `ts-morph` are imported at their call
+// sites rather than here, deliberately. Together they are ~31 MB of JS across
+// 1600 modules (ts-morph alone embeds the whole TypeScript compiler), and the
+// cost is parse + top-level evaluation, so bundling does not help — measured
+// at ~300 ms. Only `moi ui-components add` ever fetches or transforms; a
+// static import here made every `moi` command pay it, `moi version` included.
+import type { Project, SourceFile } from 'ts-morph'
 import { join } from 'path'
 
 // ---------------------------------------------------------------------------
@@ -265,6 +268,8 @@ export async function fetchUiComponents(registryNames: string[]): Promise<Fetche
   const fetched = new Set<string>()
   let queue = [...new Set(['utils', ...registryNames])]
 
+  const { getRegistryItems } = await import('shadcn/registry')
+
   while (queue.length > 0) {
     const batch = queue.filter(name => !fetched.has(name))
     if (batch.length === 0) break
@@ -330,7 +335,12 @@ function rewriteRegistryImports(sourceFile: SourceFile): void {
 // `ui/applet-portal.tsx`) that re-establishes the scope attribute on the
 // portalled subtree. Type positions (`X.Portal.Props`) are untouched — the
 // rewrite only sees JSX tag names.
-function rewritePortals(sourceFile: SourceFile): boolean {
+// `SyntaxKind` is passed in rather than imported: ts-morph is loaded lazily by
+// the one caller below, so this helper cannot close over a module-level import.
+function rewritePortals(
+  sourceFile: SourceFile,
+  SyntaxKind: typeof import('ts-morph').SyntaxKind
+): boolean {
   const PORTAL_TAG = /^[A-Za-z_$][\w$]*\.Portal$/
   let touched = false
 
@@ -369,6 +379,9 @@ let project: Project | undefined
 // (cn-menu-* classes for the default menu color), then the relative-import
 // rewrite and the portal codemod.
 export async function transformUiComponentSource(name: string, raw: string): Promise<string> {
+  const { Project, ScriptKind, SyntaxKind } = await import('ts-morph')
+  const { transformIcons, transformMenu } = await import('shadcn/utils')
+
   project ??= new Project({ useInMemoryFileSystem: true })
   const sourceFile = project.createSourceFile(`moi-ui/${name}`, raw, {
     scriptKind: name.endsWith('.tsx') ? ScriptKind.TSX : ScriptKind.TS,
@@ -378,7 +391,7 @@ export async function transformUiComponentSource(name: string, raw: string): Pro
   await transformIcons(opts)
   await transformMenu(opts)
   rewriteRegistryImports(sourceFile)
-  rewritePortals(sourceFile)
+  rewritePortals(sourceFile, SyntaxKind)
   return sourceFile.getFullText()
 }
 


### PR DESCRIPTION
Every `moi` command — `version`, `bundle`, `tab`, all of them — spent ~500ms loading `shadcn/registry`, `shadcn/utils` and `ts-morph` before doing anything. That is 31MB of JS across 1600 modules (ts-morph alone embeds the entire TypeScript compiler), and only `moi ui-components add` ever touches it. These imports now happen at their call sites, so the CLI starts ~6x faster.

```
                                before    after
moi version                     0.61 s    0.09 s
moi --help                      0.57 s    0.09 s
moi ui-components list          0.39 s    0.09 s
```

The cost is JS parse + top-level evaluation, not resolution or transpile — pre-bundling the graph into one file changed nothing (296ms → 294ms), which also rules out `BUN_RUNTIME_TRANSPILER_CACHE_PATH`.

Worth a close look:

- **`cli.ts` keeps a *static* meta for the shell, duplicating the real command's.** This is load-bearing, not laziness: citty's `renderUsage` resolves every subcommand just to read `meta.description` (`node_modules/citty/dist/index.mjs:244`), and `printMainHelp` does the same. A plain `() => import(...)` subcommand would still be loaded by every `moi --help`. The duplicated description can drift.
- **`rewritePortals` now takes `SyntaxKind` as a parameter**, since it can no longer close over a module-level import. This is the portal codemod that keeps Base UI overlays inside the applet's style scope.
- **`list` and `docs` only got faster because the imports moved inside `ui-components.ts`** — they share that module with `add`, so deferring at the `cli.ts` boundary alone would not have helped them.

Verified: `bun test server/` — 960 pass, 0 fail (964 across 98 files). `bunx tsc --noEmit` unchanged from main (41 pre-existing errors, none new). Live fetch + transform of `popover`/`dialog` against the real registry exercises the risky path end to end: 3 and 2 portal rewrites, Tabler icon transform applied, no leftover `@/registry/` aliases. Catalog, `list`, `docs` and `--help` at every level checked by hand in a real workspace.

Not addressed: `ts-morph` is a phantom dependency — imported directly by `server/ui-components.ts` but reaching the tree only transitively via `shadcn@4.13.0`. Separate concern, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
