### PR TITLE
Fix silent moi init no-op on Windows

### DIFF
--- a/server/registry.test.ts
+++ b/server/registry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'path'
 
@@ -211,6 +211,16 @@ describe('listWorkspaces', () => {
     expect(list).toHaveLength(2)
     expect(list.map(e => e.path)).toContain('/Users/foo/project-a')
     expect(list.map(e => e.path)).toContain('/Users/foo/project-b')
+  })
+})
+
+describe('readRegistry', () => {
+  test('creates the parent directory on first read, before any write', async () => {
+    // Regression test for a Windows-only hang when the parent dir is missing.
+    const dataDir = join(tmpDir, 'nested', 'deeper')
+    setRegistryPath(join(dataDir, 'workspaces.json'))
+    expect(await listWorkspaces()).toEqual([])
+    expect((await stat(dataDir)).isDirectory()).toBe(true)
   })
 })
 

--- a/server/registry.ts
+++ b/server/registry.ts
@@ -1,6 +1,6 @@
-import { rename, rm } from 'node:fs/promises'
+import { mkdir, rename, rm } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join, resolve, sep } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 
 import { newWorkspaceId, validateWorkspaceId } from '@/lib/ids'
 import type { DiscoveredWorkspace, WorkspaceEntry, WorkspaceType } from '@/lib/types'
@@ -35,6 +35,9 @@ export function setRegistryPath(p: string) {
 
 async function readRegistry(): Promise<WorkspaceEntry[]> {
   try {
+    // On some Windows/Bun setups, Bun.file(...).text() never settles when the
+    // parent directory is missing (instead of rejecting with ENOENT).
+    await mkdir(dirname(_registryPath), { recursive: true })
     const text = await Bun.file(_registryPath).text()
     return JSON.parse(text) as WorkspaceEntry[]
   } catch {


### PR DESCRIPTION
##  Fix silent moi init no-op on Windows

moi init reads the workspace registry before it ever writes one. On some Windows/Bun setups, reading a file whose parent directory doesn't exist never settles, it neither resolves nor rejects, instead of rejecting with ENOENT. With nothing else keeping the event loop alive, the process  just exits, so every first-ever moi init on a fresh install silently no-ops: exit code 0, no output, no workspace registered.

**Before:** fresh install → moi start → moi init completes instantly with no output and registers nothing.
**After:** the registry read ensures its parent directory exists first, so it reliably resolves (to [] on a fresh install) and moi init runs to completion.

### Review notes
readRegistry() now creates dirname(_registryPath) before calling Bun.file(...).text(), mirroring what writeRegistry() already does before its write. Added a regression test asserting listWorkspaces() succeeds and creates the parent directory when it's missing several levels deep.

### Verification
  - bun test — 1,479 passed, 61 failed, 4 errors (pre-existing Windows path-separator failures on fresh main; none touch registry.ts)
  - bun test server/registry.test.ts — 24 passed (up from 23; same pre-existing failures as on main)
  - bun run typecheck
  - Scoped oxlint on both changed files
  - Scoped format:check on both changed files
  - git diff --check on both changed files
