### PR TITLE
Stop workspace processes when removing workspaces

### DIFF
--- a/server/api-remove.test.ts
+++ b/server/api-remove.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { api } from './api'
+import { codexHarness } from './harness/codex'
+import { DEFAULT_REGISTRY_PATH, getWorkspace, registerWorkspace, setRegistryPath } from './registry'
+
+const originalStopWorkspace = codexHarness.stopWorkspace
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'moi-api-remove-'))
+  setRegistryPath(join(tempDir, 'workspaces.json'))
+})
+
+afterEach(async () => {
+  codexHarness.stopWorkspace = originalStopWorkspace
+  setRegistryPath(DEFAULT_REGISTRY_PATH)
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+test('removing a workspace stops its harness', async () => {
+  const workspacePath = join(tempDir, 'workspace')
+  const workspace = await registerWorkspace(workspacePath, { type: 'codex' })
+  const stopped: string[] = []
+  codexHarness.stopWorkspace = path => stopped.push(path)
+
+  const response = await api.request(`/api/workspaces/${workspace.id}`, { method: 'DELETE' })
+
+  expect(response.status).toBe(204)
+  expect(stopped).toEqual([workspacePath])
+  expect(await getWorkspace(workspace.id)).toBeNull()
+})

--- a/server/api.ts
+++ b/server/api.ts
@@ -906,8 +906,10 @@ one.put('/', async c => {
 })
 
 one.delete('/', async c => {
-  const ok = await removeWorkspace(c.get('ws').id)
+  const ws = c.get('ws')
+  const ok = await removeWorkspace(ws.id)
   if (!ok) return c.text('Workspace not found', 404)
+  harnessFor(ws).stopWorkspace?.(ws.path)
   return c.body(null, 204)
 })
 

--- a/server/harness/claude-code/index.ts
+++ b/server/harness/claude-code/index.ts
@@ -16,6 +16,7 @@ import {
   getCCActiveSessions,
   interruptCCSession,
   killAllCCSessions,
+  killWorkspaceSessions,
   restartWorkspaceSessions,
   retireCCSessionsOnCliChange,
   sendCCMessage
@@ -109,6 +110,7 @@ export const claudeCodeHarness: Harness = {
   startLogin: ws => startClaudeLogin(ws.path),
 
   onEnvChanged: workspacePath => restartWorkspaceSessions(workspacePath),
+  stopWorkspace: workspacePath => killWorkspaceSessions(workspacePath),
   shutdown: () => killAllCCSessions(),
   skillsDir: workspaceRoot => join(workspaceRoot, '.claude', 'skills'),
 

--- a/server/harness/claude-code/session.test.ts
+++ b/server/harness/claude-code/session.test.ts
@@ -16,6 +16,7 @@ import {
   getCCDebugSnapshot,
   interruptCCSession,
   killAllCCSessions,
+  killWorkspaceSessions,
   retireCCSessionsOnCliChange,
   sendCCMessage
 } from './session'
@@ -138,6 +139,22 @@ afterEach(async () => {
 })
 
 describe('Claude session message queue', () => {
+  test('removing a workspace stops only its sessions and queued messages', async () => {
+    await send()
+    await send({ workspaceId: 'other', workspacePath: '/fake/other', sessionId: 'other' })
+    const queued = send({ content: 'second' })
+    await settle()
+
+    killWorkspaceSessions(input.workspacePath)
+
+    await expect(queued).rejects.toThrow('Workspace removed')
+    expect(drivers[0]?.closed).toBe(true)
+    expect(drivers[1]?.closed).toBe(false)
+    expect(getCCActiveSessions()).toEqual([
+      { workspaceId: 'other', sessionId: 'other', activity: 'running' }
+    ])
+  })
+
   test('keeps follow-ups in moi until each preceding result, without state events', async () => {
     await send()
     const d = drivers[0]!

--- a/server/harness/claude-code/session.ts
+++ b/server/harness/claude-code/session.ts
@@ -969,6 +969,23 @@ export function restartWorkspaceSessions(workspacePath: string): void {
   }
 }
 
+// Stop every queued message and subprocess for a workspace being removed.
+export function killWorkspaceSessions(workspacePath: string): void {
+  for (const messages of messageQueues.values()) {
+    if (messages.workspacePath !== workspacePath) continue
+    messages.stopping = true
+    cancelPendingMessages(messages, new Error('Workspace removed'))
+    messages.active?.complete()
+    messages.active = null
+  }
+  for (const s of [...sessions.values()]) {
+    if (s.workspacePath === workspacePath) teardown(s)
+  }
+  for (const [key, messages] of messageQueues) {
+    if (messages.workspacePath === workspacePath) messageQueues.delete(key)
+  }
+}
+
 // A CLI update may introduce models the current process cannot use. Mark it
 // for replacement at the next safe dispatch boundary.
 export function retireCCSessionsOnCliChange(): void {

--- a/server/harness/codex/index.ts
+++ b/server/harness/codex/index.ts
@@ -70,6 +70,7 @@ export const codexHarness: Harness = {
   startLogin: ws => startCodexLogin(ws.path),
 
   onEnvChanged: workspacePath => killCodexWorkspace(workspacePath),
+  stopWorkspace: workspacePath => killCodexWorkspace(workspacePath),
   shutdown: () => killAllCodexClients(),
   skillsDir: workspaceRoot => `${workspaceRoot}/.agents/skills`,
   debugInfo: ws => getCodexProcessInfo(ws.path),

--- a/server/harness/hermes/index.ts
+++ b/server/harness/hermes/index.ts
@@ -138,6 +138,10 @@ export const hermesHarness: Harness = {
     forgetAcpWorkspaceSessions(workspacePath)
     killAcpWorkspace(workspacePath)
   },
+  stopWorkspace: workspacePath => {
+    forgetAcpWorkspaceSessions(workspacePath)
+    killAcpWorkspace(workspacePath)
+  },
   shutdown: () => {
     forgetAllAcpSessions()
     killAllAcpClients()

--- a/server/harness/types.ts
+++ b/server/harness/types.ts
@@ -114,6 +114,8 @@ export type Harness = {
   // Env is frozen at spawn everywhere; this reaps idle sessions/processes so
   // the next message picks up fresh env.
   onEnvChanged?(workspacePath: string): void
+  // Workspace removal: stop every child process owned by that workspace.
+  stopWorkspace?(workspacePath: string): void
   // Server shutdown: kill child processes so nothing is orphaned.
   shutdown?(): void
   // Where this backend loads workspace skills from (workspace provisioning).


### PR DESCRIPTION
Removing a workspace now stops the harness processes and live sessions owned by that workspace. Re-adding a folder at the same path therefore starts a fresh agent process instead of reusing one whose working directory was moved or deleted.

Before: remove a workspace, move its folder, recreate that path, and Codex can reuse the stale path-keyed process.
After: the removal request clears the registry entry and tells the matching harness to stop that workspace.

### Review notes

- Codex and Hermes clear their path-keyed clients immediately, then terminate the old process asynchronously.
- Claude Code cancels queued messages, completes active waiters, closes matching subprocesses, and leaves other workspaces running.
- OpenClaw has no per-workspace child process, so it does not implement the optional hook.

### Verification

- `bun test` — 1,553 passed, 4 skipped
- `bun run typecheck`
- Scoped `oxlint` on all changed files
- `bun run format:check` on all changed files
- `git diff --check`

The repository-wide lint hook is currently blocked by unrelated React lint errors present on fresh `main`; no changed server file reports a lint error.
