### PR TITLE
Report an unsupported Claude Code before the first message fails on auto permissions

### DIFF
--- a/server/harness/claude-code/NOTES.md
+++ b/server/harness/claude-code/NOTES.md
@@ -35,6 +35,20 @@ and version-manager shims. There is no SDK bundled-executable fallback. If the
 command is missing, setup and existing workspaces report:
 `Run curl -fsSL https://claude.ai/install.sh | sh in your terminal to install Claude`.
 
+**Spawn environment.** Every Claude Code subprocess builds its env through
+`claudeSpawnEnv()` in `spawn-env.ts` — chat sessions, the session-title run, the
+model catalog, the MCP probe, and the `auth status` / `auth login` spawns. It
+merges the caller's extra env (workspace env, `MOI_AGENT`,
+`DISABLE_AUTOUPDATER`) over `process.env` and always strips `CLAUDECODE`.
+Claude Code refuses to launch nested when that variable is set, and the server
+inherits it whenever moi is started from inside an agent session — which is
+what the install prompt does. Only the auth spawns were missing the strip, and
+because they also discarded stderr the refusal was invisible: the workspace sat
+on "Log in to your agent" and the login button did nothing. Both auth spawns
+now pipe stderr and print it as `[claude auth status stderr]` /
+`[claude auth login stderr]`, so any future refusal shows up in the server log.
+The exit-code mapping (0 logged in, 1 logged out) is unchanged.
+
 **In-place updates.** Claude Code can replace its binary at the same path
 while moi keeps running, changing which models are available.
 

--- a/server/harness/claude-code/NOTES.md
+++ b/server/harness/claude-code/NOTES.md
@@ -58,6 +58,16 @@ while moi keeps running, changing which models are available.
 - The model catalog (`models.ts`) is keyed by executable path and the first
   line of `claude --version`. Each lookup probes that identity again. Changes
   refetch the catalog; a failed version probe at the same path retains it.
+- Capabilities are asked of the CLI, not of its version number. Every session
+  runs `permissionMode: 'auto'`, and a CLI that doesn't accept it kills the
+  first message with `option '--permission-mode <mode>' argument 'auto' is
+invalid`. `capabilities.ts` parses the accepted choices out of
+  `claude --help` — one spawn per CLI identity, cached beside the catalog's —
+  and `availability` reports `Claude Code <version> doesn't support auto
+permissions. Run claude update` before the auth probe, so the composer shows
+  one reason. There is no version floor: the changelog does not date when
+  `auto` arrived and the Agent SDK declares no minimum. A failed or unreadable
+  probe is unknown and never blocks, same as a failed version probe.
 - On a changed identity, `index.ts` marks existing subprocesses `staleCli`
   (`retireCCSessionsOnCliChange`). Invalidation never interrupts work. Before
   the next message, the dispatcher waits for the current turn and background

--- a/server/harness/claude-code/auth.ts
+++ b/server/harness/claude-code/auth.ts
@@ -2,6 +2,7 @@ import type { HarnessAvailability, HarnessLogin } from '@/lib/types'
 
 import { resolveWorkspaceEnv } from '../../workspace-env'
 import { findHarnessExecutable } from '../executable'
