### PR TITLE
Ship ui-components in the workspace skill unconditionally

### DIFF
--- a/docs/moi-shadcn.md
+++ b/docs/moi-shadcn.md
@@ -255,10 +255,7 @@ frame tokens onto the wrapper is a possible follow-up.
    offline transform tests in `server/test/ui-components.test.ts`.
 3. **Skill** — ✅ SKILL.md pointer + `references/UI-COMPONENTS.md` cheat
    sheet (catalog at a glance, install/rebuild responsibility, the
-   relative-import rule, per-kind fit). TEMPORARILY gated: the section and
-   cheat sheet install only for workspaces created with
-   `moi init --experimental-shadcn` (marker-stripped otherwise; the
-   installed SKILL.md carries the choice across `moi skill update` — see
-   `server/skills-template.ts`). The command itself is always available;
-   the gate only controls whether the skill advertises it. Remove when the
-   feature graduates.
+   relative-import rule, per-kind fit). Ships to every workspace as of skill
+   version 0.15.0 — the `moi init --experimental-shadcn` gate is gone.
+   Workspaces installed before that get the section on their next
+   `moi skill update`.

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -336,12 +336,6 @@ const init = defineCommand({
       type: 'string',
       description:
         'Register under this id instead of a generated one — fails if the workspace is already registered'
-    },
-    'experimental-shadcn': {
-      type: 'boolean',
-      default: false,
-      description:
-        'Include the experimental ui-components section in the workspace skill (temporary)'
     }
   },
   async run({ args }) {
@@ -399,9 +393,7 @@ const init = defineCommand({
     // Provision: bundled skills + the `.moi/` bootstrap (widgets dir +
     // package.json + bun install). An existing `.moi/` is left untouched.
     console.log()
-    const { scaffold, skillsDir } = await provisionWorkspace(target, type, {
-      experimentalShadcn: args['experimental-shadcn']
-    })
+    const { scaffold, skillsDir } = await provisionWorkspace(target, type)
     if (scaffold !== 'exists') {
       if (scaffold === 'installing') {
         console.log(pc.dim('  Widget dependencies still installing in .moi/ (background)'))

--- a/server/skills-template.ts
+++ b/server/skills-template.ts
@@ -2,7 +2,7 @@
 // (Claude Code workspace) and `moi openclaw init <agent>` (OpenClaw agent
 // workspace). Both commands take a fresh or existing directory and lay
 // down the same set of skill folders.
-import { cp, mkdir, rm } from 'node:fs/promises'
+import { cp, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
 // Source directory for shipped templates. Resolved relative to this file so
@@ -14,68 +14,18 @@ export const TEMPLATE_DIR = join(import.meta.dir, '..', 'workspace')
 // for what `moi skill update` copies and what versions it compares against.
 export const BUNDLED_SKILLS_DIR = join(TEMPLATE_DIR, '.claude', 'skills')
 
-// TEMPORARY gate for the ui-components rollout: the "Standard UI components"
-// section ships in the bundled SKILL.md wrapped in these markers, and installs
-// only for workspaces that opted in via `moi init --experimental-shadcn`.
-// Everything else (the `moi ui-components` command itself, the build patches)
-// is always present — the gate only controls whether the skill TELLS agents
-// about it. Remove the markers, this stripping, and the flag when the feature
-// graduates.
-const EXPERIMENTAL_SHADCN_START = '<!-- moi:experimental-shadcn -->'
-const EXPERIMENTAL_SHADCN_END = '<!-- /moi:experimental-shadcn -->'
-// The cheat sheet only makes sense alongside the section — omitted with it.
-const EXPERIMENTAL_SHADCN_FILES = ['moi-workspace/references/UI-COMPONENTS.md']
-const GATED_SKILL_MD = 'moi-workspace/SKILL.md'
-
-// Remove every marked experimental-shadcn block (markers included), collapsing
-// the blank lines the removal leaves behind.
-export function stripExperimentalShadcn(text: string): string {
-  let out = text
-  for (;;) {
-    const start = out.indexOf(EXPERIMENTAL_SHADCN_START)
-    if (start === -1) break
-    const end = out.indexOf(EXPERIMENTAL_SHADCN_END, start)
-    if (end === -1) break
-    out = out.slice(0, start) + out.slice(end + EXPERIMENTAL_SHADCN_END.length)
-  }
-  return out.replace(/\n{3,}/g, '\n\n')
-}
-
-// Whether a previously installed skills dir opted into the experimental
-// ui-components section — the marker survives in the installed SKILL.md, so
-// its presence IS the stored flag. Lets `moi skill update` (and an unflagged
-// re-init) preserve the choice without any registry state.
-export async function hasExperimentalShadcn(targetSkillsDir: string): Promise<boolean> {
-  const file = Bun.file(join(targetSkillsDir, GATED_SKILL_MD))
-  if (!(await file.exists())) return false
-  return (await file.text()).includes(EXPERIMENTAL_SHADCN_START)
-}
-
-export type InstallBundledSkillsOptions = {
-  // Keep the experimental-shadcn section (see the gate note above). Defaults
-  // to preserving whatever the target dir already chose.
-  experimentalShadcn?: boolean
-}
-
 // Copy each shipped skill folder into `targetSkillsDir`. Overwrites existing
 // files (e.g. on a re-install after a moi upgrade) but leaves unrelated
 // directories alone. Creates the target if missing.
-export async function installBundledSkills(
-  targetSkillsDir: string,
-  options: InstallBundledSkillsOptions = {}
-): Promise<void> {
-  const experimentalShadcn =
-    options.experimentalShadcn ?? (await hasExperimentalShadcn(targetSkillsDir))
+//
+// The ui-components section used to be stripped here unless a workspace opted
+// in with `moi init --experimental-shadcn`. It ships to everyone now; the skill
+// version bump is what pulls it into workspaces installed before the flag went
+// away (the copy below restores both the section and its cheat sheet).
+export async function installBundledSkills(targetSkillsDir: string): Promise<void> {
   await mkdir(targetSkillsDir, { recursive: true })
   await cp(BUNDLED_SKILLS_DIR, targetSkillsDir, {
     recursive: true,
     force: true
   })
-  if (experimentalShadcn) return
-
-  const skillMd = join(targetSkillsDir, GATED_SKILL_MD)
-  await Bun.write(skillMd, stripExperimentalShadcn(await Bun.file(skillMd).text()))
-  for (const rel of EXPERIMENTAL_SHADCN_FILES) {
-    await rm(join(targetSkillsDir, rel), { force: true })
-  }
 }

--- a/server/test/skills-template.test.ts
+++ b/server/test/skills-template.test.ts
@@ -3,11 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import {
-  hasExperimentalShadcn,
-  installBundledSkills,
-  stripExperimentalShadcn
-} from '../skills-template'
+import { installBundledSkills } from '../skills-template'
 import { updateWorkspaceSkills } from '../skill-update'
 
 const SKILL_MD = join('moi-workspace', 'SKILL.md')
@@ -22,71 +18,43 @@ async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
   }
 }
 
-describe('stripExperimentalShadcn', () => {
-  test('removes marked blocks and collapses blank lines', () => {
-    const text =
-      'before\n\n<!-- moi:experimental-shadcn -->\ngated\n<!-- /moi:experimental-shadcn -->\n\nafter\n'
-    expect(stripExperimentalShadcn(text)).toBe('before\n\nafter\n')
-  })
-
-  test('leaves unmarked text untouched', () => {
-    const text = 'plain\n\ncontent\n'
-    expect(stripExperimentalShadcn(text)).toBe(text)
-  })
-})
-
-describe('installBundledSkills experimental-shadcn gate', () => {
-  test('strips the section and the cheat sheet by default', async () => {
+describe('installBundledSkills', () => {
+  test('installs the ui-components section and cheat sheet for every workspace', async () => {
     await withTempDir(async dir => {
       await installBundledSkills(dir)
-
-      const skillMd = await Bun.file(join(dir, SKILL_MD)).text()
-      expect(skillMd).not.toContain('moi:experimental-shadcn')
-      expect(skillMd).not.toContain('Standard UI components')
-      expect(await Bun.file(join(dir, CHEAT_SHEET)).exists()).toBe(false)
-      // The rest of the skill installs normally.
-      expect(skillMd).toContain('# Workspace')
-      expect(await hasExperimentalShadcn(dir)).toBe(false)
-    })
-  })
-
-  test('keeps the section, markers, and cheat sheet when opted in', async () => {
-    await withTempDir(async dir => {
-      await installBundledSkills(dir, { experimentalShadcn: true })
 
       const skillMd = await Bun.file(join(dir, SKILL_MD)).text()
       expect(skillMd).toContain('Standard UI components')
       expect(skillMd).toContain('moi ui-components add')
       expect(await Bun.file(join(dir, CHEAT_SHEET)).exists()).toBe(true)
-      expect(await hasExperimentalShadcn(dir)).toBe(true)
+      // The rest of the skill installs normally.
+      expect(skillMd).toContain('# Workspace')
     })
   })
 
-  test('an unflagged re-install preserves a prior opt-in', async () => {
+  test('no experimental-shadcn gate markers survive in the shipped skill', async () => {
     await withTempDir(async dir => {
-      await installBundledSkills(dir, { experimentalShadcn: true })
       await installBundledSkills(dir)
-
-      expect(await Bun.file(join(dir, SKILL_MD)).text()).toContain('Standard UI components')
-      expect(await Bun.file(join(dir, CHEAT_SHEET)).exists()).toBe(true)
+      expect(await Bun.file(join(dir, SKILL_MD)).text()).not.toContain('experimental-shadcn')
     })
   })
 
-  test('moi skill update preserves the choice in both directions', async () => {
+  test('moi skill update restores the section for a workspace installed before the flag went away', async () => {
     // Skills live under <workspace>/.claude/skills for the default backend —
     // updateWorkspaceSkills re-derives that from the workspace root.
     await withTempDir(async workspace => {
       const skillsDir = join(workspace, '.claude', 'skills')
-
       await installBundledSkills(skillsDir)
-      await updateWorkspaceSkills(workspace)
-      expect(await Bun.file(join(skillsDir, SKILL_MD)).text()).not.toContain(
-        'Standard UI components'
-      )
 
-      await installBundledSkills(skillsDir, { experimentalShadcn: true })
+      // Simulate a pre-graduation opt-out: section stripped, cheat sheet absent.
+      const skillMd = join(skillsDir, SKILL_MD)
+      const stripped = (await Bun.file(skillMd).text()).replace(/## Standard UI components/, '')
+      await Bun.write(skillMd, stripped)
+      rmSync(join(skillsDir, CHEAT_SHEET), { force: true })
+
       await updateWorkspaceSkills(workspace)
-      expect(await Bun.file(join(skillsDir, SKILL_MD)).text()).toContain('Standard UI components')
+
+      expect(await Bun.file(skillMd).text()).toContain('Standard UI components')
       expect(await Bun.file(join(skillsDir, CHEAT_SHEET)).exists()).toBe(true)
     })
   })

--- a/server/workspace-init.ts
+++ b/server/workspace-init.ts
@@ -36,28 +36,17 @@ export type ProvisionResult = {
   scaffold: 'exists' | 'installing' | number
 }
 
-export type ProvisionOptions = {
-  // TEMPORARY: include the experimental ui-components section in the
-  // installed skill (`moi init --experimental-shadcn`). Omitted or false, a
-  // workspace that opted in earlier keeps the section — the installed
-  // SKILL.md carries the choice (see skills-template.ts).
-  experimentalShadcn?: boolean
-}
-
 // Lay down everything a workspace needs: create the folder, copy the bundled
 // skills into the backend's skills dir, and bootstrap `.moi/`. Idempotent —
 // re-running refreshes skills and leaves an existing `.moi/` untouched.
 // Registration in the workspace registry is a separate, caller-owned step.
 export async function provisionWorkspace(
   workspaceRoot: string,
-  type?: WorkspaceType,
-  options: ProvisionOptions = {}
+  type?: WorkspaceType
 ): Promise<ProvisionResult> {
   const skillsDir = skillsDirFor(workspaceRoot, type)
   await mkdir(workspaceRoot, { recursive: true })
-  await installBundledSkills(skillsDir, {
-    experimentalShadcn: options.experimentalShadcn || undefined
-  })
+  await installBundledSkills(skillsDir)
   const scaffold = await scaffoldMoiDir(workspaceRoot)
   return { skillsDir, scaffold }
 }

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -209,6 +209,8 @@ relatively: `import { Button } from '../ui/button'`.
   `.moi/` and run `moi bundle` yourself.
 - Files in `.moi/ui/` are yours to customize (edits propagate to every applet using them);
   re-running `add` refuses to overwrite them without `--force`.
+- Component names, their API, and the CLI are very close to a selected subset of shadcn, but the
+  actual implementation might differ.
 
 ## Server functions — `<name>.server.ts`
 

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -192,8 +192,6 @@ function cx(...classes: (string | false | undefined | null)[]) {
 }
 ```
 
-<!-- moi:experimental-shadcn -->
-
 ## Standard UI components
 
 Need a standard control (button, dialog, select, table, chart…)? Don't hand-roll it —
@@ -211,8 +209,6 @@ relatively: `import { Button } from '../ui/button'`.
   `.moi/` and run `moi bundle` yourself.
 - Files in `.moi/ui/` are yours to customize (edits propagate to every applet using them);
   re-running `add` refuses to overwrite them without `--force`.
-
-<!-- /moi:experimental-shadcn -->
 
 ## Server functions — `<name>.server.ts`
 
@@ -441,4 +437,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.14.0" />
+<moi-skill version="0.15.0" />

--- a/workspace/.claude/skills/moi-workspace/references/UI-COMPONENTS.md
+++ b/workspace/.claude/skills/moi-workspace/references/UI-COMPONENTS.md
@@ -1,9 +1,9 @@
 # UI components cheat sheet
 
-`moi ui-components` installs standard controls from the shadcn registry, pre-tuned for moi
-applets: **Base UI** primitives, **Tabler** icons, workspace theme tokens, relative imports, and
-overlays patched so applet styling survives portalling. Components land in `.moi/ui/` as plain
-source files you own.
+`moi ui-components` installs standard controls from a selected subset of the shadcn registry,
+pre-tuned for moi applets: **Base UI** primitives, **Tabler** icons, workspace theme tokens,
+relative imports, and overlays patched so applet styling survives portalling. Components land
+in `.moi/ui/` as plain source files you own.
 
 This file is the catalog plus the essential usage rules (condensed from the official shadcn
 skill). Read it once; fetch full per-component docs with `moi ui-components docs <name>` **before


### PR DESCRIPTION
The "Standard UI components" section and its `references/UI-COMPONENTS.md` cheat sheet only installed for workspaces created with `moi init --experimental-shadcn`; everyone else got a marker-stripped SKILL.md. The feature is releasing, so the gate is gone — every workspace gets the section, and the flag, the markers, and the strip/detect machinery go with it.

The skill an agent reads now always contains:

```md
## Standard UI components

Need a standard control (button, dialog, select, table, chart…)? Don't hand-roll it —
`moi ui-components add <name>` installs a moi-tuned shadcn component (Base UI + Tabler icons,
workspace theme tokens, overlays patched to keep applet styling) into `.moi/ui/`.
```

Worth a close look:

- **The skill version bump to 0.15.0 *is* the migration.** Workspaces that never opted in have a stripped SKILL.md and no cheat sheet on disk. A minor bump is what surfaces the `moi skill update` nudge — patch bumps stay silent (`isMinorBehind`, `server/skill-version.ts`) — and the update recopies the bundled tree, restoring both files. Get the bump wrong and existing workspaces silently never learn the feature exists.
- **`provisionWorkspace` lost its third parameter.** Its other four call sites (`api.ts:982`, `api.ts:1046`, `cli.ts` openclaw/hermes init) already passed two args, so nothing else changed — but it is a public-ish seam worth confirming.
- **A stale `--experimental-shadcn` is now silently ignored rather than rejected.** Verified the positional dir still parses correctly alongside it, so existing scripts and muscle memory keep working instead of erroring.

Verified: `bun test server/` — 957 pass, 0 fail (961 across 98 files). `bunx tsc --noEmit` — 41 errors, byte-identical to main's set (diffed; none added, none removed). `provisionWorkspace` run end to end into a temp dir with no flag: section present, cheat sheet present, zero gate markers, version marker reads 0.15.0. `moi init --help` no longer advertises the flag. `server/test/skills-template.test.ts` was rewritten — the three gate tests are replaced by coverage that the section always ships, that no markers survive, and that `moi skill update` restores a pre-graduation stripped install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)