### PR TITLE
Tell the agent when to build a view instead of a widget

### DIFF
--- a/server/cli.ts
+++ b/server/cli.ts
@@ -426,7 +426,7 @@ const init = defineCommand({
         pc.dim(skillsDir) +
         ' — ask ' +
         (type === 'claude-code' ? 'Claude' : 'your agent') +
-        ' to build a widget to get started\n'
+        ' to build a widget or a view to get started\n'
     )
 
     // If --web and server not running, start it (stay alive as wrapper)

--- a/workspace/.claude/skills/moi-workspace/SKILL.md
+++ b/workspace/.claude/skills/moi-workspace/SKILL.md
@@ -22,6 +22,24 @@ Workspace features/pages:
   concepts. Read `references/SCRATCHPAD.md` before building on or modifying it.
 - "Views" - full-stack embedded apps for bigger work, consume more space, live in their own tab.
 
+Which applet? Pick before you write code — rebuilding a cramped widget as a view is the common
+first-request mistake.
+
+| Build a widget when | Build a view when |
+| --- | --- |
+| It is glanceable — one number, a status, a short list | It is a page someone would bookmark and return to |
+| Several of them make sense side by side on the dashboard | It needs a table, a chart, filters, or more than ~3 numbers |
+| It fits a fixed 160 px row and at most 640 px of width | It owns the full frame: its own layout, scrolling, and chrome |
+| Nothing navigates to it — widgets are never a target | It gets its own tab and can be addressed with `focusTab` |
+
+- Widget: "today's visitor count", "build status for the current branch", "a button that runs the
+  nightly import".
+- View: "a status page with tiles, a chart, and per-service rows", "traffic for my three sites with
+  a date filter", "a table of beta signups I can sort and search".
+
+A widget may link into a view for the detail — that pairing is normal, and the view is where the
+detail lives.
+
 User can switch between these, but can access the chat (this conversation and other chats) from
 **any place in the app** (copilot mode), or on a dedicated page.
 
@@ -462,6 +480,15 @@ export const config = {
 } as const
 ```
 
+Valid `icon` ids (same set for the builder request and `config.icon`): `rocket`, `sparkles`, `bolt`,
+`flame`, `star`, `heart`, `diamond`, `trophy`, `target`, `bulb`, `brain`, `robot`, `wand`, `atom`,
+`flask`, `cpu`, `code`, `terminal`, `api`, `database`, `cube`, `hexagon`, `plug`, `tool`, `settings`,
+`bug`, `activity`, `chart`, `briefcase`, `folder`, `file`, `book`, `message`, `mail`, `bell`,
+`paperclip`, `key`, `shield`, `user`, `home`, `globe`, `world`, `planet`, `compass`, `map`,
+`calendar`, `cloud`, `sun`, `moon`, `snowflake`, `leaf`, `mountain`, `feather`, `ghost`, `music`,
+`piano`, `camera`, `photo`, `palette`, `gamepad`, `gift`, `cart`, `chef`. Anything else fails the
+bundle — pick the closest id rather than inventing one such as `chart-bar`.
+
 The inverse of a widget: a view **owns its whole page** — its own `h-full w-full` layout, scrolling
 (`overflow-auto`), padding, and chrome. Build it to read like an app screen. See `references/DESIGN.md`.
 
@@ -478,4 +505,4 @@ This skill is installed with moi (via the CLI or the UI) and can fall behind whe
 - **Then** — if you updated, mention it.
 
 <!-- moi skill version marker — read by `moi skill` to detect drift; do not edit by hand -->
-<moi-skill version="0.18.0" />
+<moi-skill version="0.18.1" />


### PR DESCRIPTION

`moi init` ends with "ask Claude to build a widget to get started", and the workspace skill introduces widgets first without saying when a view is the right shape. A first request for "one place to see traffic for my three sites, with a chart and where it came from" became a widget, hit the dashboard's 640 px / 160 px-row cap, and was rebuilt as a view — the same shape as the demo workspace's "System status" page. The skill now carries a short "Which applet?" table with examples at the point the two are introduced, lists the valid view icon ids (they only surfaced as a bundle error before, so agents guessed `chart-bar` and retried), and the init line says "a widget or a view".

Same request, fresh folder, skill 0.15.1 → 0.18.1 (this change):

```
0.15.1  builds a widget; cramped at 4 columns; rebuilt as a view on request
0.18.1  "This is clearly a view rather than a widget: a chart, a sources
         breakdown, and a visits table per site. I'll build a 'Traffic' view…"
```

**Look closely at**

- The skill version marker moves 0.18.0 → 0.18.1, so every workspace's next `moi` command offers the update. `skill-version.ts` treats a patch gap as "behind" but not "outdated", so no warning banner; if that's not the intended channel for copy-only changes, say so and I'll drop the bump.
- The icon list is the full 63 ids from `lib/app-icons.ts` inline. It's the longest paragraph in the section; a pointer to the file would be shorter but the agent can't read moi's source, only the skill.
- The empty-state suggestions the agent volunteers unprompted are still all widgets (the dashboard's empty-state copy pulls that way); the table only steers once a real request arrives.

**Verified**: `bun test` unchanged (420/44 in `server/harness`; full suite's 14 e2e failures are pre-existing and need a global install/launchd); `format:check` clean. Manual: fresh-folder run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)