+import { claudeSpawnEnv } from './spawn-env'
 
 function signedOut(reason: string): HarnessAvailability {
   return { status: 'login-required', reason }
@@ -17,6 +18,14 @@ type ClaudeAuthProbeResult = {
 }
 
 const CLAUDE_AUTH_UNAVAILABLE = 'Could not check the Claude login status'
+
+// Both auth spawns used to discard stderr, which hid the one failure that
+// matters most: Claude Code refusing to launch nested. Surface it the way the
+// session subprocess surfaces its own stderr.
+async function logAuthStderr(label: string, stream: ReadableStream<Uint8Array>): Promise<void> {
+  const text = (await Bun.readableStreamToText(stream)).trim()
+  if (text) console.error(`[claude ${label} stderr]`, text)
+}
 
 export function claudeAuthReadiness(result: ClaudeAuthProbeResult): HarnessAvailability {
   if (result.timedOut) return unavailable(CLAUDE_AUTH_UNAVAILABLE)
@@ -35,11 +44,12 @@ export async function getClaudeAuthReadiness(workspacePath: string): Promise<Har
   const workspaceEnv = await resolveWorkspaceEnv(workspacePath)
   const proc = Bun.spawn([executable, 'auth', 'status'], {
     cwd: workspacePath,
-    env: { ...process.env, ...workspaceEnv },
+    env: claudeSpawnEnv(workspaceEnv),
     stdin: 'ignore',
     stdout: 'ignore',
-    stderr: 'ignore'
+    stderr: 'pipe'
   })
+  const stderrLogged = logAuthStderr('auth status', proc.stderr)
   let timedOut = false
   const timeout = setTimeout(() => {
     timedOut = true
@@ -47,6 +57,7 @@ export async function getClaudeAuthReadiness(workspacePath: string): Promise<Har
   }, 5_000)
   try {
     const exitCode = await proc.exited
+    await stderrLogged
     return claudeAuthReadiness({ exitCode, timedOut })
   } finally {
     clearTimeout(timeout)
@@ -58,12 +69,14 @@ export async function startClaudeLogin(workspacePath: string): Promise<HarnessLo
   if (!executable) throw new Error('Claude is not installed')
 
   const workspaceEnv = await resolveWorkspaceEnv(workspacePath)
-  Bun.spawn([executable, 'auth', 'login'], {
+  const proc = Bun.spawn([executable, 'auth', 'login'], {
     cwd: workspacePath,
-    env: { ...process.env, ...workspaceEnv },
+    env: claudeSpawnEnv(workspaceEnv),
     stdin: 'ignore',
     stdout: 'ignore',
-    stderr: 'ignore'
-  }).unref()
+    stderr: 'pipe'
+  })
+  void logAuthStderr('auth login', proc.stderr)
+  proc.unref()
   return {}
 }

--- a/server/harness/claude-code/capabilities.test.ts
+++ b/server/harness/claude-code/capabilities.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ClaudeCli } from './cli'
+import {
+  type ClaudeCapabilities,
+  autoPermissionsAvailability,
+  createClaudeCapabilityCache,
+  parseAutoPermissionMode,
+  parsePermissionModes
+} from './capabilities'
+
+// Verbatim from `env -u CLAUDECODE claude --help` on 2.1.263, wrapping included.
+const HELP_WITH_AUTO = `Usage: claude [options] [command] [prompt]
+
+Options:
+  --output-format <format>              Output format (only works with --print)
+                                        (choices: "text", "json",
+                                        "stream-json")
+  --permission-mode <mode>              Permission mode to use for the session
+                                        (choices: "acceptEdits", "auto",
+                                        "bypassPermissions", "manual",
+                                        "dontAsk", "plan")
+  --permission-prompts <target>         Who answers permission prompts
+`
+
+// The 2.1.45 lineup, as quoted by the error the first message produced.
+const HELP_WITHOUT_AUTO = `Options:
+  --permission-mode <mode>              Permission mode to use for the session
+                                        (choices: "acceptEdits",
+                                        "bypassPermissions", "default",
+                                        "delegate", "dontAsk", "plan")
+`
+
+describe('parsePermissionModes', () => {
+  test('reads the choices across wrapped lines', () => {
+    expect(parsePermissionModes(HELP_WITH_AUTO)).toEqual([
+      'acceptEdits',
+      'auto',
+      'bypassPermissions',
+      'manual',
+      'dontAsk',
+      'plan'
+    ])
+  })
+
+  test('ignores the choices of earlier flags', () => {
+    expect(parsePermissionModes(HELP_WITH_AUTO)).not.toContain('stream-json')
+  })
+
+  test('returns null when the flag or its choices are missing', () => {
+    expect(parsePermissionModes('')).toBeNull()
+    expect(parsePermissionModes('  --print   Print the response\n')).toBeNull()
+    expect(parsePermissionModes('  --permission-mode <mode>  Permission mode\n')).toBeNull()
+    expect(parsePermissionModes('--permission-mode (choices: acceptEdits, plan)')).toBeNull()
+  })
+})
+
+describe('parseAutoPermissionMode', () => {
+  test('accepts a CLI that lists auto', () => {
+    expect(parseAutoPermissionMode(HELP_WITH_AUTO)).toBe(true)
+  })
+
+  test('rejects a CLI that does not list auto', () => {
+    expect(parseAutoPermissionMode(HELP_WITHOUT_AUTO)).toBe(false)
+  })
+
+  test('stays unknown for garbage input', () => {
+    expect(parseAutoPermissionMode('')).toBeNull()
+    expect(parseAutoPermissionMode('  not help text at all')).toBeNull()
+  })
+})
+
+const EXECUTABLE = '/usr/local/bin/claude'
+const OLD_CLI: ClaudeCli = { executable: EXECUTABLE, version: '2.1.45 (Claude Code)' }
+const NEW_CLI: ClaudeCli = { executable: EXECUTABLE, version: '2.1.263 (Claude Code)' }
+
+const SUPPORTED: ClaudeCapabilities = { autoPermissionMode: true }
+const UNSUPPORTED: ClaudeCapabilities = { autoPermissionMode: false }
+const UNKNOWN: ClaudeCapabilities = { autoPermissionMode: null }
+
+// A capability cache whose CLI identity and `--help` answers are scripted.
+function scriptedCache(script: { probes: ClaudeCli[]; capabilities: ClaudeCapabilities[] }) {
+  let probeCalls = 0
+  let inspectCalls = 0
+  const cache = createClaudeCapabilityCache({
+    probe: async () => {
+      const cli = script.probes[probeCalls] ?? script.probes[script.probes.length - 1]
+      probeCalls += 1
+      if (!cli) throw new Error('no scripted probe')
+      return cli
+    },
+    inspect: async () => {
+      const capabilities =
+        script.capabilities[inspectCalls] ?? script.capabilities[script.capabilities.length - 1]
+      inspectCalls += 1
+      if (!capabilities) throw new Error('no scripted capabilities')
+      return capabilities
+    }
+  })
+  return { cache, inspectCalls: () => inspectCalls }
+}
+
+describe('createClaudeCapabilityCache', () => {
+  test('runs one help probe per CLI identity', async () => {
+    const { cache, inspectCalls } = scriptedCache({
+      probes: [OLD_CLI],
+      capabilities: [UNSUPPORTED]
+    })
+
+    expect((await cache.get(EXECUTABLE)).capabilities).toEqual(UNSUPPORTED)
+    expect((await cache.get(EXECUTABLE)).capabilities).toEqual(UNSUPPORTED)
+    expect(inspectCalls()).toBe(1)
+    expect(cache.current()).toEqual(UNSUPPORTED)
+  })
+
+  test('re-probes when the CLI identity changes', async () => {
+    const { cache, inspectCalls } = scriptedCache({
+      probes: [OLD_CLI, NEW_CLI],
+      capabilities: [UNSUPPORTED, SUPPORTED]
+    })
+
+    expect((await cache.get(EXECUTABLE)).capabilities).toEqual(UNSUPPORTED)
+    expect((await cache.get(EXECUTABLE)).capabilities).toEqual(SUPPORTED)
+    expect(inspectCalls()).toBe(2)
+  })
+
+  test('keeps the cached answer while the version probe fails', async () => {
+    const unknownCli: ClaudeCli = { executable: EXECUTABLE, version: null }
+    const { cache, inspectCalls } = scriptedCache({
+      probes: [OLD_CLI, unknownCli],
+      capabilities: [UNSUPPORTED, SUPPORTED]
+    })
+
+    const first = await cache.get(EXECUTABLE)
+    const second = await cache.get(EXECUTABLE)
+
+    expect(second.capabilities).toEqual(first.capabilities)
+    expect(second.cli).toEqual(OLD_CLI)
+    expect(inspectCalls()).toBe(1)
+  })
+})
+
+describe('autoPermissionsAvailability', () => {
+  test('names the version moi cannot use', async () => {
+    const { cache } = scriptedCache({ probes: [OLD_CLI], capabilities: [UNSUPPORTED] })
+
+    expect(autoPermissionsAvailability(await cache.get(EXECUTABLE))).toEqual({
+      status: 'unavailable',
+      reason: "Claude Code 2.1.45 doesn't support auto permissions. Run claude update"
+    })
+  })
+
+  test('does not block a supported CLI', async () => {
+    const { cache } = scriptedCache({ probes: [NEW_CLI], capabilities: [SUPPORTED] })
+
+    expect(autoPermissionsAvailability(await cache.get(EXECUTABLE))).toBeNull()
+  })
+
+  test('does not block when the probe came back unknown', async () => {
+    const { cache } = scriptedCache({ probes: [NEW_CLI], capabilities: [UNKNOWN] })
+
+    expect(autoPermissionsAvailability(await cache.get(EXECUTABLE))).toBeNull()
+  })
+
+  test('still reports an unsupported CLI whose version is unknown', () => {
+    expect(
+      autoPermissionsAvailability({
+        cli: { executable: EXECUTABLE, version: null },
+        capabilities: UNSUPPORTED
+      })
+    ).toEqual({
+      status: 'unavailable',
+      reason: "This Claude Code doesn't support auto permissions. Run claude update"
+    })
+  })
+})

--- a/server/harness/claude-code/capabilities.ts
+++ b/server/harness/claude-code/capabilities.ts
@@ -1,0 +1,155 @@
+// What the installed `claude` accepts, asked of the CLI itself rather than
+// compared against a version floor: the changelog does not date when `auto`
+// arrived and the Agent SDK declares no minimum, so the only honest source is
+// the binary's own `--help`.
+import type { HarnessAvailability } from '@/lib/types'
+
+import { requireHarnessExecutable } from '../executable'
+import { type ClaudeCli, claudeCliKey, probeClaudeCli } from './cli'
+
+const HELP_PROBE_TIMEOUT_MS = 5_000
+
+export type ClaudeCapabilities = {
+  // `null` when the probe failed or the help text could not be read: unknown
+  // never blocks a send.
+  autoPermissionMode: boolean | null
+}
+
+export const UNKNOWN_CLAUDE_CAPABILITIES: ClaudeCapabilities = { autoPermissionMode: null }
+
+// `claude --help` lists the accepted values inline, wrapped across lines:
+//
+//   --permission-mode <mode>   Permission mode to use for the session
+//                              (choices: "acceptEdits", "auto",
+//                              "bypassPermissions", "manual", "dontAsk", "plan")
+//
+// Returns null when the flag or its choices are absent, so an unreadable help
+// text stays unknown instead of reading as "auto is unsupported".
+export function parsePermissionModes(help: string): string[] | null {
+  const flag = help.indexOf('--permission-mode')
+  if (flag === -1) return null
+  const start = help.indexOf('(choices:', flag)
+  if (start === -1) return null
+  const end = help.indexOf(')', start)
+  if (end === -1) return null
+  const modes = [...help.slice(start, end).matchAll(/"([^"]+)"/g)].map(match => match[1] as string)
+  return modes.length > 0 ? modes : null
+}
+
+export function parseAutoPermissionMode(help: string): boolean | null {
+  const modes = parsePermissionModes(help)
+  return modes ? modes.includes('auto') : null
+}
+
+export async function probeClaudeCapabilities(executable: string): Promise<ClaudeCapabilities> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    const proc = Bun.spawn([executable, '--help'], {
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: { ...process.env, CLAUDECODE: undefined }
+    })
+    timeout = setTimeout(() => proc.kill(), HELP_PROBE_TIMEOUT_MS)
+    const [output, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    if (exitCode !== 0) return UNKNOWN_CLAUDE_CAPABILITIES
+    return { autoPermissionMode: parseAutoPermissionMode(output) }
+  } catch {
+    return UNKNOWN_CLAUDE_CAPABILITIES
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export type ClaudeCapabilityCacheOptions = {
+  probe: (executable: string) => Promise<ClaudeCli>
+  inspect: (executable: string) => Promise<ClaudeCapabilities>
+}
+
+export type ProbedClaudeCapabilities = {
+  cli: ClaudeCli
+  capabilities: ClaudeCapabilities
+}
+
+type CapabilityEntry = {
+  key: string
+  cli: ClaudeCli
+  capabilities: Promise<ClaudeCapabilities>
+  // Settled value, for the synchronous diagnostics read.
+  settled?: ClaudeCapabilities
+}
+
+// One `--help` spawn per CLI identity, the same shape the model catalog uses:
+// re-probe the identity on every lookup, reuse the cached answer while it
+// matches, and keep the cached answer when the version probe itself fails.
+export function createClaudeCapabilityCache(options: ClaudeCapabilityCacheOptions) {
+  let entry: CapabilityEntry | null = null
+
+  function store(cli: ClaudeCli): CapabilityEntry {
+    const capabilities = options.inspect(cli.executable).catch(err => {
+      if (entry?.capabilities === capabilities) entry = null
+      throw err
+    })
+    const next: CapabilityEntry = { key: claudeCliKey(cli), cli, capabilities }
+    entry = next
+    return next
+  }
+
+  async function settle(current: CapabilityEntry): Promise<ProbedClaudeCapabilities> {
+    const capabilities = await current.capabilities
+    current.settled = capabilities
+    return { cli: current.cli, capabilities }
+  }
+
+  async function get(executable: string): Promise<ProbedClaudeCapabilities> {
+    const cli = await options.probe(executable)
+    const current = entry
+    if (current) {
+      if (current.key === claudeCliKey(cli)) return settle(current)
+      // A failed version probe says nothing about the CLI: keep the answer we
+      // already have instead of spawning another `--help`.
+      if (cli.version === null && current.cli.executable === executable) return settle(current)
+    }
+    return settle(store(cli))
+  }
+
+  // Cached answer for diagnostics; availability checks still need `get`.
+  function current(): ClaudeCapabilities | undefined {
+    return entry?.settled
+  }
+
+  return { get, current }
+}
+
+const capabilities = createClaudeCapabilityCache({
+  probe: probeClaudeCli,
+  inspect: probeClaudeCapabilities
+})
+
+export const lastProbedClaudeCapabilities = capabilities.current
+
+function versionLabel(cli: ClaudeCli): string {
+  const version = cli.version?.split(/\s+/)[0]
+  return version ? `Claude Code ${version}` : 'This Claude Code'
+}
+
+export function autoPermissionsAvailability(
+  probed: ProbedClaudeCapabilities
+): HarnessAvailability | null {
+  if (probed.capabilities.autoPermissionMode !== false) return null
+  return {
+    status: 'unavailable',
+    reason: `${versionLabel(probed.cli)} doesn't support auto permissions. Run claude update`
+  }
+}
+
+// A CLI that cannot report its capabilities is not a CLI we block.
+export async function getClaudeAutoPermissionsReadiness(): Promise<HarnessAvailability | null> {
+  try {
+    return autoPermissionsAvailability(
+      await capabilities.get(requireHarnessExecutable('claude-code'))
+    )
+  } catch {
+    return null
+  }
+}

--- a/server/harness/claude-code/index.ts
+++ b/server/harness/claude-code/index.ts
@@ -7,6 +7,7 @@ import type { McpServer } from '@/lib/types'
 import type { DiscoveredWorkspaceCandidate, Harness } from '../types'
 import { findHarnessExecutable, pathHarnessAvailability } from '../executable'
 import { getClaudeAuthReadiness, startClaudeLogin } from './auth'
+import { getClaudeAutoPermissionsReadiness, lastProbedClaudeCapabilities } from './capabilities'
 import { isLinkedGitWorktree } from './git-worktree'
 import { getMcpStatus } from './mcp'
 import { getClaudeModels, lastProbedClaudeCli, onClaudeCliChanged } from './models'
@@ -105,7 +106,13 @@ export const claudeCodeHarness: Harness = {
   discoverWorkspaces,
   availability: async ws => {
     const runtime = await pathHarnessAvailability('claude-code')
-    return runtime.status === 'available' && ws ? getClaudeAuthReadiness(ws.path) : runtime
+    if (runtime.status !== 'available') return runtime
+    // Every session runs with `permissionMode: 'auto'`. A CLI that rejects it
+    // fails on the first message, so report it here instead — before the auth
+    // probe, so there is one reason to act on.
+    const permissions = await getClaudeAutoPermissionsReadiness()
+    if (permissions) return permissions
+    return ws ? getClaudeAuthReadiness(ws.path) : runtime
   },
   startLogin: ws => startClaudeLogin(ws.path),
 
@@ -119,7 +126,8 @@ export const claudeCodeHarness: Harness = {
     const busy = cc.sessions.filter(s => s.activity !== 'idle').length
     const lines = [
       `claude executable  ${findHarnessExecutable('claude-code') ?? '(not found)'}` +
-        `  (${lastProbedClaudeCli()?.version ?? 'version not probed yet'})`,
+        `  (${lastProbedClaudeCli()?.version ?? 'version not probed yet'}` +
+        `${lastProbedClaudeCapabilities()?.autoPermissionMode === false ? ', no auto permission mode' : ''})`,
       `live CC sessions  ${cc.sessions.length}/${SESSION_LIMITS.maxLive}  ` +
         `(${busy} busy, ${cc.sessions.length - busy} idle, ${cc.aliases} alias${cc.aliases === 1 ? '' : 'es'}, ` +
         `idle TTL ${fmtDuration(SESSION_LIMITS.idleTtlMs)})`

--- a/server/harness/claude-code/mcp.ts
+++ b/server/harness/claude-code/mcp.ts
@@ -3,6 +3,7 @@ import type { McpServerStatus, SDKUserMessage } from '@anthropic-ai/claude-agent
 
 import { debugEnabled } from '../../debug'
 import { requireHarnessExecutable } from '../executable'
+import { claudeSpawnEnv } from './spawn-env'
 
 // MCP server status probing. Intentionally decoupled from agent chat runs
 // (cc-session.ts): connecting to MCP servers and reading their status is a
@@ -64,7 +65,7 @@ async function probeMcpStatus(workspacePath: string): Promise<McpServerStatus[]>
       pathToClaudeCodeExecutable: requireHarnessExecutable('claude-code'),
       persistSession: false,
       settingSources: ['user', 'project'],
-      env: { ...process.env, CLAUDECODE: undefined }
+      env: claudeSpawnEnv()
     }
   })
 

--- a/server/harness/claude-code/models.ts
+++ b/server/harness/claude-code/models.ts
@@ -5,6 +5,7 @@ import type { Model } from '@/lib/types'
 
 import { requireHarnessExecutable } from '../executable'
 import { type ClaudeCli, claudeCliKey, probeClaudeCli } from './cli'
+import { claudeSpawnEnv } from './spawn-env'
 
 // The metadata query needs a cwd; its catalog is cached across workspaces.
 async function fetchClaudeModels(cwd: string, executable: string): Promise<ModelInfo[]> {
@@ -15,7 +16,7 @@ async function fetchClaudeModels(cwd: string, executable: string): Promise<Model
       pathToClaudeCodeExecutable: executable,
       persistSession: false,
       settingSources: ['user', 'project'],
-      env: { ...process.env, CLAUDECODE: undefined }
+      env: claudeSpawnEnv()
     }
   })
   const models = await q.supportedModels()

