### PR TITLE
Rename tab focus command to tabs focus

### DIFF
--- a/client/features/applets/useApplet.ts
+++ b/client/features/applets/useApplet.ts
@@ -17,7 +17,7 @@ import { type WorkspaceEvent, useWorkspaceEvent } from '@/client/runtime/useWork
 import type { AppletKind } from '@/lib/types'
 
 // The props the host passes to a mounted applet component. Views receive
-// `params` from navigation state (focusTab / `moi tab focus` → the URL's
+// `params` from navigation state (focusTab / `moi tabs focus` → the URL's
 // history entry — see ViewApp in WorkspaceScreen.tsx); widgets are mounted
 // bare, so the applet must render sensibly with `params` absent.
 export type AppletComponentProps = {

--- a/client/features/views/ViewManager.tsx
+++ b/client/features/views/ViewManager.tsx
@@ -44,7 +44,7 @@ type ViewManagerProps = {
   // agent or widgets tab instant too.
   activeViewId: string | null
   // The active view's addressable state, read from navigation state (focusTab /
-  // `moi tab focus`). `{}` on a fresh mount, a new browser tab, or a plain
+  // `moi tabs focus`). `{}` on a fresh mount, a new browser tab, or a plain
   // tab-bar click — a view must render sensibly with that.
   params: Record<string, unknown>
 }

--- a/client/features/workspace/WorkspaceScreen.tsx
+++ b/client/features/workspace/WorkspaceScreen.tsx
@@ -423,7 +423,7 @@ export function WorkspaceScreen({ widgets, views, builders }: WorkspaceScreenPro
   // resolves to the default like any dead URL.
   useAppletEvent(workspaceId, 'focusTab', openTab)
 
-  // `moi tab focus` — a workspace event, not an applet call: the control
+  // `moi tabs focus` — a workspace event, not an applet call: the control
   // server validated the target and params before publishing.
   useWorkspaceEvent(event => {
     if (event.type === 'tab:focus' && event.workspaceId === workspaceId) {

--- a/client/features/workspace/useWorkspaceNavigation.ts
+++ b/client/features/workspace/useWorkspaceNavigation.ts
@@ -5,7 +5,7 @@
 //
 // Everything that merely reacts to navigation stays with the screen: tab-bar
 // policy (close, reorder, availability pruning), view-builder lifecycle, the
-// applet-runtime `focusTab` subscription, and the `moi tab focus` subscription.
+// applet-runtime `focusTab` subscription, and the `moi tabs focus` subscription.
 // They all route through the `navigateToTab` returned here, so every origin —
 // tab click, applet, CLI — shares one code path.
 import { useCallback, useEffect, useMemo } from 'react'

--- a/client/runtime/useWorkspaceEvents.ts
+++ b/client/runtime/useWorkspaceEvents.ts
@@ -45,7 +45,7 @@ export type WorkspaceEvent =
   // App settings changed (PATCH /api/settings from any client) — carries the
   // new value so caches update without a refetch.
   | { type: 'settings:updated'; settings: AppSettings }
-  // `moi tab focus` — every open client of `workspaceId` navigates (replace)
+  // `moi tabs focus` — every open client of `workspaceId` navigates (replace)
   // to `tab`, delivering `params` to the target view via navigation state.
   | {
       type: 'tab:focus'

--- a/docs/rfc-intents-v2.md
+++ b/docs/rfc-intents-v2.md
@@ -48,8 +48,8 @@ workspace's **default tab**, not live focus state.
 ## 3. Commands
 
 ```
-moi tabs            # alias: moi tab — all tabs, one per row, the default one marked
-moi tab focus <tab-id> [--params '<json-object>']
+moi tabs            # all tabs, one per row, the default one marked
+moi tabs focus <tab-id> [--params '<json-object>']
 ```
 
 `moi tabs` output (colors omitted):
@@ -64,11 +64,11 @@ moi tabs — workspace tabs, the default one marked
      view:orders  Orders
      view:shop    Shop
 
-  Focus one: moi tab focus <tab-id> [--params '{"k":"v"}']
+  Focus one: moi tabs focus <tab-id> [--params '{"k":"v"}']
 ```
 
 - `moi tabs` prints tab id + title; the marked row is the saved default (`layout.tabs.active`).
-- `moi tab focus` validates the tab id server-side (unknown id fails listing the valid ids), then
+- `moi tabs focus` validates the tab id server-side (unknown id fails listing the valid ids), then
   publishes a workspace-scoped `tab:focus` event; every connected client of that workspace
   navigates (replace) with the params in navigation state. Addressing is by **tab id**, never by
   title — titles are ambiguous and rename.
@@ -213,7 +213,7 @@ The word "intent" stays out of the API: the focus event is `tab:focus`, the enve
 
 - **MVP 1 — tab foundation (first PR):** the working end-to-end core and nothing else. URL-routed
   tabs with replace-only navigation and the default redirect; the `params` prop delivered to
-  views from navigation state; `focusTab` in the `moi` module; `moi tabs` / `moi tab focus` CLI
+  views from navigation state; `focusTab` in the `moi` module; `moi tabs` / `moi tabs focus` CLI
   with the `tab:focus` event. Explicitly out: skill changes, `sendChatMessage`, envelope changes,
   dead-URL journaling.
 - **MVP 2 — chat messaging (implemented):** `sendChatMessage` + the `# Applet message` envelope
@@ -224,6 +224,6 @@ The word "intent" stays out of the API: the focus event is `tab:focus`, the enve
 - **MVP 3 — authoring (skill guidance done):** the workspace skill now documents the API —
   `SKILL.md` gained a "Driving the workspace" section (`focusTab`, `sendChatMessage`, the render-time
   ban and rate limits, the `Params` type convention with the read-the-source rule) plus `moi tabs` /
-  `moi tab focus` in its CLI list, and the skill version marker moved to `0.9.0` so installed
+  `moi tabs focus` in its CLI list, and the skill version marker moved to `0.9.0` so installed
   workspace copies are prompted to update. Still open: folding the surviving parts of this RFC into
   permanent docs.

--- a/lib/workspace-tabs.ts
+++ b/lib/workspace-tabs.ts
@@ -32,7 +32,7 @@ export const viewBuilderTabId = (builderId: string): WorkspaceTabId => `view-bui
 export const viewBuilderIdFromTab = (tab: WorkspaceTabId): string | null =>
   tab.startsWith('view-builder:') ? tab.slice('view-builder:'.length) : null
 
-// The only params shape focusTab / `moi tab focus` carry: one JSON-plain
+// The only params shape focusTab / `moi tabs focus` carry: one JSON-plain
 // object. Arrays and null are valid JSON but not a params record.
 export function isParamsRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -2350,8 +2350,8 @@ const debug = defineCommand({
 
 // ---- workspace tabs ----------------------------------------------------------
 
-// The shared listing behind `moi tabs` and bare `moi tab`: every tab (static +
-// views), one per row, the saved default (`layout.tabs.active`) marked. The
+// The listing behind `moi tabs`: every tab (static + views), one per row, the
+// saved default (`layout.tabs.active`) marked. The
 // output shape is documented in docs/rfc-intents-v2.md §3 — keep them in sync.
 function runTabsList(dir: string) {
   const path = resolve(dir)
@@ -2372,7 +2372,7 @@ function runTabsList(dir: string) {
       )
     )
     console.log(
-      '\n' + pc.dim('  Focus one: moi tab focus <tab-id> [--params \'{"k":"v"}\']') + '\n'
+      '\n' + pc.dim('  Focus one: moi tabs focus <tab-id> [--params \'{"k":"v"}\']') + '\n'
     )
   })
 }
@@ -2416,25 +2416,20 @@ const tabFocus = defineCommand({
   }
 })
 
-const tabSubCommands = { focus: tabFocus }
+const tabsSubCommands = { focus: tabFocus }
 
-const tab = defineCommand({
-  meta: { name: 'tab', description: 'List workspace tabs, or focus one: `moi tab focus <tab-id>`' },
-  subCommands: tabSubCommands,
+const tabs = defineCommand({
+  meta: {
+    name: 'tabs',
+    description: 'List workspace tabs, or focus one: `moi tabs focus <tab-id>`'
+  },
+  subCommands: tabsSubCommands,
   args: { dir: dirArg },
   run({ args, rawArgs }) {
     // citty invokes the parent run even after dispatching a subcommand — only
     // list when none ran (same pattern as `moi env` / `moi skill`).
     const sub = rawArgs.find(a => !a.startsWith('-'))
-    if (sub && Object.hasOwn(tabSubCommands, sub)) return
-    runTabsList(args.dir)
-  }
-})
-
-const tabs = defineCommand({
-  meta: { name: 'tabs', description: 'List workspace tabs (alias for `moi tab`)' },
-  args: { dir: dirArg },
-  run({ args }) {
+    if (sub && Object.hasOwn(tabsSubCommands, sub)) return
     runTabsList(args.dir)
   }
 })
@@ -2828,7 +2823,7 @@ const service = defineCommand({
   subCommands: serviceSubCommands,
   async run({ rawArgs }) {
     // citty invokes the parent run even after dispatching a subcommand — only
-    // show status when none ran (same pattern as `moi env` / `moi tab`).
+    // show status when none ran (same pattern as `moi env` / `moi tabs`).
     const sub = rawArgs.find(a => !a.startsWith('-'))
     if (sub && Object.hasOwn(serviceSubCommands, sub)) return
     await runServiceStatus()
@@ -3051,7 +3046,6 @@ const workspaceCommands = {
   env,
   scratch,
   skill,
-  tab,
   tabs,
   'ui-components': uiComponents
 }

--- a/server/control.ts
+++ b/server/control.ts
@@ -295,7 +295,7 @@ export const control = Bun.serve({
           return
         }
 
-        // The workspace tab listing — `moi tabs` (and bare `moi tab`).
+        // The workspace tab listing — `moi tabs`.
         if (data.type === 'tabs') {
           const match = await resolveWorkspace(ws, data.path)
           if (!match) return
@@ -307,7 +307,7 @@ export const control = Bun.serve({
           return
         }
 
-        // `moi tab focus <tab-id>` — validate the target, then publish a
+        // `moi tabs focus <tab-id>` — validate the target, then publish a
         // workspace-scoped `tab:focus` event. Every connected client of that
         // workspace navigates (replace) with the params in navigation state.
         if (data.type === 'tab:focus') {

--- a/server/harness/codex/permissions.ts
+++ b/server/harness/codex/permissions.ts
@@ -19,7 +19,7 @@ export const CODEX_TURN_ACCESS = {
 } as const
 
 const CODEX_LOCAL_CONTROL_GUIDANCE =
-  'Commands that contact the moi control server, including moi tabs, bundle, tab, debug, call-server-fn, theme, and config, need localhost network access. Run them with sandbox_permissions set to require_escalated on the first attempt so moi can approve the escalated request. A connection failure from a sandboxed attempt does not prove the control server is offline.'
+  'Commands that contact the moi control server, including moi tabs, bundle, debug, call-server-fn, theme, and config, need localhost network access. Run them with sandbox_permissions set to require_escalated on the first attempt so moi can approve the escalated request. A connection failure from a sandboxed attempt does not prove the control server is offline.'
 
 export const CODEX_LOCAL_CONTROL_CONTEXT = {
   'moi-control-access': {

--- a/server/tabs.ts
+++ b/server/tabs.ts
@@ -1,4 +1,4 @@
-// `moi tabs` / `moi tab focus` server logic: assemble the tab listing and
+// `moi tabs` / `moi tabs focus` server logic: assemble the tab listing and
 // validate a focus target. Pure given its inputs — the control handler wires
 // in the workspace lookups (see control.ts), tests pass fakes.
 import type { ViewInfo, WorkspaceTabId } from '@/lib/types'
@@ -38,7 +38,7 @@ type FocusTabDeps = {
 
 export type FocusTabResult = { ok: true; tab: WorkspaceTabId } | { ok: false; error: string }
 
-// Validate a `moi tab focus` target: static ids pass as-is, `view:<id>` must
+// Validate a `moi tabs focus` target: static ids pass as-is, `view:<id>` must
 // name a real view. Anything else — including view-builder tabs — fails with
 // the list of valid ids. Addressing is by tab id, never by title.
 export async function resolveFocusTab(raw: unknown, deps: FocusTabDeps): Promise<FocusTabResult> {

--- a/server/test/cli-help.test.ts
+++ b/server/test/cli-help.test.ts
@@ -22,8 +22,11 @@ describe('isAgentCaller', () => {
   })
 })
 
-async function runHelp(envPatch: Record<string, string | undefined>): Promise<string> {
-  const proc = Bun.spawn(['bun', CLI, '--help'], {
+async function runHelp(
+  envPatch: Record<string, string | undefined>,
+  command?: string
+): Promise<string> {
+  const proc = Bun.spawn(['bun', CLI, ...(command ? [command] : []), '--help'], {
     stdin: 'ignore',
     stdout: 'pipe',
     stderr: 'ignore',
@@ -63,5 +66,15 @@ describe('moi --help (e2e)', () => {
   test('third-party markers hide it too', async () => {
     const out = await runHelp({ CLAUDECODE: '1' })
     expect(out).not.toContain('System commands:')
+  }, 30_000)
+
+  test('tabs owns the focus subcommand without a singular alias', async () => {
+    const rootHelp = await runHelp({})
+    const tabsHelp = await runHelp({}, 'tabs')
+
+    expect(rootHelp).toContain('moi tabs focus <tab-id>')
+    expect(rootHelp).not.toMatch(/^\s+tab\s/m)
+    expect(tabsHelp).toContain('focus    Focus a workspace tab in every open client')
+    expect(tabsHelp).toContain('Use moi tabs <command> --help')
   }, 30_000)
 })

--- a/server/test/skills-template.test.ts
+++ b/server/test/skills-template.test.ts
@@ -30,6 +30,8 @@ describe('installBundledSkills', () => {
       expect(skillMd).toContain('moi theme --font=<key> --color=<key>')
       expect(skillMd).toContain('### Running commands with workspace env')
       expect(skillMd).toContain('moi env exec -- bun script.ts')
+      expect(skillMd).toContain('moi tabs focus')
+      expect(skillMd).not.toContain('moi tab focus')
       expect(await Bun.file(join(dir, CHEAT_SHEET)).exists()).toBe(true)
       // The rest of the skill installs normally.
       expect(skillMd).toContain('# Workspace')

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -126,7 +126,7 @@ Use the task-specific sections below for workflow guidance. The CLI will grow ov
 - **Develop applets:** `moi check`, `moi bundle`, and `moi refresh`.
 - **Call actions:** `moi call-server-fn`.
 - **Debug applets:** `moi debug logs` (see Debugging applets).
-- **Navigate the workspace:** `moi tabs` and `moi tab focus` (see Driving the workspace).
+- **Navigate the workspace:** `moi tabs` and `moi tabs focus` (see Driving the workspace).
 - **Customize the workspace:** `moi theme` and `moi config` (see Customizing workspace appearance).
 - **Use workspace env:** `moi env` and `moi env exec` (see Environment & secrets).
 - **Maintain workspace guidance:** `moi skill` (see Keeping this skill current).
@@ -383,8 +383,8 @@ unavailable, keep verification in the browser instead of retrying the unsupporte
 
 After the final successful checks, always make tab focus the final workspace action:
 
-- After building or editing a widget, run `moi tab focus widgets`.
-- After building or editing a view, run `moi tab focus view:<view-id>`, using its file name or claimed
+- After building or editing a widget, run `moi tabs focus widgets`.
+- After building or editing a view, run `moi tabs focus view:<view-id>`, using its file name or claimed
   builder id.
 
 The focused applet is the handoff. Keep the final reply brief and user-facing. Do not include file
@@ -478,4 +478,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.17.1" />
+<moi-skill version="0.18.0" />


### PR DESCRIPTION
The workspace tab CLI now uses one plural namespace: `moi tabs` lists tabs and `moi tabs focus` focuses one. The singular `moi tab` alias is removed, and help text, docs, comments, and bundled workspace guidance now use the same command.

```console
moi tabs
moi tabs focus view:orders --params '{"order":"o-1"}'
```

Review closely:

- `tabs` now owns the `focus` subcommand while preserving the parent-command guard that prevents a list after subcommand dispatch.
- The bundled workspace skill moves to v0.18.0 so existing workspaces are offered the corrected command guidance.
- Removing `moi tab` is intentionally breaking; root help tests assert that only the plural command is exposed.

Verified with:

- `bun test` — 1,569 passed, 4 skipped
- `bun run typecheck`
- `bun run lint` — passed with existing React warnings
- `bun run format:check`
