### PR TITLE
Preselect Hermes's configured default model

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -648,8 +648,9 @@ export type Model = {
   // Id used to select the model (Claude `value`; OpenClaw catalog id).
   value: string
   // Canonical wire model id this row resolves to (Claude, e.g. 'default' and
-  // 'opus[1m]' both → 'claude-opus-4-8[1m]'). Lets the picker map the synthetic
-  // "default" entry onto the concrete model it points at.
+  // 'opus[1m]' both → 'claude-opus-4-8[1m]'; Hermes maps its structured ACP
+  // default the same way). Lets the picker map a synthetic "default" entry
+  // onto the concrete model it points at.
   resolvedModel?: string
   // Human-readable label (Claude `displayName`; OpenClaw `name`).
   displayName: string

--- a/server/harness/acp/discovery.test.ts
+++ b/server/harness/acp/discovery.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { killAllAcpClients } from './client'
+import { clearAcpModelCache, listAcpModels } from './discovery'
+import type { AcpProviderConfig } from './session'
+
+const AGENT_SOURCE = `
+const states = JSON.parse(process.env.MOCK_MODEL_STATES ?? '[]')
+const send = value => process.stdout.write(JSON.stringify(value) + '\\n')
+let stateIndex = 0
+let buffer = ''
+process.stdin.on('data', chunk => {
+  buffer += chunk
+  let newline
+  while ((newline = buffer.indexOf('\\n')) >= 0) {
+    const line = buffer.slice(0, newline)
+    buffer = buffer.slice(newline + 1)
+    if (!line.trim()) continue
+    const message = JSON.parse(line)
+    if (message.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: message.id, result: { protocolVersion: 1, agentCapabilities: {} } })
+    } else if (message.method === 'session/new') {
+      const models = states[Math.min(stateIndex++, states.length - 1)]
+      send({ jsonrpc: '2.0', id: message.id, result: { sessionId: 'discovery-test', models } })
+    }
+  }
+})
+`
+
+const modelStates = [
+  {
+    availableModels: [{ modelId: 'model-a' }, { modelId: 'model-b' }],
+    currentModelId: 'model-a'
+  },
+  {
+    availableModels: [{ modelId: 'model-a' }, { modelId: 'model-b' }],
+    currentModelId: 'model-b'
+  }
+]
+
+async function mockConfig(refreshModelState: boolean) {
+  const workspacePath = await mkdtemp(join(tmpdir(), 'acp-discovery-test-'))
+  const agentPath = join(workspacePath, 'mock-acp-agent.js')
+  await Bun.write(agentPath, AGENT_SOURCE)
+  const config: AcpProviderConfig = {
+    id: 'hermes',
+    provider: 'hermes',
+    refreshModelState,
+    mapModels: state => [
+      {
+        value: state.currentModelId ?? 'missing',
+        displayName: state.currentModelId ?? 'missing'
+      }
+    ],
+    spawn: async () => ({
+      provider: 'hermes',
+      command: process.execPath,
+      args: [agentPath],
+      workspacePath,
+      env: { MOCK_MODEL_STATES: JSON.stringify(modelStates) }
+    })
+  }
+  return { config, workspacePath }
+}
+
+afterAll(() => {
+  killAllAcpClients()
+})
+
+describe('ACP model discovery cache', () => {
+  test('refreshes mutable model state for providers that opt in', async () => {
+    const { config, workspacePath } = await mockConfig(true)
+    const context = { workspaceId: 'refresh', workspacePath }
+
+    expect((await listAcpModels(config, context))[0]?.value).toBe('model-a')
+    expect((await listAcpModels(config, context))[0]?.value).toBe('model-b')
+  })
+
+  test('keeps the existing process-lifetime cache for other ACP providers', async () => {
+    const { config, workspacePath } = await mockConfig(false)
+    const context = { workspaceId: 'cached', workspacePath }
+
+    expect((await listAcpModels(config, context))[0]?.value).toBe('model-a')
+    expect((await listAcpModels(config, context))[0]?.value).toBe('model-a')
+    clearAcpModelCache(workspacePath)
+    expect((await listAcpModels(config, context))[0]?.value).toBe('model-b')
+  })
+})

--- a/server/harness/acp/discovery.ts
+++ b/server/harness/acp/discovery.ts
@@ -5,7 +5,7 @@ import { type AcpProviderConfig, type AcpSpawnContext } from './session'
 import { acpSessionToSessionInfo } from './adapter'
 import { archivedAcpSessions } from './archived'
 import { getAcpClient, peekAcpClient } from './client'
-import type { ListSessionsResponse, AcpModelInfo, AcpModelState, AcpNewSessionResult } from './wire'
+import type { ListSessionsResponse, AcpModelState, AcpNewSessionResult } from './wire'
 import type { WorkspaceActivityPreview } from '../types'
 import { debug } from '../../debug'
 
@@ -78,10 +78,23 @@ export async function acpWorkspacePreview(
 }
 
 // The model catalog arrives inline on `session/new`, so there is no standalone
-// list RPC. Cache it per workspace: creating a session just to read models is
-// wasteful, and an empty session is invisible to `session/list` anyway (agents
-// skip zero-history rows).
+// list RPC. Cache it per workspace by default: creating a session just to read
+// models is wasteful, and an empty session is invisible to `session/list`
+// anyway (agents skip zero-history rows). Providers whose state includes a
+// mutable external default can opt into refreshing it on each picker snapshot.
 const modelCatalogs = new Map<string, Promise<AcpModelState | undefined>>()
+
+async function discoverAcpModelState(
+  config: AcpProviderConfig,
+  ctx: AcpSpawnContext
+): Promise<AcpModelState | undefined> {
+  const client = await getAcpClient(await config.spawn(ctx))
+  const created = await client.rpc<AcpNewSessionResult>('session/new', {
+    cwd: ctx.workspacePath,
+    mcpServers: []
+  })
+  return created.models ?? undefined
+}
 
 export function cacheAcpModelState(workspacePath: string, models: AcpModelState | undefined): void {
   if (models?.availableModels?.length) {
@@ -97,32 +110,31 @@ export async function listAcpModels(
   config: AcpProviderConfig,
   ctx: AcpSpawnContext
 ): Promise<Model[]> {
-  let cached: Promise<AcpModelState | undefined> | undefined = modelCatalogs.get(ctx.workspacePath)
-  if (!cached) {
-    cached = (async () => {
-      const client = await getAcpClient(await config.spawn(ctx))
-      const created = await client.rpc<AcpNewSessionResult>('session/new', {
-        cwd: ctx.workspacePath,
-        mcpServers: []
+  let statePromise: Promise<AcpModelState | undefined>
+  if (config.refreshModelState) {
+    statePromise = discoverAcpModelState(config, ctx)
+  } else {
+    let cached = modelCatalogs.get(ctx.workspacePath)
+    if (!cached) {
+      cached = discoverAcpModelState(config, ctx).catch(err => {
+        modelCatalogs.delete(ctx.workspacePath)
+        throw err
       })
-      return created.models ?? undefined
-    })().catch(err => {
-      modelCatalogs.delete(ctx.workspacePath)
-      throw err
-    })
-    modelCatalogs.set(ctx.workspacePath, cached)
+      modelCatalogs.set(ctx.workspacePath, cached)
+    }
+    statePromise = cached
   }
   const mapModels =
     config.mapModels ??
-    ((infos: AcpModelInfo[]): Model[] =>
-      infos.map(m => ({
+    ((modelState: AcpModelState): Model[] =>
+      (modelState.availableModels ?? []).map(m => ({
         value: m.modelId,
         displayName: m.name ?? m.modelId,
         ...(m.description ? { description: m.description } : {})
       })))
   try {
-    const state = await cached
-    return mapModels(state?.availableModels ?? [])
+    const state = await statePromise
+    return mapModels(state ?? {})
   } catch (err) {
     debug(`${config.id} model catalog failed: ${err instanceof Error ? err.message : String(err)}`)
     return []

--- a/server/harness/acp/session.test.ts
+++ b/server/harness/acp/session.test.ts
@@ -13,7 +13,12 @@ import { appendMoiContext, renderMoiContext } from '@/lib/moi-context'
 
 import { killAllAcpClients } from './client'
 import { appendRunDuration, setRunDurationsPath } from './run-durations'
-import { type AcpProviderConfig, ensureAcpSessionLive, forgetAllAcpSessions } from './session'
+import {
+  type AcpProviderConfig,
+  ensureAcpSessionLive,
+  forgetAllAcpSessions,
+  sendAcpMessage
+} from './session'
 
 let seq = 0
 
@@ -21,7 +26,10 @@ let seq = 0
 // object per line on stdio. Replay updates ride in via MOCK_UPDATES so each
 // test controls its own history.
 const AGENT_SOURCE = `
+const { appendFileSync } = require('node:fs')
 const updates = JSON.parse(process.env.MOCK_UPDATES ?? '[]')
+const newSession = JSON.parse(process.env.MOCK_NEW_SESSION ?? 'null')
+const methodLog = process.env.MOCK_METHOD_LOG
 const send = o => process.stdout.write(JSON.stringify(o) + '\\n')
 let buf = ''
 process.stdin.on('data', chunk => {
@@ -32,8 +40,13 @@ process.stdin.on('data', chunk => {
     buf = buf.slice(nl + 1)
     if (!line.trim()) continue
     const msg = JSON.parse(line)
+    if (methodLog && msg.method !== 'initialize') {
+      appendFileSync(methodLog, JSON.stringify({ method: msg.method, params: msg.params }) + '\\n')
+    }
     if (msg.method === 'initialize') {
       send({ jsonrpc: '2.0', id: msg.id, result: { protocolVersion: 1, agentCapabilities: {} } })
+    } else if (msg.method === 'session/new' && newSession) {
+      send({ jsonrpc: '2.0', id: msg.id, result: newSession })
     } else if (msg.method === 'session/load') {
       for (const update of updates) {
         send({
@@ -43,6 +56,8 @@ process.stdin.on('data', chunk => {
         })
       }
       send({ jsonrpc: '2.0', id: msg.id, result: {} })
+    } else if (msg.method === 'session/prompt') {
+      send({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn' } })
     } else if (msg.id !== undefined) {
       send({ jsonrpc: '2.0', id: msg.id, result: {} })
     }
@@ -76,6 +91,64 @@ async function replayThroughMockAgent(updates: unknown[], seedDurations: number[
     workspacePath: dir,
     sessionId
   })
+}
+
+type LoggedRpc = {
+  method: string
+  params?: unknown
+}
+
+async function exerciseModelSwitchThroughMockAgent(): Promise<LoggedRpc[]> {
+  const dir = await mkdtemp(join(tmpdir(), 'acp-model-switch-test-'))
+  const agentPath = join(dir, 'mock-acp-agent.js')
+  const methodLog = join(dir, 'methods.jsonl')
+  await Bun.write(agentPath, AGENT_SOURCE)
+  const sessionId = 'sess-model-' + ++seq
+  const workspaceId = 'ws-model-' + seq
+  const currentModelId = 'bedrock:us.anthropic.claude-sonnet-4-6'
+  const alternateModelId = 'bedrock:global.anthropic.claude-sonnet-4-6'
+  const config: AcpProviderConfig = {
+    id: 'hermes',
+    provider: 'hermes',
+    spawn: async () => ({
+      provider: 'hermes',
+      command: process.execPath,
+      args: [agentPath],
+      workspacePath: dir,
+      env: {
+        MOCK_METHOD_LOG: methodLog,
+        MOCK_NEW_SESSION: JSON.stringify({
+          sessionId,
+          models: {
+            availableModels: [{ modelId: currentModelId }, { modelId: alternateModelId }],
+            currentModelId
+          }
+        })
+      }
+    })
+  }
+
+  await sendAcpMessage(config, {
+    workspaceId,
+    workspacePath: dir,
+    sessionId,
+    isNew: true,
+    content: 'first'
+  })
+  await sendAcpMessage(config, {
+    workspaceId,
+    workspacePath: dir,
+    sessionId,
+    isNew: false,
+    content: 'second',
+    model: alternateModelId
+  })
+
+  return (await Bun.file(methodLog).text())
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as LoggedRpc)
 }
 
 afterAll(() => {
@@ -252,5 +325,25 @@ describe('ACP session replay', () => {
     expect(turns[0].parts).toEqual([
       { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,aGVsbG8=' }
     ])
+  })
+})
+
+describe('ACP model selection', () => {
+  test('uses the agent default until moi explicitly switches before the next prompt', async () => {
+    const calls = await exerciseModelSwitchThroughMockAgent()
+
+    expect(calls.map(call => call.method)).toEqual([
+      'session/new',
+      'session/prompt',
+      'session/set_model',
+      'session/prompt'
+    ])
+    expect(calls[2]).toMatchObject({
+      method: 'session/set_model',
+      params: {
+        sessionId: expect.stringMatching(/^sess-model-/),
+        modelId: 'bedrock:global.anthropic.claude-sonnet-4-6'
+      }
+    })
   })
 })

--- a/server/harness/acp/session.ts
+++ b/server/harness/acp/session.ts
@@ -34,7 +34,7 @@ import {
 import { type AcpClient, type AcpSpawnSpec, getAcpClient } from './client'
 import { appendRunDuration, runDurations } from './run-durations'
 import {
-  type AcpModelInfo,
+  type AcpModelState,
   type AcpNewSessionResult,
   type AcpPromptBlock,
   type ContentChunk,
@@ -71,11 +71,17 @@ export type AcpProviderConfig = {
   noPromptModeId?: string
   // Does the backend send images as base64 content blocks?
   supportsImages?: boolean
-  // How the backend's model catalog becomes picker rows. ACP says nothing
-  // about how `name`/`description` are formatted, so a backend that packs
-  // extra structure into them (Hermes: the provider) unpacks it here.
-  // Defaults to a straight passthrough.
-  mapModels?: (models: AcpModelInfo[]) => Model[]
+  // How the backend's model state becomes picker rows. ACP says nothing about
+  // how `name`/`description` are formatted, so a backend that packs extra
+  // structure into them (Hermes: the provider) unpacks it here. The full state
+  // also preserves a structured provider default such as `currentModelId`.
+  // Defaults to a straight catalog passthrough.
+  mapModels?: (state: AcpModelState) => Model[]
+  // Re-read the model state whenever the picker snapshot is fetched. Most ACP
+  // catalogs are stable enough to cache for the process lifetime, but a
+  // backend whose `currentModelId` follows mutable external config must opt in
+  // so the picker cannot drift from what a fresh session would run.
+  refreshModelState?: boolean
 }
 
 type QueuedSend = { blocks: AcpPromptBlock[]; turnId: string }

--- a/server/harness/hermes/index.ts
+++ b/server/harness/hermes/index.ts
@@ -42,6 +42,10 @@ const config: AcpProviderConfig = {
   provider: 'hermes',
   noPromptModeId: NO_PROMPT_MODE,
   mapModels: hermesModels,
+  // Hermes's global default can change outside moi while the server stays up.
+  // Its only structured source is `currentModelId` on `session/new`, so refresh
+  // that state for each picker snapshot instead of freezing it with the catalog.
+  refreshModelState: true,
   supportsImages: true,
   async spawn(ctx) {
     const bin = findHarnessExecutable('hermes')

--- a/server/harness/hermes/models.test.ts
+++ b/server/harness/hermes/models.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
 import { hermesModels } from './models'
-import type { AcpModelInfo } from '../acp/wire'
+import type { AcpModelInfo, AcpModelState } from '../acp/wire'
 
 function one(info: AcpModelInfo) {
-  return hermesModels([info])[0]
+  return hermesModels({ availableModels: [info] })[0]
 }
 
 describe('hermesModels', () => {
@@ -112,32 +112,119 @@ describe('hermesModels deduping', () => {
   // Hermes lists a configured provider's models twice — under the provider id
   // and again namespaced under `custom:` — both routing to the same endpoint.
   test('keeps the first of two ids for the same provider and model', () => {
-    const models = hermesModels([
-      {
-        modelId: 'ollama-launch:gpt-oss:20b',
-        name: 'Ollama · gpt-oss:20b',
-        description: 'Provider: Ollama'
-      },
-      {
-        modelId: 'custom:ollama-launch:gpt-oss:20b',
-        name: 'gpt-oss:20b',
-        description: 'Provider: Ollama'
-      }
-    ])
+    const models = hermesModels({
+      availableModels: [
+        {
+          modelId: 'ollama-launch:gpt-oss:20b',
+          name: 'Ollama · gpt-oss:20b',
+          description: 'Provider: Ollama'
+        },
+        {
+          modelId: 'custom:ollama-launch:gpt-oss:20b',
+          name: 'gpt-oss:20b',
+          description: 'Provider: Ollama'
+        }
+      ]
+    })
 
     expect(models.map(m => m.value)).toEqual(['ollama-launch:gpt-oss:20b'])
   })
 
-  test('keeps same-named models from different providers', () => {
-    const models = hermesModels([
-      {
-        modelId: 'nous:x-ai/grok-4.5',
-        name: 'Nous Portal · x-ai/grok-4.5',
-        description: 'Provider: Nous Portal'
-      },
-      { modelId: 'xai-oauth:grok-4.5', name: 'xAI · grok-4.5', description: 'Provider: xAI' }
+  test('keeps the current id when it is the duplicate spelling', () => {
+    const models = hermesModels({
+      availableModels: [
+        {
+          modelId: 'ollama-launch:gpt-oss:20b',
+          name: 'Ollama · gpt-oss:20b',
+          description: 'Provider: Ollama'
+        },
+        {
+          modelId: 'custom:ollama-launch:gpt-oss:20b',
+          name: 'gpt-oss:20b',
+          description: 'Provider: Ollama • current'
+        }
+      ],
+      currentModelId: 'custom:ollama-launch:gpt-oss:20b'
+    })
+
+    expect(models.map(model => model.value)).toEqual([
+      'default',
+      'custom:ollama-launch:gpt-oss:20b'
     ])
+    expect(models.every(model => model.resolvedModel === 'custom:ollama-launch:gpt-oss:20b')).toBe(
+      true
+    )
+  })
+
+  test('keeps same-named models from different providers', () => {
+    const models = hermesModels({
+      availableModels: [
+        {
+          modelId: 'nous:x-ai/grok-4.5',
+          name: 'Nous Portal · x-ai/grok-4.5',
+          description: 'Provider: Nous Portal'
+        },
+        { modelId: 'xai-oauth:grok-4.5', name: 'xAI · grok-4.5', description: 'Provider: xAI' }
+      ]
+    })
 
     expect(models.map(m => m.providerId)).toEqual(['nous', 'xai-oauth'])
+  })
+})
+
+describe('hermesModels default', () => {
+  const availableModels: AcpModelInfo[] = [
+    {
+      modelId: 'bedrock:us.anthropic.claude-sonnet-4-6',
+      name: 'AWS Bedrock · us.anthropic.claude-sonnet-4-6',
+      description: 'Provider: AWS Bedrock • current'
+    },
+    {
+      modelId: 'openrouter:anthropic/claude-opus-4.6',
+      name: 'OpenRouter · anthropic/claude-opus-4.6',
+      description: 'Provider: OpenRouter'
+    }
+  ]
+
+  test('maps currentModelId onto the concrete current model', () => {
+    const state: AcpModelState = {
+      availableModels,
+      currentModelId: 'bedrock:us.anthropic.claude-sonnet-4-6'
+    }
+
+    expect(hermesModels(state)).toEqual([
+      {
+        value: 'default',
+        resolvedModel: 'bedrock:us.anthropic.claude-sonnet-4-6',
+        displayName: 'Default (from Hermes)'
+      },
+      {
+        value: 'bedrock:us.anthropic.claude-sonnet-4-6',
+        resolvedModel: 'bedrock:us.anthropic.claude-sonnet-4-6',
+        displayName: 'us.anthropic.claude-sonnet-4-6',
+        group: 'AWS Bedrock',
+        providerId: 'bedrock'
+      },
+      {
+        value: 'openrouter:anthropic/claude-opus-4.6',
+        displayName: 'anthropic/claude-opus-4.6',
+        group: 'OpenRouter',
+        providerId: 'openrouter'
+      }
+    ])
+  })
+
+  test('keeps the catalog unchanged without currentModelId', () => {
+    expect(hermesModels({ availableModels }).map(model => model.value)).toEqual([
+      'bedrock:us.anthropic.claude-sonnet-4-6',
+      'openrouter:anthropic/claude-opus-4.6'
+    ])
+    expect(hermesModels({})).toEqual([])
+  })
+
+  test('keeps the catalog unchanged when currentModelId is unavailable', () => {
+    expect(
+      hermesModels({ availableModels, currentModelId: 'bedrock:missing' }).map(model => model.value)
+    ).toEqual(['bedrock:us.anthropic.claude-sonnet-4-6', 'openrouter:anthropic/claude-opus-4.6'])
   })
 })

--- a/server/harness/hermes/models.ts
+++ b/server/harness/hermes/models.ts
@@ -15,10 +15,11 @@
 // in `description` alone, which is why the group comes from that field.
 import type { Model } from '@/lib/types'
 
-import type { AcpModelInfo } from '../acp/wire'
+import type { AcpModelInfo, AcpModelState } from '../acp/wire'
 
 const PROVIDER_PREFIX = /^Provider:\s*/
-// Hermes marks the model it would pick itself; moi tracks its own selection.
+// This is display cleanup only. The default comes from structured
+// `currentModelId`, never by inferring it from this suffix.
 const CURRENT_SUFFIX = /\s*•\s*current$/
 
 function providerOf(description: string | undefined): string | undefined {
@@ -65,15 +66,34 @@ function hermesModel(info: AcpModelInfo): Model {
 // — for the same endpoint and model. Both spellings work, so keep the first
 // and drop rows the picker would render as an exact duplicate. Keyed on
 // `providerId` where there is one, since both spellings normalize to it.
-export function hermesModels(infos: AcpModelInfo[]): Model[] {
-  const seen = new Set<string>()
+export function hermesModels(state: AcpModelState): Model[] {
+  const seen = new Map<string, number>()
   const out: Model[] = []
-  for (const info of infos) {
+  for (const info of state.availableModels ?? []) {
     const model = hermesModel(info)
     const key = `${model.providerId ?? model.group ?? ''} ${model.displayName}`
-    if (seen.has(key)) continue
-    seen.add(key)
+    const existingIndex = seen.get(key)
+    if (existingIndex !== undefined) {
+      // If Hermes names a duplicate spelling as current, retain that exact id
+      // so the structured default can resolve to a visible picker row.
+      if (info.modelId === state.currentModelId) out[existingIndex] = model
+      continue
+    }
+    seen.set(key, out.length)
     out.push(model)
   }
-  return out
+
+  if (!state.currentModelId) return out
+  const currentIndex = out.findIndex(model => model.value === state.currentModelId)
+  if (currentIndex === -1) return out
+
+  out[currentIndex] = { ...out[currentIndex], resolvedModel: state.currentModelId }
+  return [
+    {
+      value: 'default',
+      resolvedModel: state.currentModelId,
+      displayName: 'Default (from Hermes)'
+    },
+    ...out
+  ]
 }


### PR DESCRIPTION
Hermes workspaces now preselect the model reported by ACP when moi has no explicit chat selection. Explicit moi selections still win and persist, while a refreshed workspace snapshot follows changes to the Hermes global default.

ACP signal used by the picker:
```text
session/new → models.currentModelId
bedrock:us.anthropic.claude-sonnet-4-6
```

The display-only `• current` suffix remains stripped; it is never parsed to determine the default.

Reviewer focus:
- `listAcpModels` now passes the complete structured model state into provider mapping.
- Hermes refreshes model state per `/agent` snapshot so its mutable default is not cached indefinitely; other ACP consumers retain the existing cache.
- Duplicate Hermes model aliases retain the exact ID named by `currentModelId` so the default always resolves to a visible row.

Verification:
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck:client`
- `bun test` — 1,404 passed, 4 skipped, 0 failed
- Hermes Agent v0.16.0: fresh workspace selected the configured Bedrock Sonnet 4.6 default without interaction
- Switching to Bedrock Haiku persisted across reload and sent `session/set_model` before the next prompt