--- a/server/harness/claude-code/session-title.ts
+++ b/server/harness/claude-code/session-title.ts
@@ -10,6 +10,7 @@ import {
   runSessionTitleCommand
 } from '../session-title'
 import { requireHarnessExecutable } from '../executable'
+import { claudeSpawnEnv } from './spawn-env'
 
 export function claudeSessionTitleCommand(executable: string): string[] {
   return [
@@ -67,7 +68,7 @@ export async function generateClaudeSessionTitle(input: {
       cwd: tempDir,
       stdin: JSON.stringify({ sessionTitleSource: input.source }),
       signal: input.abortController.signal,
-      env: { ...process.env, CLAUDECODE: undefined, DISABLE_AUTOUPDATER: '1' }
+      env: claudeSpawnEnv({ DISABLE_AUTOUPDATER: '1' })
     })
     return output ? parseClaudeSessionTitleOutput(output) : null
   } finally {

--- a/server/harness/claude-code/session.ts
+++ b/server/harness/claude-code/session.ts
@@ -37,6 +37,7 @@ import {
 import { resolveWorkspaceEnv } from '../../workspace-env'
 import { requireHarnessExecutable } from '../executable'
 import type { SendMessageInput } from '../types'
+import { claudeSpawnEnv } from './spawn-env'
 
 // Media types Claude vision accepts; uploads.ts guarantees every image upload is
 // normalized to one of these, so the cast on `media_type` below is sound.
@@ -664,7 +665,7 @@ function createLiveSession(input: {
     settingSources: ['user', 'project'],
     // MOI_AGENT marks every shell this session spawns as agent-driven (the
     // moi CLI reads it — see agent-caller.ts), surviving the CLAUDECODE strip.
-    env: { ...process.env, ...input.workspaceEnv, CLAUDECODE: undefined, MOI_AGENT: '1' },
+    env: claudeSpawnEnv({ ...input.workspaceEnv, MOI_AGENT: '1' }),
     stderr: (data: string) => console.error('[SDK stderr]', data)
   }
   if (!input.isNew) options.resume = input.sessionId

--- a/server/harness/claude-code/spawn-env.test.ts
+++ b/server/harness/claude-code/spawn-env.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+
+import { claudeSpawnEnv } from './spawn-env'
+
+const parentEnv = { PATH: '/usr/bin', CLAUDECODE: '1', HOME: '/home/tom' }
+
+test('drops CLAUDECODE inherited from a moi server started inside Claude Code', () => {
+  const env = claudeSpawnEnv({}, parentEnv)
+  expect(env.CLAUDECODE).toBeUndefined()
+  expect('CLAUDECODE' in env).toBe(true)
+  expect(env.PATH).toBe('/usr/bin')
+})
+
+test('keeps workspace env keys alongside the parent env', () => {
+  const env = claudeSpawnEnv({ ANTHROPIC_API_KEY: 'sk-test' }, parentEnv)
+  expect(env.ANTHROPIC_API_KEY).toBe('sk-test')
+  expect(env.HOME).toBe('/home/tom')
+})
+
+test('lets workspace env override the parent env', () => {
+  const env = claudeSpawnEnv({ HOME: '/workspace' }, parentEnv)
+  expect(env.HOME).toBe('/workspace')
+})
+
+test('preserves the extra keys callers add next to the workspace env', () => {
+  const env = claudeSpawnEnv({ MOI_AGENT: '1', DISABLE_AUTOUPDATER: '1' }, parentEnv)
+  expect(env.MOI_AGENT).toBe('1')
+  expect(env.DISABLE_AUTOUPDATER).toBe('1')
+  expect(env.CLAUDECODE).toBeUndefined()
+})
+
+test('never lets a caller reinstate CLAUDECODE', () => {
+  expect(claudeSpawnEnv({ CLAUDECODE: '1' }, parentEnv).CLAUDECODE).toBeUndefined()
+})

--- a/server/harness/claude-code/spawn-env.ts
+++ b/server/harness/claude-code/spawn-env.ts
@@ -1,0 +1,13 @@
+// Every Claude Code subprocess — chat sessions, the session-title run, the
+// model catalog, the MCP probe, and the auth status/login spawns — builds its
+// environment here. `CLAUDECODE` is set inside a Claude Code session, and moi
+// is often started from one (the INSTALL.md prompt does exactly that), so the
+// server inherits it. Claude Code refuses to launch nested with that variable
+// present, so it is always stripped; anything a caller passes in `extraEnv`
+// (workspace env, `MOI_AGENT`, `DISABLE_AUTOUPDATER`) is applied first.
+export function claudeSpawnEnv(
+  extraEnv: Record<string, string | undefined> = {},
+  parentEnv: Record<string, string | undefined> = process.env
+): Record<string, string | undefined> {
+  return { ...parentEnv, ...extraEnv, CLAUDECODE: undefined }
+}


### PR DESCRIPTION

A Claude Code CLI that predates `--permission-mode auto` (an npm-global install from February, never auto-updated, first on the login-shell PATH) fails moi twice with no usable message: `claude auth status` refuses to run nested under the `CLAUDECODE=1` that `moi start` inherits from the agent that ran it, so the workspace reports "signed out" forever; and once past that, the first message dies with a raw `error: option '--permission-mode <mode>' argument 'auto' is invalid`. Neither names the cause. The harness now probes what the resolved CLI accepts, keyed on the same CLI identity the model catalog already tracks, and reports one availability reason before the auth probe runs. Every Claude Code spawn also builds its env through one helper (the two auth spawns were the only ones still passing `CLAUDECODE` through, against the intent in their own comment), and the auth spawns log stderr instead of discarding it.

Server started with `CLAUDECODE=1` and Claude Code 2.1.45 first on the login-shell PATH, user signed in — `GET /api/workspaces/<id>/agent` → `availability`:

```
before  {'status': 'login-required', 'reason': 'Claude is signed out. Sign in to send messages'}
after   {'status': 'unavailable', 'reason': "Claude Code 2.1.45 doesn't support auto permissions. Run claude update"}
        moi status: claude executable  …/claude  (2.1.45 (Claude Code), no auto permission mode)
```

With any CLI from 2.1.100 up, before and after both report `available`; the nested-launch refusal and the missing `auto` mode are both pre-2.1.100 (bisected on 2.1.45, 2.1.80, 2.1.100, 2.1.150, 2.1.200, 2.1.245, 2.1.260–268). Details in `server/harness/claude-code/NOTES.md` → "Runtime executable".

**Look closely at**

- `capabilities.ts` parses the `(choices: …)` list after `--permission-mode` in `claude --help`. No version constant: the changelog doesn't date `auto`, the SDK declares no minimum, and the accepted set itself drifts (2.1.263 lists `manual`, 2.1.45 lists `delegate`). A failed or timed-out probe is *unknown* and never blocks, same policy as the version probe.
- The check sits before `getClaudeAuthReadiness` in `index.ts`, so an old *and* signed-out CLI shows the update reason rather than a login button that can't help. It's one extra `claude --help` spawn per CLI identity change; the identity cache is separate from the catalog's, so `/agent` costs two `--version` probes instead of one — sharing them means threading a `cwd` the availability path doesn't have, so I left that as a follow-up.
- `auth.ts` now pipes stderr and prints it unconditionally (`[claude auth status stderr]`), modelled on `[SDK stderr]` in `session.ts`, since the defect was a silent one. The `auth login` drain is fire-and-forget on an unref'd process.

**Verified**: `bun test server/harness` 438 pass / 0 fail across 46 files (+18 from `spawn-env.test.ts` and `capabilities.test.ts`; baseline 420/44); `bun run typecheck`, `lint`, `format:check` clean. Manual: the before/after above via a scratch `ZDOTDIR` profile putting 2.1.45 first; a fresh-folder run of the INSTALL.md prompt on a current CLI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)